### PR TITLE
[CUB tests] `misc-const-correctness`

### DIFF
--- a/cub/benchmarks/bench/for_each/extents.cu
+++ b/cub/benchmarks/bench/for_each/extents.cu
@@ -47,8 +47,8 @@ void for_each_in_extents(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   auto elements_1D = ::cuda::isqrt(elements);
   ext_t ext{elements_1D, elements_1D};
-  cuda::std::mdspan<T, ext_t> temp_in{d_in, ext};
-  cuda::std::mdspan<T, ext_t> temp_out{d_out, ext};
+  const cuda::std::mdspan<T, ext_t> temp_in{d_in, ext};
+  const cuda::std::mdspan<T, ext_t> temp_out{d_out, ext};
   op_t<T, OffsetT> op{temp_in, temp_out};
 
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {

--- a/cub/benchmarks/bench/merge/merge_common.cuh
+++ b/cub/benchmarks/bench/merge/merge_common.cuh
@@ -79,7 +79,7 @@ generate_lhs_rhs(std::size_t num_items_lhs, std::size_t num_items_rhs, bit_entro
   // We generate data distributions in the range [0, 255], which, with lower entropy, get skewed towards 0.
   // We use this to generate increasingly large *consecutive* segments of data that are getting selected from the lhs
   thrust::device_vector<uint8_t> rnd_selector_val = generate(elements, entropy);
-  uint8_t threshold                               = 128;
+  const uint8_t threshold                         = 128;
   select_if_less_than_t select_lhs_op{false, threshold};
   select_if_less_than_t select_rhs_op{true, threshold};
 
@@ -115,8 +115,8 @@ generate_lhs_rhs(std::size_t num_items_lhs, std::size_t num_items_rhs, bit_entro
   thrust::device_vector<KeyT> increasing_input = generate(elements);
   thrust::sort(increasing_input.begin(), increasing_input.end());
 
-  offset_t pivot_point_val = pivot_point[0];
-  auto const end_lhs       = thrust::copy_if(
+  const offset_t pivot_point_val = pivot_point[0];
+  auto const end_lhs             = thrust::copy_if(
     increasing_input.cbegin(),
     increasing_input.cbegin() + pivot_point_val,
     rnd_selector_val.cbegin(),

--- a/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/non-commutative-bicyclic-monoid.cu
@@ -101,7 +101,7 @@ static void inclusive_scan(nvbench::state& state, nvbench::type_list<T, OffsetT>
     thrust::device_vector<T> q_exponents = generate(elements);
     thrust::device_vector<T> p_exponents = generate(elements);
 
-    impl::repack_pair<T> repack_op{};
+    const impl::repack_pair<T> repack_op{};
 
     cub::DeviceTransform::Transform(
       cuda::std::tuple{q_exponents.begin(), p_exponents.begin()}, input.begin(), elements, repack_op);

--- a/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
@@ -83,21 +83,21 @@ inline ZpT __host__ __device__ Zp_add(ZpT v1, ZpT v2, cuda::fast_mod_div<WideT> 
 
 inline MatT __host__ __device__ Zp_matmul(MatT v1, MatT v2, cuda::fast_mod_div<WideT> m_p)
 {
-  ZpT _1_00_2_00 = Zp_mul(v1[0], v2[0], m_p);
-  ZpT _1_01_2_10 = Zp_mul(v1[1], v2[2], m_p);
-  ZpT _r_00      = Zp_add(_1_00_2_00, _1_01_2_10, m_p);
+  const ZpT _1_00_2_00 = Zp_mul(v1[0], v2[0], m_p);
+  const ZpT _1_01_2_10 = Zp_mul(v1[1], v2[2], m_p);
+  const ZpT _r_00      = Zp_add(_1_00_2_00, _1_01_2_10, m_p);
 
-  ZpT _1_00_2_01 = Zp_mul(v1[0], v2[1], m_p);
-  ZpT _1_01_2_11 = Zp_mul(v1[1], v2[3], m_p);
-  ZpT _r_01      = Zp_add(_1_00_2_01, _1_01_2_11, m_p);
+  const ZpT _1_00_2_01 = Zp_mul(v1[0], v2[1], m_p);
+  const ZpT _1_01_2_11 = Zp_mul(v1[1], v2[3], m_p);
+  const ZpT _r_01      = Zp_add(_1_00_2_01, _1_01_2_11, m_p);
 
-  ZpT _1_10_2_00 = Zp_mul(v1[2], v2[0], m_p);
-  ZpT _1_11_2_10 = Zp_mul(v1[3], v2[2], m_p);
-  ZpT _r_10      = Zp_add(_1_10_2_00, _1_11_2_10, m_p);
+  const ZpT _1_10_2_00 = Zp_mul(v1[2], v2[0], m_p);
+  const ZpT _1_11_2_10 = Zp_mul(v1[3], v2[2], m_p);
+  const ZpT _r_10      = Zp_add(_1_10_2_00, _1_11_2_10, m_p);
 
-  ZpT _1_10_2_01 = Zp_mul(v1[2], v2[1], m_p);
-  ZpT _1_11_2_11 = Zp_mul(v1[3], v2[3], m_p);
-  ZpT _r_11      = Zp_add(_1_10_2_01, _1_11_2_11, m_p);
+  const ZpT _1_10_2_01 = Zp_mul(v1[2], v2[1], m_p);
+  const ZpT _1_11_2_11 = Zp_mul(v1[3], v2[3], m_p);
+  const ZpT _r_11      = Zp_add(_1_10_2_01, _1_11_2_11, m_p);
 
   return {_r_00, _r_01, _r_10, _r_11};
 }

--- a/cub/benchmarks/bench/segmented_radix_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_radix_sort/keys.cu
@@ -66,10 +66,10 @@ using some_offset_types = nvbench::type_list<int32_t, int64_t>;
 template <class T, typename OffsetT>
 void power_law(nvbench::state& state, nvbench::type_list<T, OffsetT> ts)
 {
-  const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
-  const auto segments                    = static_cast<std::size_t>(state.get_int64("Segments{io}"));
-  const bit_entropy entropy              = str_to_entropy(state.get_string("Entropy"));
-  thrust::device_vector<OffsetT> offsets = generate.power_law.segment_offsets(elements, segments);
+  const auto elements                          = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto segments                          = static_cast<std::size_t>(state.get_int64("Segments{io}"));
+  const bit_entropy entropy                    = str_to_entropy(state.get_string("Entropy"));
+  const thrust::device_vector<OffsetT> offsets = generate.power_law.segment_offsets(elements, segments);
 
   seg_radix_sort(state, ts, offsets, entropy);
 }
@@ -90,7 +90,7 @@ void uniform(nvbench::state& state, nvbench::type_list<T, OffsetT> ts)
   const auto max_segment_size_log = static_cast<OffsetT>(std::log2(max_segment_size));
   const auto min_segment_size     = 1 << (max_segment_size_log - 1);
 
-  thrust::device_vector<OffsetT> offsets =
+  const thrust::device_vector<OffsetT> offsets =
     generate.uniform.segment_offsets(elements, min_segment_size, max_segment_size);
 
   seg_radix_sort(state, ts, offsets, bit_entropy::_1_000);

--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -126,10 +126,10 @@ using some_offset_types = nvbench::type_list<int32_t>;
 template <class T, typename OffsetT>
 void power_law(nvbench::state& state, nvbench::type_list<T, OffsetT> ts)
 {
-  const auto elements                    = static_cast<std::size_t>(state.get_int64("Elements{io}"));
-  const auto segments                    = static_cast<std::size_t>(state.get_int64("Segments{io}"));
-  const bit_entropy entropy              = str_to_entropy(state.get_string("Entropy"));
-  thrust::device_vector<OffsetT> offsets = generate.power_law.segment_offsets(elements, segments);
+  const auto elements                          = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto segments                          = static_cast<std::size_t>(state.get_int64("Segments{io}"));
+  const bit_entropy entropy                    = str_to_entropy(state.get_string("Entropy"));
+  const thrust::device_vector<OffsetT> offsets = generate.power_law.segment_offsets(elements, segments);
 
   seg_sort(state, ts, offsets, entropy);
 }
@@ -150,7 +150,7 @@ void uniform(nvbench::state& state, nvbench::type_list<T, OffsetT> ts)
   const auto max_segment_size_log = static_cast<OffsetT>(std::log2(max_segment_size));
   const auto min_segment_size     = 1 << (max_segment_size_log - 1);
 
-  thrust::device_vector<OffsetT> offsets =
+  const thrust::device_vector<OffsetT> offsets =
     generate.uniform.segment_offsets(elements, min_segment_size, max_segment_size);
 
   seg_sort(state, ts, offsets, bit_entropy::_1_000);

--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -57,7 +57,7 @@ void select(nvbench::state& state, nvbench::type_list<T, InPlace>)
   thrust::device_vector<T> out(selected_elements, thrust::no_init);
 
   T* d_in                  = thrust::raw_pointer_cast(in.data());
-  T* d_out                 = thrust::raw_pointer_cast(out.data());
+  T* d_out                 = thrust::raw_pointer_cast(out.data()); // NOLINT(misc-const-correctness)
   const bool* d_flags      = thrust::raw_pointer_cast(flags.data());
   offset_t* d_num_selected = thrust::raw_pointer_cast(num_selected.data());
 

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -58,7 +58,7 @@ void select(nvbench::state& state, nvbench::type_list<T, InPlace>)
   thrust::device_vector<T> out(selected_elements, thrust::no_init);
 
   T* d_in                  = thrust::raw_pointer_cast(in.data());
-  T* d_out                 = thrust::raw_pointer_cast(out.data());
+  T* d_out                 = thrust::raw_pointer_cast(out.data()); // NOLINT(misc-const-correctness)
   offset_t* d_num_selected = thrust::raw_pointer_cast(num_selected.data());
 
   state.add_element_count(elements);

--- a/cub/benchmarks/bench/transform/applications/P1/bfloat16.h
+++ b/cub/benchmarks/bench/transform/applications/P1/bfloat16.h
@@ -37,7 +37,7 @@ inline __host__ __device__ uint16_t round_to_nearest_even(float src)
   {
     uint32_t U32;
     std::memcpy(&U32, &src, sizeof(U32));
-    uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
+    const uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
     return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
   }
 }

--- a/cub/benchmarks/bench/transform/applications/P1/pytorch.cu
+++ b/cub/benchmarks/bench/transform/applications/P1/pytorch.cu
@@ -114,9 +114,9 @@ __device__ __forceinline__ scalar_t aten_lerp(scalar_t self_, scalar_t end_, wei
   using opmath_t        = opmath_type<scalar_t>;
   using opmath_weight_t = opmath_type<weight_t>;
 
-  opmath_t self          = self_;
-  opmath_t end           = end_;
-  opmath_weight_t weight = weight_;
+  const opmath_t self          = self_;
+  const opmath_t end           = end_;
+  const opmath_weight_t weight = weight_;
 
   return is_lerp_weight_small(weight) ? self + weight * (end - self) : end - (end - self) * (opmath_t(1) - weight);
 }
@@ -629,7 +629,7 @@ try
     // note: even though output is bool, we use d_b as output because
     // it must hold at least enough memory per element for bool (1 byte)
     // greater: native/cuda/CompareKernels.cu:69
-    CompareFunctor<T> comp_f(OpType::GT);
+    const CompareFunctor<T> comp_f(OpType::GT);
     transform(cuda::std::make_tuple(d_a, d_in[12]), d_b, n, comp_f, s);
   });
 }
@@ -722,8 +722,8 @@ try
       d_a,
       n,
       [beta, threshold] __device__(T a) -> T {
-        using opmath_t = opmath_type<T>;
-        opmath_t aop   = static_cast<opmath_t>(a);
+        using opmath_t     = opmath_type<T>;
+        const opmath_t aop = static_cast<opmath_t>(a);
         return (aop * beta) > threshold ? aop : (::log1p(std::exp(aop * beta))) / beta;
       },
       s);
@@ -758,8 +758,8 @@ try
       d_b,
       n,
       [negcoef, poscoef, negiptcoef] __device__(T a) -> T {
-        using opmath_t = opmath_type<T>;
-        opmath_t aop   = static_cast<opmath_t>(a);
+        using opmath_t     = opmath_type<T>;
+        const opmath_t aop = static_cast<opmath_t>(a);
         return aop > 0 ? aop * poscoef : std::expm1(aop * negiptcoef) * negcoef;
       },
       s);
@@ -909,8 +909,8 @@ try
       d_b,
       n,
       [negval] __device__(T a) -> T {
-        using opmath_t = opmath_type<T>;
-        opmath_t aop   = static_cast<opmath_t>(a);
+        using opmath_t     = opmath_type<T>;
+        const opmath_t aop = static_cast<opmath_t>(a);
         return aop > opmath_t(0) ? aop : aop * negval;
       },
       s);
@@ -921,8 +921,8 @@ try
       d_a,
       n,
       [zero, one_sixth, three, six] __device__(T self_val) -> T {
-        using opmath_t = opmath_type<T>;
-        opmath_t x     = static_cast<opmath_t>(self_val);
+        using opmath_t   = opmath_type<T>;
+        const opmath_t x = static_cast<opmath_t>(self_val);
         return x * cuda::std::min(cuda::std::max(x + three, zero), six) * one_sixth;
       },
       s);
@@ -943,14 +943,14 @@ try
       d_a,
       n,
       [zero, one_sixth, three, six] __device__(T self_val) -> T {
-        using opmath_t = opmath_type<T>;
-        opmath_t x     = static_cast<opmath_t>(self_val);
+        using opmath_t   = opmath_type<T>;
+        const opmath_t x = static_cast<opmath_t>(self_val);
         return cuda::std::min<opmath_t>(cuda::std::max<opmath_t>(x + three, zero), six) * one_sixth;
       },
       s);
 
     // gt(scalar=0): native/cuda/CompareKernels.cu:47
-    CompareFunctor<T> comp_f(OpType::GT);
+    const CompareFunctor<T> comp_f(OpType::GT);
     transform(
       d_a,
       d_b,

--- a/cub/benchmarks/bench/transform/tile/pytorch.cu
+++ b/cub/benchmarks/bench/transform/tile/pytorch.cu
@@ -36,7 +36,7 @@ struct relu_op
   template <class T>
   __host__ __device__ T operator()(T v) const
   {
-    float f = to_f(v);
+    const float f = to_f(v);
     return from_f<T>(f > 0.0f ? f : 0.0f);
   }
 };
@@ -45,7 +45,7 @@ struct sigmoid_op
   template <class T>
   __host__ __device__ T operator()(T v) const
   {
-    float f = to_f(v);
+    const float f = to_f(v);
     return from_f<T>(1.0f / (1.0f + ::cuda::std::exp(-f)));
   }
 };
@@ -63,7 +63,7 @@ struct gelu_op
   __host__ __device__ T operator()(T v) const
   {
     constexpr float k0 = 0.7978845608028654f, k1 = 0.044715f;
-    float f = to_f(v);
+    const float f = to_f(v);
     return from_f<T>(0.5f * f * (1.0f + ::cuda::std::tanh(k0 * (f + k1 * f * f * f))));
   }
 };

--- a/cub/examples/block/example_block_radix_sort.cu
+++ b/cub/examples/block/example_block_radix_sort.cu
@@ -76,7 +76,7 @@ __launch_bounds__(BLOCK_THREADS) __global__
   Key items[ITEMS_PER_THREAD];
 
   // Our current block's offset
-  int block_offset = blockIdx.x * TILE_SIZE;
+  const int block_offset = blockIdx.x * TILE_SIZE;
 
   // Load items into a blocked arrangement
   BlockLoadT(temp_storage.load).Load(d_in + block_offset, items);
@@ -85,13 +85,13 @@ __launch_bounds__(BLOCK_THREADS) __global__
   __syncthreads();
 
   // Start cycle timer
-  clock_t start = clock();
+  const clock_t start = clock();
 
   // Sort keys
   BlockRadixSortT(temp_storage.sort).SortBlockedToStriped(items);
 
   // Stop cycle timer
-  clock_t stop = clock();
+  const clock_t stop = clock();
 
   // Store output in striped fashion
   StoreDirectStriped<BLOCK_THREADS>(threadIdx.x, d_out + block_offset, items);
@@ -191,7 +191,7 @@ void Test()
 
   // Check results
   printf("\tOutput items: ");
-  int compare = CompareDeviceResults(h_reference, d_out, TILE_SIZE, g_verbose, g_verbose);
+  const int compare = CompareDeviceResults(h_reference, d_out, TILE_SIZE, g_verbose, g_verbose);
   printf("%s\n", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
   fflush(stdout);
@@ -223,10 +223,10 @@ void Test()
   CubDebugExit(cudaDeviceSynchronize());
 
   // Display timing results
-  float avg_millis           = elapsed_millis / static_cast<float>(g_timing_iterations);
-  float avg_items_per_sec    = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
-  double avg_clocks          = double(elapsed_clocks) / g_timing_iterations / g_grid_size;
-  double avg_clocks_per_item = avg_clocks / TILE_SIZE;
+  const float avg_millis           = elapsed_millis / static_cast<float>(g_timing_iterations);
+  const float avg_items_per_sec    = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
+  const double avg_clocks          = double(elapsed_clocks) / g_timing_iterations / g_grid_size;
+  const double avg_clocks_per_item = avg_clocks / TILE_SIZE;
 
   printf("\tAverage BlockRadixSort::SortBlocked clocks: %.3f\n", avg_clocks);
   printf("\tAverage BlockRadixSort::SortBlocked clocks per item: %.3f\n", avg_clocks_per_item);

--- a/cub/examples/block/example_block_reduce.cu
+++ b/cub/examples/block/example_block_reduce.cu
@@ -62,13 +62,13 @@ __global__ void BlockReduceKernel(int* d_in, // Tile of input
   LoadDirectStriped<BLOCK_THREADS>(threadIdx.x, d_in, data);
 
   // Start cycle timer
-  clock_t start = clock();
+  const clock_t start = clock();
 
   // Compute sum
-  int aggregate = BlockReduceT(temp_storage).Sum(data);
+  const int aggregate = BlockReduceT(temp_storage).Sum(data);
 
   // Stop cycle timer
-  clock_t stop = clock();
+  const clock_t stop = clock();
 
   // Store aggregate and elapsed clocks
   if (threadIdx.x == 0)
@@ -108,8 +108,8 @@ void Test()
   constexpr int TILE_SIZE = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   // Allocate host arrays
-  int* h_in  = new int[TILE_SIZE];
-  int* h_gpu = new int[TILE_SIZE + 1];
+  int* h_in        = new int[TILE_SIZE];
+  const int* h_gpu = new int[TILE_SIZE + 1];
 
   // Initialize problem and reference output on host
   int h_aggregate = Initialize(h_in, TILE_SIZE);
@@ -156,7 +156,7 @@ void Test()
 
   // Check total aggregate
   printf("\tAggregate: ");
-  int compare = CompareDeviceResults(&h_aggregate, d_out, 1, g_verbose, g_verbose);
+  const int compare = CompareDeviceResults(&h_aggregate, d_out, 1, g_verbose, g_verbose);
   printf("%s\n", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 
@@ -190,10 +190,10 @@ void Test()
   CubDebugExit(cudaDeviceSynchronize());
 
   // Display timing results
-  float avg_millis          = elapsed_millis / static_cast<float>(g_timing_iterations);
-  float avg_items_per_sec   = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
-  float avg_clocks          = float(elapsed_clocks) / static_cast<float>(g_timing_iterations);
-  float avg_clocks_per_item = avg_clocks / TILE_SIZE;
+  const float avg_millis          = elapsed_millis / static_cast<float>(g_timing_iterations);
+  const float avg_items_per_sec   = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
+  const float avg_clocks          = float(elapsed_clocks) / static_cast<float>(g_timing_iterations);
+  const float avg_clocks_per_item = avg_clocks / TILE_SIZE;
 
   printf("\tAverage BlockReduce::Sum clocks: %.3f\n", avg_clocks);
   printf("\tAverage BlockReduce::Sum clocks per item: %.3f\n", avg_clocks_per_item);

--- a/cub/examples/block/example_block_reduce_dyn_smem.cu
+++ b/cub/examples/block/example_block_reduce_dyn_smem.cu
@@ -62,7 +62,7 @@ __global__ void BlockReduceKernel(int* d_in, // Tile of input
   // cast to lvalue reference of expected type
   auto& temp_storage = reinterpret_cast<TempStorageT&>(smem);
 
-  int data = d_in[threadIdx.x];
+  const int data = d_in[threadIdx.x];
 
   // Compute sum
   int aggregate = BlockReduceT(temp_storage).Sum(data);

--- a/cub/examples/block/example_block_scan.cu
+++ b/cub/examples/block/example_block_scan.cu
@@ -80,14 +80,14 @@ __global__ void BlockPrefixSumKernel(int* d_in, // Tile of input
   __syncthreads();
 
   // Start cycle timer
-  clock_t start = clock();
+  const clock_t start = clock();
 
   // Compute exclusive prefix sum
   int aggregate;
   BlockScanT(temp_storage.scan).ExclusiveSum(data, data, aggregate);
 
   // Stop cycle timer
-  clock_t stop = clock();
+  const clock_t stop = clock();
 
   // Barrier for smem reuse
   __syncthreads();
@@ -137,7 +137,7 @@ void Test()
   // Allocate host arrays
   int* h_in        = new int[TILE_SIZE];
   int* h_reference = new int[TILE_SIZE];
-  int* h_gpu       = new int[TILE_SIZE + 1];
+  const int* h_gpu = new int[TILE_SIZE + 1];
 
   // Initialize problem and reference output on host
   int h_aggregate = Initialize(h_in, h_reference, TILE_SIZE);
@@ -229,10 +229,10 @@ void Test()
   CubDebugExit(cudaDeviceSynchronize());
 
   // Display timing results
-  float avg_millis          = elapsed_millis / static_cast<float>(g_timing_iterations);
-  float avg_items_per_sec   = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
-  float avg_clocks          = float(elapsed_clocks) / static_cast<float>(g_timing_iterations);
-  float avg_clocks_per_item = avg_clocks / TILE_SIZE;
+  const float avg_millis          = elapsed_millis / static_cast<float>(g_timing_iterations);
+  const float avg_items_per_sec   = float(TILE_SIZE * g_grid_size) / avg_millis / 1000.0f;
+  const float avg_clocks          = float(elapsed_clocks) / static_cast<float>(g_timing_iterations);
+  const float avg_clocks_per_item = avg_clocks / TILE_SIZE;
 
   printf("\tAverage BlockScan::Sum clocks: %.3f\n", avg_clocks);
   printf("\tAverage BlockScan::Sum clocks per item: %.3f\n", avg_clocks_per_item);
@@ -355,7 +355,7 @@ struct BlockPrefixCallbackOp
   // Thread-0 is responsible for returning a value for seeding the block-wide scan.
   __device__ int operator()(int block_aggregate)
   {
-    int old_prefix = running_total;
+    const int old_prefix = running_total;
     running_total += block_aggregate;
     return old_prefix;
   }
@@ -570,8 +570,8 @@ struct BlockPrefixCallbackMaxOp
   // Thread-0 is responsible for returning a value for seeding the block-wide scan.
   __device__ int operator()(int block_aggregate)
   {
-    int old_prefix = running_total;
-    running_total  = (block_aggregate > old_prefix) ? block_aggregate : old_prefix;
+    const int old_prefix = running_total;
+    running_total        = (block_aggregate > old_prefix) ? block_aggregate : old_prefix;
     return old_prefix;
   }
 };
@@ -836,7 +836,7 @@ void TestDocumentationExamples()
     {
       for (int j = 0; j < 4 && passed; j++)
       {
-        int expected = i * 4 + j;
+        const int expected = i * 4 + j;
         if (h_data[i * 4 + j] != expected)
         {
           printf("FAILED at [%d]: expected %d, got %d\n", i * 4 + j, expected, h_data[i * 4 + j]);
@@ -972,7 +972,7 @@ void TestDocumentationExamples()
     {
       for (int j = 0; j < 4 && passed; j++)
       {
-        int expected = i * 4 + j + 1;
+        const int expected = i * 4 + j + 1;
         if (h_data[i * 4 + j] != expected)
         {
           printf("FAILED at [%d]: expected %d, got %d\n", i * 4 + j, expected, h_data[i * 4 + j]);
@@ -1029,8 +1029,8 @@ void TestDocumentationExamples()
     {
       for (int j = 0; j < 4 && passed; j++)
       {
-        int idx      = i * 4 + j;
-        int expected = running_max;
+        const int idx      = i * 4 + j;
+        const int expected = running_max;
         if (h_data[idx] != expected)
         {
           printf("FAILED at [%d]: expected %d, got %d\n", idx, expected, h_data[idx]);
@@ -1060,7 +1060,7 @@ void TestDocumentationExamples()
     bool passed = true;
     for (int i = 0; i < 128 && passed; i++)
     {
-      int expected = running_max;
+      const int expected = running_max;
       if (h_data[i] != expected)
       {
         printf("FAILED at [%d]: expected %d, got %d\n", i, expected, h_data[i]);
@@ -1089,8 +1089,8 @@ void TestDocumentationExamples()
     bool passed = true;
     for (int i = 0; i < num_items && passed; i++)
     {
-      int input_val = (i % 2 == 0) ? i : -i;
-      int expected  = running_max;
+      const int input_val = (i % 2 == 0) ? i : -i;
+      const int expected  = running_max;
       if (h_data[i] != expected)
       {
         printf("FAILED at [%d]: expected %d, got %d\n", i, expected, h_data[i]);
@@ -1121,8 +1121,8 @@ void TestDocumentationExamples()
     {
       for (int j = 0; j < 4 && passed; j++)
       {
-        int idx     = i * 4 + j;
-        running_max = (idx > running_max) ? idx : running_max;
+        const int idx = i * 4 + j;
+        running_max   = (idx > running_max) ? idx : running_max;
         if (h_data[idx] != running_max)
         {
           printf("FAILED at [%d]: expected %d, got %d\n", idx, running_max, h_data[idx]);
@@ -1179,8 +1179,8 @@ void TestDocumentationExamples()
     bool passed = true;
     for (int i = 0; i < num_items && passed; i++)
     {
-      int input_val = (i % 2 == 0) ? i : -i;
-      running_max   = (input_val > running_max) ? input_val : running_max;
+      const int input_val = (i % 2 == 0) ? i : -i;
+      running_max         = (input_val > running_max) ? input_val : running_max;
       if (h_data[i] != running_max)
       {
         printf("FAILED at [%d]: expected %d, got %d\n", i, running_max, h_data[i]);

--- a/cub/examples/device/example_device_env_memory_resource.cu
+++ b/cub/examples/device/example_device_env_memory_resource.cu
@@ -36,8 +36,8 @@ struct synchronous_memory_resource : cuda::mr::memory_resource_base<synchronous_
       throw std::invalid_argument("invalid alignment for synchronous_memory_resource");
     }
 
-    void* ptr          = nullptr;
-    cudaError_t status = cudaMalloc(&ptr, bytes);
+    void* ptr                = nullptr;
+    const cudaError_t status = cudaMalloc(&ptr, bytes);
     if (status != cudaSuccess)
     {
       throw std::runtime_error(cudaGetErrorString(status));

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
 
   // DevicePartition a pivot index
   unsigned int pivot_index;
-  unsigned int max_int = (unsigned int) -1;
+  const unsigned int max_int = (unsigned int) -1;
   RandomBits(pivot_index);
   pivot_index = (unsigned int) ((float(pivot_index) * (float(num_items - 1) / float(max_int))));
   printf("Pivot idx: %d\n", pivot_index);
@@ -164,7 +164,7 @@ int main(int argc, char** argv)
 
   // Initialize problem and solution
   Initialize(h_in, num_items, max_segment);
-  GreaterThan select_op(h_in[pivot_index]);
+  const GreaterThan select_op(h_in[pivot_index]);
 
   int num_selected = Solve(h_in, select_op, h_reference, num_items);
 

--- a/cub/examples/device/example_device_radix_sort_custom.cu
+++ b/cub/examples/device/example_device_radix_sort_custom.cu
@@ -54,7 +54,7 @@ int main()
   std::cout << "The `custom_t{65535, -4.2f}` has the following binary representation:\n\n";
 
   auto print_segment = [](std::string msg, std::size_t segment_size, char filler = '-') {
-    std::string spaces((segment_size - msg.size()) / 2 - 1, filler);
+    const std::string spaces((segment_size - msg.size()) / 2 - 1, filler);
     std::cout << '<' << spaces << msg << spaces << '>';
   };
 
@@ -71,7 +71,7 @@ int main()
   print_segment(" short -", 16);
   std::cout << '\n';
 
-  custom_t the_answer{65535, -4.2f};
+  const custom_t the_answer{65535, -4.2f};
   std::cout << '\t' << to_binary_representation(the_answer);
   std::cout << "\n\t";
   print_segment(" <----  higher bits  /  lower bits  ----> ", 64, ' ');
@@ -185,7 +185,7 @@ int main()
   thrust::device_vector<custom_t> in = {{4, +2.5f}, {0, -2.5f}, {3, +1.1f}, {1, +0.0f}, {2, -0.0f}, {5, +3.7f}};
 
   std::cout << "in:\n";
-  for (custom_t key : in)
+  for (const custom_t key : in)
   {
     std::cout << "\t{.i = " << key.i << ", .f = " << key.f << "},\n";
   }
@@ -221,7 +221,7 @@ int main()
   std::cout << "\t                               decomposer_t{});\n\n";
 
   std::cout << "out:\n";
-  for (custom_t key : out)
+  for (const custom_t key : out)
   {
     std::cout << "\t{.i = " << key.i << ", .f = " << key.f << "},\n";
   }

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
 
   // Check for correctness (and display results, if specified)
   stream.sync();
-  int compare = CompareDeviceResults(&h_reference, d_out.data(), 1, g_verbose, g_verbose);
+  const int compare = CompareDeviceResults(&h_reference, d_out.data(), 1, g_verbose, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -137,7 +137,7 @@ int main(int argc, char** argv)
 
   // Check for correctness (and display results, if specified)
   stream.sync();
-  int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
+  const int compare = CompareDeviceResults(h_reference, d_out.data(), num_items, true, g_verbose);
   printf("\t%s", compare ? "FAIL" : "PASS");
   AssertEquals(0, compare);
 

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
 
   // Select a pivot index
   unsigned int pivot_index;
-  unsigned int max_int = (unsigned int) -1;
+  const unsigned int max_int = (unsigned int) -1;
   RandomBits(pivot_index);
   pivot_index = (unsigned int) ((float(pivot_index) * (float(num_items - 1) / float(max_int))));
   printf("Pivot idx: %d\n", pivot_index);
@@ -164,7 +164,7 @@ int main(int argc, char** argv)
 
   // Initialize problem and solution
   Initialize(h_in, num_items, max_segment);
-  GreaterThan select_op(h_in[pivot_index]);
+  const GreaterThan select_op(h_in[pivot_index]);
 
   int num_selected = Solve(h_in, select_op, h_reference, num_items);
 

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& os, const Pair<Key, Value>& val)
 template <typename Key, typename Value>
 void Initialize(Key* h_keys, Value* h_values, int num_items, int max_key)
 {
-  float scale = float(max_key) / float(UINT_MAX);
+  const float scale = float(max_key) / float(UINT_MAX);
   for (int i = 0; i < num_items; ++i)
   {
     Key sample;

--- a/cub/examples/device/example_device_topk_keys.cu
+++ b/cub/examples/device/example_device_topk_keys.cu
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   CubDebugExit(cudaStreamCreate(&stream));
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};

--- a/cub/examples/device/example_device_topk_pairs.cu
+++ b/cub/examples/device/example_device_topk_pairs.cu
@@ -104,10 +104,10 @@ int main(int argc, char** argv)
   // Allocate host arrays
   thrust::host_vector<float> h_keys_vector(num_items);
   thrust::host_vector<float> h_reference_keys_vector(k);
-  thrust::host_vector<float> h_res_keys_vector(k);
+  const thrust::host_vector<float> h_res_keys_vector(k);
   thrust::host_vector<int> h_values_vector(num_items);
   thrust::host_vector<int> h_reference_values_vector(k);
-  thrust::host_vector<int> h_res_values_vector(k);
+  const thrust::host_vector<int> h_res_values_vector(k);
 
   // Initialize problem and solution on host
   initialize(h_keys_vector.data(),
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   CubDebugExit(cudaStreamCreate(&stream));
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};

--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -256,7 +256,7 @@ c2h::host_vector<std::size_t> get_permutation(
   auto bit_ordered_striped_keys =
     reinterpret_cast<const bit_ordered_t*>(thrust::raw_pointer_cast(h_striped_keys.data()));
 
-  indirect_binary_comparator_t<bit_ordered_t> comp{bit_ordered_striped_keys, is_descending};
+  const indirect_binary_comparator_t<bit_ordered_t> comp{bit_ordered_striped_keys, is_descending};
 
   for (std::size_t segment = 0; segment < num_segments; ++segment)
   {
@@ -274,9 +274,9 @@ c2h::host_vector<KeyT> radix_sort_reference(
   int begin_bit = 0,
   int end_bit   = static_cast<int>(sizeof(KeyT) * CHAR_BIT))
 {
-  c2h::host_vector<KeyT> h_keys(d_keys);
-  std::array<std::size_t, 2> segments{0, d_keys.size()};
-  c2h::host_vector<std::size_t> h_permutation =
+  const c2h::host_vector<KeyT> h_keys(d_keys);
+  const std::array<std::size_t, 2> segments{0, d_keys.size()};
+  const c2h::host_vector<std::size_t> h_permutation =
     get_permutation(h_keys, is_descending, 1, segments.cbegin(), segments.cbegin() + 1, begin_bit, end_bit);
   c2h::host_vector<KeyT> result(d_keys.size());
   thrust::gather(h_permutation.cbegin(), h_permutation.cend(), h_keys.cbegin(), result.begin());
@@ -296,13 +296,13 @@ std::pair<c2h::host_vector<KeyT>, c2h::host_vector<ValueT>> radix_sort_reference
   result.first.resize(d_keys.size());
   result.second.resize(d_keys.size());
 
-  std::array<std::size_t, 2> segments{0, d_keys.size()};
+  const std::array<std::size_t, 2> segments{0, d_keys.size()};
 
-  c2h::host_vector<KeyT> h_keys(d_keys);
-  c2h::host_vector<std::size_t> h_permutation =
+  const c2h::host_vector<KeyT> h_keys(d_keys);
+  const c2h::host_vector<std::size_t> h_permutation =
     get_permutation(h_keys, is_descending, 1, segments.cbegin(), segments.cbegin() + 1, begin_bit, end_bit);
 
-  c2h::host_vector<ValueT> h_values(d_values);
+  const c2h::host_vector<ValueT> h_values(d_values);
   thrust::gather(h_permutation.cbegin(),
                  h_permutation.cend(),
                  thrust::make_zip_iterator(h_keys.cbegin(), h_values.cbegin()),
@@ -321,8 +321,8 @@ c2h::host_vector<KeyT> segmented_radix_sort_reference(
   int begin_bit = 0,
   int end_bit   = static_cast<int>(sizeof(KeyT) * CHAR_BIT))
 {
-  c2h::host_vector<KeyT> h_keys(d_keys);
-  c2h::host_vector<std::size_t> h_permutation =
+  const c2h::host_vector<KeyT> h_keys(d_keys);
+  const c2h::host_vector<std::size_t> h_permutation =
     get_permutation(h_keys, is_descending, num_segments, h_seg_begin_it, h_seg_end_it, begin_bit, end_bit);
   c2h::host_vector<KeyT> result(d_keys.size());
   thrust::gather(h_permutation.cbegin(), h_permutation.cend(), h_keys.cbegin(), result.begin());
@@ -345,11 +345,11 @@ std::pair<c2h::host_vector<KeyT>, c2h::host_vector<ValueT>> segmented_radix_sort
   result.first.resize(d_keys.size());
   result.second.resize(d_keys.size());
 
-  c2h::host_vector<KeyT> h_keys(d_keys);
-  c2h::host_vector<std::size_t> h_permutation =
+  const c2h::host_vector<KeyT> h_keys(d_keys);
+  const c2h::host_vector<std::size_t> h_permutation =
     get_permutation(h_keys, is_descending, num_segments, h_seg_begin_it, h_seg_end_it, begin_bit, end_bit);
 
-  c2h::host_vector<ValueT> h_values(d_values);
+  const c2h::host_vector<ValueT> h_values(d_values);
   thrust::gather(h_permutation.cbegin(),
                  h_permutation.cend(),
                  thrust::make_zip_iterator(h_keys.cbegin(), h_values.cbegin()),

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -99,7 +99,7 @@ struct short_key_verification_helper
 public:
   void prepare_verification_data(const c2h::device_vector<key_t>& in_keys)
   {
-    c2h::host_vector<key_t> h_in{in_keys};
+    const c2h::host_vector<key_t> h_in{in_keys};
     keys_histogram = c2h::host_vector<std::size_t>(max_histo_size, 0);
     for (const auto& key : h_in)
     {
@@ -411,6 +411,7 @@ private:
                && current_key == this->compute_key(key_out_dup_end, segment_size, key_conversion));
 
       // Bookkeeping for validating unstable sorts:
+      // NOLINTNEXTLINE(misc-const-correctness)
       int unchecked_values_for_current_dup_key_begin     = segment_begin + key_out_dup_begin;
       const int unchecked_values_for_current_dup_key_end = segment_begin + key_out_dup_end;
 
@@ -481,7 +482,7 @@ private:
 
   __device__ _CCCL_FORCEINLINE KeyT compute_key(int seg_idx, int segment_size, double conversion)
   {
-    int conv_idx = sort_descending ? (segment_size - 1 - seg_idx) : seg_idx;
+    const int conv_idx = sort_descending ? (segment_size - 1 - seg_idx) : seg_idx;
     return static_cast<KeyT>(conv_idx * conversion);
   }
 };
@@ -503,9 +504,11 @@ void generate_unsorted_derived_inputs(
 
   static constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
-  const int num_segments          = static_cast<int>(d_offsets.size() - 1);
-  const int* offsets              = thrust::raw_pointer_cast(d_offsets.data());
-  KeyT* keys                      = thrust::raw_pointer_cast(d_keys.data());
+  const int num_segments = static_cast<int>(d_offsets.size() - 1);
+  const int* offsets     = thrust::raw_pointer_cast(d_offsets.data());
+  KeyT* keys             = thrust::raw_pointer_cast(d_keys.data());
+  // The pointee cannot be const: segment_filler writes through it in the sort_pairs branch below.
+  // NOLINTNEXTLINE(misc-const-correctness)
   [[maybe_unused]] ValueT* values = thrust::raw_pointer_cast(d_values.data());
 
   // Build keys in reversed order from how they'll eventually be sorted:
@@ -778,8 +781,8 @@ CUB_RUNTIME_FUNCTION cudaError_t call_cub_segmented_sort_api(
   auto output_keys = reinterpret_cast<KeyT*>(wrapped_output_keys);
 
   // Use different types for the offset begin/end iterators to ensure that this is supported:
-  const int* offset_begin_it                  = d_begin_offsets;
-  thrust::device_ptr<const int> offset_end_it = thrust::device_pointer_cast(d_end_offsets);
+  const int* offset_begin_it                        = d_begin_offsets;
+  const thrust::device_ptr<const int> offset_end_it = thrust::device_pointer_cast(d_end_offsets);
 
   cudaError_t status = cudaErrorInvalidValue;
 
@@ -1380,8 +1383,8 @@ void test_segments_random(
 
   C2H_TIME_SECTION("D->H input arrays");
 
-  c2h::device_vector<KeyT> keys_orig     = keys_input;
-  c2h::device_vector<ValueT> values_orig = values_input;
+  const c2h::device_vector<KeyT> keys_orig     = keys_input;
+  const c2h::device_vector<ValueT> values_orig = values_input;
 
   C2H_TIME_SECTION("Clone input arrays on device");
 
@@ -1395,17 +1398,17 @@ void test_segments_random(
 
   C2H_TIME_SECTION_RESET();
 
-  c2h::device_vector<KeyT> keys_ref     = h_keys_ref;
-  c2h::device_vector<ValueT> values_ref = h_values_ref;
+  const c2h::device_vector<KeyT> keys_ref     = h_keys_ref;
+  const c2h::device_vector<ValueT> values_ref = h_values_ref;
 
   C2H_TIME_SECTION("H->D reference arrays");
 
   bool need_reset = false;
 
   // Don't use GENERATE for these. We can reuse the expensive reference arrays for them:
-  for (bool stable_sort : {unstable, stable})
+  for (const bool stable_sort : {unstable, stable})
   {
-    for (bool sort_buffers : {pointers, double_buffer})
+    for (const bool sort_buffers : {pointers, double_buffer})
     {
       CAPTURE(stable_sort, sort_descending, sort_buffers);
 
@@ -1662,7 +1665,7 @@ template <typename KeyT, typename ValueT = cub::NullType>
 void test_same_size_segments_derived(int segment_size, int num_segments)
 {
   CAPTURE(segment_size, num_segments);
-  c2h::device_vector<int> offsets = generate_same_size_offsets(segment_size, num_segments);
+  const c2h::device_vector<int> offsets = generate_same_size_offsets(segment_size, num_segments);
   test_segments_derived<KeyT, ValueT>(offsets);
 }
 
@@ -1670,7 +1673,7 @@ template <typename KeyT, typename ValueT = cub::NullType>
 void test_random_size_segments_derived(c2h::seed_t seed, int max_items, int max_segment, int num_segments)
 {
   CAPTURE(seed.get());
-  c2h::device_vector<int> offsets = generate_random_offsets(seed, max_items, max_segment, num_segments);
+  const c2h::device_vector<int> offsets = generate_random_offsets(seed, max_items, max_segment, num_segments);
   test_segments_derived<KeyT, ValueT>(offsets);
 }
 
@@ -1678,7 +1681,7 @@ template <typename KeyT, typename ValueT = cub::NullType>
 void test_random_size_segments_random(c2h::seed_t seed, int max_items, int max_segment, int num_segments)
 {
   CAPTURE(seed.get());
-  c2h::device_vector<int> offsets = generate_random_offsets(seed, max_items, max_segment, num_segments);
+  const c2h::device_vector<int> offsets = generate_random_offsets(seed, max_items, max_segment, num_segments);
   test_segments_random<KeyT, ValueT>(seed, offsets);
 }
 
@@ -1686,7 +1689,7 @@ template <typename KeyT, typename ValueT = cub::NullType>
 void test_edge_case_segments_random(c2h::seed_t seed)
 {
   CAPTURE(seed.get());
-  c2h::device_vector<int> offsets = generate_edge_case_offsets<KeyT, ValueT>();
+  const c2h::device_vector<int> offsets = generate_edge_case_offsets<KeyT, ValueT>();
   test_segments_random<KeyT, ValueT>(seed, offsets);
 }
 

--- a/cub/test/catch2_test_block_adjacent_difference.cu
+++ b/cub/test/catch2_test_block_adjacent_difference.cu
@@ -85,7 +85,7 @@ struct last_tile_op_t
   __device__ void
   operator()(BlockAdjDiff& block_adj_diff, T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD]) const
   {
-    custom_difference_t<T> diff{};
+    const custom_difference_t<T> diff{};
 
     if (ReadLeft)
     {
@@ -111,7 +111,7 @@ struct middle_tile_op_t
   __device__ void
   operator()(BlockAdjDiff& block_adj_diff, T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD]) const
   {
-    custom_difference_t<T> diff{};
+    const custom_difference_t<T> diff{};
 
     if (ReadLeft)
     {
@@ -139,7 +139,7 @@ struct last_tile_with_pred_op_t
   __device__ void
   operator()(BlockAdjDiff& block_adj_diff, T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD]) const
   {
-    custom_difference_t<T> diff{};
+    const custom_difference_t<T> diff{};
     block_adj_diff.SubtractLeftPartialTile(input, output, diff, m_valid_items, m_neighbour_tile_value);
   }
 };
@@ -286,7 +286,7 @@ CUB_TEST("Block adjacent difference works with single tiles",
   constexpr bool read_left = true;
 
   c2h::host_vector<key_t> h_data = d_data;
-  key_t neighbour_value          = h_data[h_data.size() / 2];
+  const key_t neighbour_value    = h_data[h_data.size() / 2];
 
   host_adj_diff<read_left>(h_data, valid_items, neighbour_value);
 
@@ -313,7 +313,7 @@ CUB_TEST("Block adjacent difference works with middle tiles",
   const bool in_place = GENERATE(false, true);
 
   c2h::host_vector<key_t> h_data = d_data;
-  key_t neighbour_value          = h_data[h_data.size() / 2];
+  const key_t neighbour_value    = h_data[h_data.size() / 2];
 
   host_adj_diff<params::read_left>(h_data, params::tile_size, neighbour_value);
 

--- a/cub/test/catch2_test_block_histogram.cu
+++ b/cub/test/catch2_test_block_histogram.cu
@@ -81,7 +81,7 @@ CUB_TEST("Block histogram can be computed with uniform input",
 
   const sample_t uniform_value = static_cast<sample_t>(GENERATE_COPY(take(10, random(0, params::bins - 1))));
 
-  c2h::host_vector<sample_t> h_samples(params::num_samples, uniform_value);
+  const c2h::host_vector<sample_t> h_samples(params::num_samples, uniform_value);
   c2h::host_vector<int> h_reference(params::bins);
   h_reference[static_cast<std::size_t>(uniform_value)] = params::num_samples;
 
@@ -126,8 +126,8 @@ CUB_TEST("Block histogram can be computed with modulo input",
 
   c2h::gen(c2h::modulo_t{params::bins}, d_samples);
 
-  c2h::host_vector<sample_t> h_samples = d_samples;
-  auto h_reference                     = compute_host_reference(params::bins, h_samples);
+  const c2h::host_vector<sample_t> h_samples = d_samples;
+  auto h_reference                           = compute_host_reference(params::bins, h_samples);
 
   // Run kernel
   block_histogram<params::items_per_thread, params::threads_in_block, params::bins, params::algorithm>(
@@ -159,8 +159,8 @@ CUB_TEST("Block histogram can be computed with random input",
 
   c2h::gen(C2H_SEED(10), d_samples, min_bin, max_bin);
 
-  c2h::host_vector<sample_t> h_samples = d_samples;
-  auto h_reference                     = compute_host_reference(params::bins, h_samples);
+  const c2h::host_vector<sample_t> h_samples = d_samples;
+  auto h_reference                           = compute_host_reference(params::bins, h_samples);
 
   // Run kernel
   block_histogram<params::items_per_thread, params::threads_in_block, params::bins, params::algorithm>(

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -200,7 +200,7 @@ CUB_TEST("Block load works with caching iterators", "[load][block]", CUB_SMALL, 
 
   c2h::device_vector<type> d_input(GENERATE_COPY(take(10, random(0, tile_size))));
   c2h::gen(C2H_SEED(10), d_input);
-  cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_DEFAULT, type> in(
+  const cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_DEFAULT, type> in(
     thrust::raw_pointer_cast(d_input.data()));
   test_block_load<items_per_thread, threads_in_block, load_algorithm>(d_input, in);
 }

--- a/cub/test/catch2_test_block_load_to_shared.cu
+++ b/cub/test/catch2_test_block_load_to_shared.cu
@@ -37,10 +37,11 @@ __global__ void kernel(InputPointerT input, OutputIteratorT output, int num_item
   constexpr int buffer_align             = cub::detail::LoadToSharedBufferAlignBytes<input_t>();
   constexpr int buffer_size              = cub::detail::LoadToSharedBufferSizeBytes<input_t>(max_num_items_first_copy);
   alignas(buffer_align) __shared__ char buffer[num_buffers][buffer_size];
-  cuda::std::span<const input_t> src{input, static_cast<cuda::std::size_t>(num_items)};
-  cuda::std::span<char> dst_buff{buffer[0]};
+  const cuda::std::span<const input_t> src{input, static_cast<cuda::std::size_t>(num_items)};
+  const cuda::std::span<char> dst_buff{buffer[0]};
   const int num_items_first_copy = cuda::std::min(num_items, max_num_items_first_copy);
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   cuda::std::span<input_t> dst = block_load2sh.CopyAsync(dst_buff, src.first(num_items_first_copy));
   if constexpr (Mode == test_mode::single_copy || Mode == test_mode::multi_copy_multi_phase
                 || Mode == test_mode::multi_copy_multi_barrier)
@@ -54,8 +55,8 @@ __global__ void kernel(InputPointerT input, OutputIteratorT output, int num_item
   }
   else if constexpr (Mode == test_mode::multi_copy_single_phase)
   {
-    cuda::std::span<char> dst_buff2{buffer[1]};
-    cuda::std::span<input_t> dst2 = block_load2sh.CopyAsync(dst_buff2, src.subspan(num_items_first_copy));
+    const cuda::std::span<char> dst_buff2{buffer[1]};
+    const cuda::std::span<input_t> dst2 = block_load2sh.CopyAsync(dst_buff2, src.subspan(num_items_first_copy));
 
     block_load2sh.CommitAndWait();
 
@@ -85,7 +86,7 @@ __global__ void kernel(InputPointerT input, OutputIteratorT output, int num_item
     // Reuse TempStorage
     block_load2sh_t second_block_load2sh{storage};
 
-    cuda::std::span<input_t> dst = second_block_load2sh.CopyAsync(dst_buff, src.subspan(num_items_first_copy));
+    const cuda::std::span<input_t> dst = second_block_load2sh.CopyAsync(dst_buff, src.subspan(num_items_first_copy));
 
     second_block_load2sh.CommitAndWait();
 
@@ -138,10 +139,10 @@ __global__ void kernel_dyn_smem_dst(InputPointerT input, OutputIteratorT output,
 
   constexpr int ThreadsInBlock = ThreadsInBlockX * ThreadsInBlockY * ThreadsInBlockZ;
 
-  cuda::std::span<input_t> src{input, static_cast<cuda::std::size_t>(num_items)};
-  cuda::std::span<char> dst_buff{smem_buff, cuda::std::size_t{cuda::ptx::get_sreg_dynamic_smem_size()}};
+  const cuda::std::span<input_t> src{input, static_cast<cuda::std::size_t>(num_items)};
+  const cuda::std::span<char> dst_buff{smem_buff, cuda::std::size_t{cuda::ptx::get_sreg_dynamic_smem_size()}};
 
-  cuda::std::span<input_t> dst = block_load2sh.CopyAsync(dst_buff, src.first(num_items));
+  const cuda::std::span<input_t> dst = block_load2sh.CopyAsync(dst_buff, src.first(num_items));
 
   // also test separate Commit and Wait calls with token passing here
   auto token = block_load2sh.Commit();

--- a/cub/test/catch2_test_block_prefetch.cu
+++ b/cub/test/catch2_test_block_prefetch.cu
@@ -114,7 +114,8 @@ CUB_TEST("BlockPrefetch is a no-op for CacheModifiedInputIterator", "[prefetch][
   c2h::gen(C2H_SEED(2), d_input);
 
   // can_prefetch_from<CMI> is false, so Prefetch must compile out to nothing; the copy still reads through the CMI.
-  cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, type> in(thrust::raw_pointer_cast(d_input.data()));
+  const cub::CacheModifiedInputIterator<cub::CacheLoadModifier::LOAD_CS, type> in(
+    thrust::raw_pointer_cast(d_input.data()));
   test_block_prefetch<type, threads_in_block, level>(d_input, in);
 }
 
@@ -135,7 +136,7 @@ CUB_TEST("BlockPrefetch works with thrust vector iterators", "[prefetch][block]"
   STATIC_REQUIRE(cub::detail::can_prefetch_from<decltype(d_input.cbegin())>);
   test_block_prefetch<type, threads_in_block, level>(d_input, d_input.cbegin());
 
-  thrust::universal_vector<type> universal_input(d_input.begin(), d_input.end());
+  const thrust::universal_vector<type> universal_input(d_input.begin(), d_input.end());
   STATIC_REQUIRE(cub::detail::can_prefetch_from<decltype(universal_input.cbegin())>);
   test_block_prefetch<type, threads_in_block, level>(d_input, universal_input.cbegin());
 }
@@ -154,7 +155,7 @@ CUB_TEST("BlockPrefetch works with cuda::buffer iterators", "[prefetch][block]",
   c2h::gen(C2H_SEED(2), d_input);
 
   // Managed memory is host- and device-accessible, so the buffer can be filled from the host and read in the kernel.
-  cuda::mr::legacy_managed_memory_resource mr;
+  cuda::mr::legacy_managed_memory_resource mr; // NOLINT(misc-const-correctness)
   auto buf =
     cuda::make_buffer<type>(cuda::stream_ref{cudaStream_t{}}, mr, static_cast<size_t>(num_items), cuda::no_init);
   REQUIRE(cudaSuccess
@@ -184,7 +185,7 @@ CUB_TEST("BlockPrefetch handles unaligned tile bases", "[prefetch][block]", CUB_
 
   // Prefetch/copy the sub-range that starts at an unaligned offset into the allocation.
   auto* start = thrust::raw_pointer_cast(d_storage.data()) + offset;
-  c2h::device_vector<type> d_input(d_storage.begin() + offset, d_storage.end());
+  const c2h::device_vector<type> d_input(d_storage.begin() + offset, d_storage.end());
 
   test_block_prefetch<type, threads_in_block, cub::detail::LoadPrefetch::bulk_l2>(d_input, start);
 }

--- a/cub/test/catch2_test_block_radix_sort_custom.cu
+++ b/cub/test/catch2_test_block_radix_sort_custom.cu
@@ -66,7 +66,7 @@ __global__ void sort_keys()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).Sort(thread_keys[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {-2.5, 0}, //
@@ -124,7 +124,7 @@ __global__ void sort_keys_bits()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).Sort(thread_keys[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        {42.4, 1ll << 60}, // thread 0 expected keys
      },
@@ -163,7 +163,7 @@ __global__ void sort_keys_descending()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortDescending(thread_keys[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {+3.7, 0}, //
@@ -221,7 +221,7 @@ __global__ void sort_keys_descending_bits()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortDescending(thread_keys[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        {24.2, 1ll << 61}, // thread 0 expected keys
      },
@@ -264,7 +264,7 @@ __global__ void sort_pairs()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).Sort(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{});
 
-  custom_t expected_keys[2][3] = //
+  const custom_t expected_keys[2][3] = //
     {{
        // thread 0 expected keys
        {-2.5, 0}, //
@@ -278,7 +278,7 @@ __global__ void sort_pairs()
        {+3.7, 5} //
      }};
 
-  int expected_values[2][3] = //
+  const int expected_values[2][3] = //
     {{0, 1, 2}, // thread 0 expected values
      {3, 4, 5}}; // thread 1 expected values
   // example-end pairs
@@ -335,7 +335,7 @@ __global__ void sort_pairs_bits()
   block_radix_sort_t(temp_storage)
     .Sort(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_keys[2][3] = //
+  const custom_t expected_keys[2][3] = //
     {{
        {42.4, 1ll << 60}, // thread 0 expected keys
      },
@@ -343,7 +343,7 @@ __global__ void sort_pairs_bits()
        {24.2, 1ll << 61} // thread 1 expected keys
      }};
 
-  int expected_values[2][1] = //
+  const int expected_values[2][1] = //
     {{0}, // thread 0 values
      {1}}; // thread 1 values
   // example-end pairs-bits
@@ -383,7 +383,7 @@ __global__ void sort_pairs_descending()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortDescending(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{});
 
-  custom_t expected_keys[2][3] = //
+  const custom_t expected_keys[2][3] = //
     {{
        // thread 0 expected keys
        {+3.7, 0}, //
@@ -397,7 +397,7 @@ __global__ void sort_pairs_descending()
        {-2.5, 5} //
      }};
 
-  int expected_values[2][3] = //
+  const int expected_values[2][3] = //
     {{0, 1, 2}, // thread 0 expected values
      {4, 3, 5}}; // thread 1 expected values
   // example-end pairs-descending
@@ -454,7 +454,7 @@ __global__ void sort_pairs_descending_bits()
   block_radix_sort_t(temp_storage)
     .SortDescending(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        {24.2, 1ll << 61}, // thread 0 expected keys
      },
@@ -462,7 +462,7 @@ __global__ void sort_pairs_descending_bits()
        {42.4, 1ll << 60} // thread 1 expected keys
      }};
 
-  int expected_values[2][1] = //
+  const int expected_values[2][1] = //
     {{0}, // thread 0 expected values
      {1}}; // thread 1 expected values
   // example-end pairs-descending-bits
@@ -498,7 +498,7 @@ __global__ void sort_keys_blocked_to_striped()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortBlockedToStriped(thread_keys[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {-2.5, 0}, //
@@ -560,7 +560,7 @@ __global__ void sort_keys_blocked_to_striped_bits()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortBlockedToStriped(thread_keys[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{// thread 0 expected keys
       {24.2, 1ll << 59},
       {42.4, 1ll << 61}},
@@ -605,7 +605,7 @@ __global__ void sort_pairs_blocked_to_striped()
   block_radix_sort_t(temp_storage)
     .SortBlockedToStriped(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {-2.5, 0}, //
@@ -619,7 +619,7 @@ __global__ void sort_pairs_blocked_to_striped()
        {+3.7, 5} //
      }};
 
-  int expected_values[2][3] = //
+  const int expected_values[2][3] = //
     {{0, 2, 4}, // thread 0 values
      {1, 3, 5}}; // thread 1 values
   // example-end pairs-striped
@@ -680,7 +680,7 @@ __global__ void sort_pairs_blocked_to_striped_bits()
   block_radix_sort_t(temp_storage)
     .SortBlockedToStriped(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{// thread 0 expected keys
       {24.2, 1ll << 59},
       {42.4, 1ll << 61}},
@@ -688,7 +688,7 @@ __global__ void sort_pairs_blocked_to_striped_bits()
       {42.4, 1ll << 60},
       {24.2, 1ll << 62}}};
 
-  int expected_values[2][2] = //
+  const int expected_values[2][2] = //
     {{0, 2}, // thread 0 values
      {1, 3}}; // thread 1 values
   // example-end pairs-striped-bits
@@ -727,7 +727,7 @@ __global__ void sort_keys_descending_blocked_to_striped()
   // Collectively sort the keys
   block_radix_sort_t(temp_storage).SortDescendingBlockedToStriped(thread_keys[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {+3.7, 0}, //
@@ -790,7 +790,7 @@ __global__ void sort_keys_descending_blocked_to_striped_bits()
   block_radix_sort_t(temp_storage)
     .SortDescendingBlockedToStriped(thread_keys[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][2] = //
+  const custom_t expected_output[2][2] = //
     {{
        // thread 0 expected keys
        {24.2, 1ll << 62}, //
@@ -839,7 +839,7 @@ __global__ void sort_pairs_descending_blocked_to_striped()
   block_radix_sort_t(temp_storage)
     .SortDescendingBlockedToStriped(thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{});
 
-  custom_t expected_output[2][3] = //
+  const custom_t expected_output[2][3] = //
     {{
        // thread 0 expected keys
        {+3.7, 0}, //
@@ -853,7 +853,7 @@ __global__ void sort_pairs_descending_blocked_to_striped()
        {-2.5, 5} //
      }};
 
-  int expected_values[2][3] = //
+  const int expected_values[2][3] = //
     {{0, 2, 3}, // thread 0 values
      {1, 4, 5}}; // thread 1 values
   // example-end pairs-striped-descending
@@ -915,7 +915,7 @@ __global__ void sort_pairs_descending_blocked_to_striped_bits()
     .SortDescendingBlockedToStriped(
       thread_keys[threadIdx.x], thread_values[threadIdx.x], decomposer_t{}, begin_bit, end_bit);
 
-  custom_t expected_output[2][2] = //
+  const custom_t expected_output[2][2] = //
     {{
        // thread 0 expected keys
        {24.2, 1ll << 62}, //
@@ -927,7 +927,7 @@ __global__ void sort_pairs_descending_blocked_to_striped_bits()
        {24.2, 1ll << 59} //
      }};
 
-  int expected_values[2][2] = //
+  const int expected_values[2][2] = //
     {{3, 1}, // thread 0 values
      {2, 0}}; // thread 1 values
   // example-end pairs-striped-descending-bits

--- a/cub/test/catch2_test_block_radix_sort_keys.cu
+++ b/cub/test/catch2_test_block_radix_sort_keys.cu
@@ -114,7 +114,7 @@ CUB_TEST("Block radix sort can sort keys",
     end_bit,
     striped);
 
-  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
+  const c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input` for comparison
   REQUIRE(binary_equal(d_output, h_reference, d_input));
@@ -159,7 +159,7 @@ CUB_TEST("Block radix sort can sort keys in descending order",
     end_bit,
     striped);
 
-  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
+  const c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input` for comparison
   REQUIRE(binary_equal(d_output, h_reference, d_input));

--- a/cub/test/catch2_test_block_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_block_radix_sort_pairs.cu
@@ -123,7 +123,7 @@ CUB_TEST("Block radix sort can sort pairs",
     end_bit,
     striped);
 
-  std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
+  const std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
     radix_sort_reference(d_input_keys, d_input_values, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input_*` for comparison
@@ -176,7 +176,7 @@ CUB_TEST("Block radix sort can sort pairs in descending order",
     end_bit,
     striped);
 
-  std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
+  const std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
     radix_sort_reference(d_input_keys, d_input_values, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input_*` for comparison
@@ -229,7 +229,7 @@ CUB_TEST("Block radix sort can sort mixed pairs",
     end_bit,
     striped);
 
-  std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
+  const std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
     radix_sort_reference(d_input_keys, d_input_values, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input_*` for comparison
@@ -282,7 +282,7 @@ CUB_TEST("Block radix sort can sort mixed pairs in descending order",
     end_bit,
     striped);
 
-  std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
+  const std::pair<c2h::host_vector<key_type>, c2h::host_vector<value_type>> h_reference =
     radix_sort_reference(d_input_keys, d_input_values, is_descending, begin_bit, end_bit);
 
   // overwrite `d_input_*` for comparison

--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -54,7 +54,7 @@ template <cub::BlockReduceAlgorithm Algorithm,
           class ActionT>
 void block_reduce(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action)
 {
-  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+  const dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
 
   block_reduce_kernel<Algorithm, ItemsPerThread, BlockDimX, BlockDimY, BlockDimZ, T, ActionT><<<1, block_dims>>>(
     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), static_cast<int>(in.size()), action);
@@ -153,7 +153,7 @@ CUB_TEST("Block reduce works with sum",
   c2h::gen(C2H_SEED(10), d_in, cuda::std::numeric_limits<type>::min());
 
   c2h::host_vector<type> h_in = d_in;
-  c2h::host_vector<type> h_reference(
+  const c2h::host_vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return static_cast<type>(lhs + rhs);
     }));
@@ -185,7 +185,7 @@ CUB_TEST("Block reduce works with sum in partial tiles",
   c2h::gen(C2H_SEED(10), d_in, cuda::std::numeric_limits<type>::min());
 
   c2h::host_vector<type> h_in = d_in;
-  std::vector<type> h_reference(
+  const std::vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return static_cast<type>(lhs + rhs);
     }));
@@ -217,7 +217,7 @@ CUB_TEST("Block reduce works with custom op",
   c2h::gen(C2H_SEED(10), d_in, cuda::std::numeric_limits<type>::min());
 
   c2h::host_vector<type> h_in = d_in;
-  c2h::host_vector<type> h_reference(
+  const c2h::host_vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return std::max(lhs, rhs);
     }));
@@ -249,7 +249,7 @@ CUB_TEST("Block reduce works with custom op in partial tiles",
   c2h::gen(C2H_SEED(10), d_in, cuda::std::numeric_limits<type>::min());
 
   c2h::host_vector<type> h_in = d_in;
-  c2h::host_vector<type> h_reference(
+  const c2h::host_vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return std::max(lhs, rhs);
     }));
@@ -281,7 +281,7 @@ CUB_TEST("Block reduce works with custom types", "[reduce][block]", CUB_SMALL, b
   c2h::gen(C2H_SEED(10), d_in, cuda::std::numeric_limits<type>::min());
 
   c2h::host_vector<type> h_in = d_in;
-  c2h::host_vector<type> h_reference(
+  const c2h::host_vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return static_cast<type>(lhs + rhs);
     }));
@@ -310,7 +310,7 @@ CUB_TEST(
   c2h::gen(C2H_SEED(10), d_in);
 
   c2h::host_vector<type> h_in = d_in;
-  c2h::host_vector<type> h_reference(
+  const c2h::host_vector<type> h_reference(
     1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type& lhs, const type& rhs) {
       return static_cast<type>(lhs + rhs);
     }));

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -167,7 +167,7 @@ public:
     // Init the BlockRunLengthDecode and get the total decoded size of this block's tile (i.e., the
     // "decompressed" size)
     uint32_t decoded_size = 0U;
-    BlockRunLengthDecodeT run_length_decode =
+    const BlockRunLengthDecodeT run_length_decode =
       InitBlockRunLengthDecode(unique_items, run_lengths, decoded_size, cuda::std::bool_constant<TEST_RUN_OFFSETS_>{});
     return decoded_size;
   }
@@ -205,7 +205,7 @@ public:
 
       // The number of decoded items that are valid within this window (aka pass) of run-length
       // decoding
-      uint32_t num_valid_items = decoded_size - decoded_window_offset;
+      const uint32_t num_valid_items = decoded_size - decoded_window_offset;
       run_length_decode.RunLengthDecode(decoded_items, relative_offsets, decoded_window_offset);
 
       BlockStoreDecodedItemT(temp_storage.decode.store_decoded_runs_storage)
@@ -245,7 +245,7 @@ __launch_bounds__(AgentTestBlockRunLengthDecode::BLOCK_THREADS) __global__ void 
   OffsetT num_valid_runs = (block_offset + RUNS_PER_BLOCK >= num_runs) ? (num_runs - block_offset) : RUNS_PER_BLOCK;
 
   AgentTestBlockRunLengthDecode run_length_decode_agent(temp_storage);
-  uint64_t num_decoded_items =
+  const uint64_t num_decoded_items =
     run_length_decode_agent.GetDecodedSize(d_unique_items + block_offset, d_run_lengths + block_offset, num_valid_runs);
 
   d_decoded_sizes[blockIdx.x] = num_decoded_items;
@@ -312,7 +312,7 @@ void TestAlgorithmSpecialisation()
   using ItemItT       = thrust::counting_iterator<RunItemT>;
   using RunLengthsItT = cuda::transform_iterator<ModOp, cuda::counting_iterator<RunLengthT>>;
 
-  ItemItT d_unique_items(1000U);
+  const ItemItT d_unique_items(1000U);
   RunLengthsItT d_run_lengths(cuda::counting_iterator<RunLengthT>(0), ModOp{});
 
   constexpr uint32_t num_runs   = 10000;

--- a/cub/test/catch2_test_block_scan.cu
+++ b/cub/test/catch2_test_block_scan.cu
@@ -72,7 +72,7 @@ template <cub::BlockScanAlgorithm Algorithm,
           class ActionT>
 void block_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action)
 {
-  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+  const dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
 
   block_scan_kernel<Algorithm, ItemsPerThread, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
     <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
@@ -84,7 +84,7 @@ void block_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT a
 template <cub::BlockScanAlgorithm Algorithm, int BlockDimX, int BlockDimY, int BlockDimZ, class T, class ActionT>
 void block_scan_single(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action)
 {
-  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+  const dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
 
   block_scan_single_kernel<Algorithm, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
     <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action);
@@ -518,7 +518,7 @@ CUB_TEST("Block scan returns valid block aggregate", "[scan][block]", CUB_SMALL,
     d_in, d_out, sum_aggregate_op_t<type, mode>{target_thread_id, thrust::raw_pointer_cast(d_block_aggregate.data())});
 
   c2h::host_vector<type> h_out = d_in;
-  type block_aggregate         = host_scan(mode, h_out, std::plus<type>{});
+  const type block_aggregate   = host_scan(mode, h_out, std::plus<type>{});
 
   REQUIRE(h_out == d_out);
   REQUIRE(block_aggregate == d_block_aggregate[0]);
@@ -659,7 +659,7 @@ CUB_TEST("Block custom op scan with initial value returns valid block aggregate"
       target_thread_id, initial_value, thrust::raw_pointer_cast(d_block_aggregate.data())});
 
   c2h::host_vector<type> h_out = d_in;
-  type h_block_aggregate       = host_scan(
+  const type h_block_aggregate = host_scan(
     mode,
     h_out,
     [](type l, type r) {

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -24,8 +24,8 @@ __global__ void InclusiveBlockScanKernel(int* output)
   // Allocate shared memory for BlockScan
   __shared__ temp_storage_t temp_storage;
 
-  int initial_value = 1;
-  int thread_data[] = {
+  const int initial_value = 1;
+  int thread_data[]       = {
     +1 * ((int) threadIdx.x * num_items_per_thread), // item 0
     -1 * ((int) threadIdx.x * num_items_per_thread + 1) // item 1
   };
@@ -74,8 +74,8 @@ __global__ void InclusiveBlockScanKernelAggregate(int* output, int* d_block_aggr
   // Allocate shared memory for BlockScan
   __shared__ temp_storage_t temp_storage;
 
-  int initial_value = 1;
-  int thread_data[] = {
+  const int initial_value = 1;
+  int thread_data[]       = {
     +1 * ((int) threadIdx.x * num_items_per_thread), // item 0
     -1 * ((int) threadIdx.x * num_items_per_thread + 1) // item 1
   };

--- a/cub/test/catch2_test_block_shuffle.cu
+++ b/cub/test/catch2_test_block_shuffle.cu
@@ -145,7 +145,7 @@ struct down_with_prefix_op_t
 template <int ItemsPerThread, int BlockDimX, int BlockDimY, int BlockDimZ, class T, class ActionT>
 void block_shuffle(c2h::device_vector<T>& data, ActionT action)
 {
-  dim3 block(BlockDimX, BlockDimY, BlockDimZ);
+  const dim3 block(BlockDimX, BlockDimY, BlockDimZ);
   block_shuffle_kernel<BlockDimX, BlockDimY, BlockDimZ, ItemsPerThread>
     <<<1, block>>>(thrust::raw_pointer_cast(data.data()), action);
 
@@ -218,7 +218,7 @@ CUB_TEST(
   c2h::device_vector<type> d_data(params::tile_size);
   c2h::gen(C2H_SEED(10), d_data);
 
-  c2h::device_vector<type> d_ref = d_data;
+  const c2h::device_vector<type> d_ref = d_data;
 
   const unsigned int distance = GENERATE_COPY(take(4, random(0, params::tile_size - 1)));
 

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -244,7 +244,7 @@ CUB_TEST("Block store works with caching iterators", "[store][block]", CUB_SMALL
   c2h::gen(C2H_SEED(10), d_input);
 
   c2h::device_vector<type> d_output(d_input.size());
-  cub::CacheModifiedOutputIterator<cub::CacheStoreModifier::STORE_DEFAULT, type> out(
+  const cub::CacheModifiedOutputIterator<cub::CacheStoreModifier::STORE_DEFAULT, type> out(
     thrust::raw_pointer_cast(d_output.data()));
 
   block_store<items_per_thread, threads_in_block, store_algorithm>(

--- a/cub/test/catch2_test_block_topk.cu
+++ b/cub/test/catch2_test_block_topk.cu
@@ -87,7 +87,7 @@ void check_topk(const c2h::host_vector<KeyT>& h_in, cuda::std::span<const KeyT> 
   std::sort(h_top.begin(),
             h_top.end(),
             direction_to_comparator_t<SelectMax ? cub::detail::topk::select::max : cub::detail::topk::select::min>{});
-  c2h::host_vector<KeyT> h_ref_vec(h_ref.begin(), h_ref.end());
+  const c2h::host_vector<KeyT> h_ref_vec(h_ref.begin(), h_ref.end());
   CAPTURE(bit_repr(h_top), bit_repr(h_ref_vec));
   REQUIRE(h_top == h_ref_vec);
 }
@@ -126,7 +126,7 @@ CUB_TEST(
   CAPTURE(c2h::type_name<key_t>(), select_max);
 
   const int num_valid = tile_size / 2 + 7;
-  c2h::host_vector<key_t> h_in_partial(h_in.begin(), h_in.begin() + num_valid);
+  const c2h::host_vector<key_t> h_in_partial(h_in.begin(), h_in.begin() + num_valid);
 
   SECTION("full tile, blocked input")
   {
@@ -177,7 +177,7 @@ CUB_TEST("block_topk::select_* selects the right top-k on a full tile",
 
   auto run_check = [&](rng_t& local_rng, key_t boundary_key) {
     CAPTURE(c2h::type_name<key_t>(), select_max, k, overhang, boundary_key);
-    c2h::host_vector<key_t> h_in =
+    const c2h::host_vector<key_t> h_in =
       gen_keys_from_boundary_key<select_max>(tile_size, k, overhang, boundary_key, local_rng);
     const auto h_ref = sorted_top_k<select_max>(h_in, k);
     check_topk<key_t, threads_per_block, items_per_thread, is_full_tile, blocked_input, select_max>(

--- a/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
+++ b/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
@@ -13,7 +13,7 @@ std::size_t get_alloc_bytes()
 {
   std::size_t free_bytes{};
   std::size_t total_bytes{};
-  cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
+  const cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
   REQUIRE(status == cudaSuccess);
 
   // Find a size that's > free but < total, preferring to return more than total if the values are

--- a/cub/test/catch2_test_debug.cu
+++ b/cub/test/catch2_test_debug.cu
@@ -12,7 +12,7 @@ CUB_TEST_CASE("CubDebug returns input error", "[debug][utils]", CUB_SMALL)
 CUB_TEST_CASE("CubDebug returns new errors", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
-  cudaError error = cudaPeekAtLastError();
+  const cudaError error = cudaPeekAtLastError();
 
   REQUIRE(error != cudaSuccess);
   REQUIRE(CubDebug(cudaSuccess) != cudaSuccess);
@@ -21,7 +21,7 @@ CUB_TEST_CASE("CubDebug returns new errors", "[debug][utils]", CUB_SMALL)
 CUB_TEST_CASE("CubDebug prefers input errors", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
-  cudaError error = cudaPeekAtLastError();
+  const cudaError error = cudaPeekAtLastError();
 
   REQUIRE(error != cudaSuccess);
   REQUIRE(CubDebug(cudaErrorMemoryAllocation) != cudaSuccess);
@@ -30,7 +30,7 @@ CUB_TEST_CASE("CubDebug prefers input errors", "[debug][utils]", CUB_SMALL)
 CUB_TEST_CASE("CubDebug resets last error", "[debug][utils]", CUB_SMALL)
 {
   cub::detail::EmptyKernel<int><<<0, 0>>>();
-  cudaError error = cudaPeekAtLastError();
+  const cudaError error = cudaPeekAtLastError();
 
   REQUIRE(error != cudaSuccess);
   REQUIRE(CubDebug(cudaSuccess) != cudaSuccess);

--- a/cub/test/catch2_test_device_adjacent_difference_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_api.cu
@@ -19,7 +19,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy legacy size-query is unambi
   int* d_in    = nullptr;
   int* d_out   = nullptr;
   size_t bytes = 0;
-  int n        = 0;
+  const int n  = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeftCopy(nullptr, bytes, d_in, d_out, n));
 }
@@ -30,7 +30,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft legacy size-query is unambiguou
 {
   int* d_in    = nullptr;
   size_t bytes = 0;
-  int n        = 0;
+  const int n  = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeft(nullptr, bytes, d_in, n));
 }
@@ -42,7 +42,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy legacy size-query is unamb
   int* d_in    = nullptr;
   int* d_out   = nullptr;
   size_t bytes = 0;
-  int n        = 0;
+  const int n  = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRightCopy(nullptr, bytes, d_in, d_out, n));
 }
@@ -53,7 +53,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight legacy size-query is unambiguo
 {
   int* d_in    = nullptr;
   size_t bytes = 0;
-  int n        = 0;
+  const int n  = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRight(nullptr, bytes, d_in, n));
 }

--- a/cub/test/catch2_test_device_adjacent_difference_env.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env.cu
@@ -42,7 +42,7 @@ CUB_TEST_CASE("Device adjacent difference subtract left copy works with default 
           == cub::DeviceAdjacentDifference::SubtractLeftCopy(
             input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(output == expected);
 }
 
@@ -54,7 +54,7 @@ CUB_TEST_CASE("Device adjacent difference subtract left works with default envir
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractLeft(data.begin(), data.size(), cuda::std::minus{}));
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(data == expected);
 }
 
@@ -69,7 +69,7 @@ CUB_TEST_CASE("Device adjacent difference subtract right copy works with default
           == cub::DeviceAdjacentDifference::SubtractRightCopy(
             input.begin(), output.begin(), input.size(), cuda::std::minus{}));
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(output == expected);
 }
 
@@ -81,7 +81,7 @@ CUB_TEST_CASE("Device adjacent difference subtract right works with default envi
 
   REQUIRE(cudaSuccess == cub::DeviceAdjacentDifference::SubtractRight(data.begin(), data.size(), cuda::std::minus{}));
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
 }
 
@@ -101,7 +101,7 @@ CUB_TEST("Device adjacent difference subtract left copy uses environment", "[adj
 
   device_adjacent_difference_subtract_left_copy(input.begin(), output.begin(), input.size(), cuda::std::minus{}, env);
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(output == expected);
 }
 
@@ -118,7 +118,7 @@ CUB_TEST("Device adjacent difference subtract left uses environment", "[adjacent
 
   device_adjacent_difference_subtract_left(data.begin(), data.size(), cuda::std::minus{}, env);
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(data == expected);
 }
 
@@ -136,7 +136,7 @@ CUB_TEST("Device adjacent difference subtract right copy uses environment", "[ad
 
   device_adjacent_difference_subtract_right_copy(input.begin(), output.begin(), input.size(), cuda::std::minus{}, env);
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(output == expected);
 }
 
@@ -153,7 +153,7 @@ CUB_TEST("Device adjacent difference subtract right uses environment", "[adjacen
 
   device_adjacent_difference_subtract_right(data.begin(), data.size(), cuda::std::minus{}, env);
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
 }
 
@@ -197,7 +197,7 @@ CUB_TEST(
 
   device_adjacent_difference_subtract_left_copy(input.begin(), output.begin(), input.size(), op, env);
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(output == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -212,7 +212,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft can be tuned", "[adjacent_diffe
 
   device_adjacent_difference_subtract_left(data.begin(), data.size(), op, env);
 
-  c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const c2h::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   REQUIRE(data == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -229,7 +229,7 @@ CUB_TEST(
 
   device_adjacent_difference_subtract_right_copy(input.begin(), output.begin(), input.size(), op, env);
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(output == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -244,7 +244,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight can be tuned", "[adjacent_diff
 
   device_adjacent_difference_subtract_right(data.begin(), data.size(), op, env);
 
-  c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const c2h::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   REQUIRE(data == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_adjacent_difference_env_api.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_env_api.cu
@@ -21,8 +21,8 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adj
   auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = thrust::device_vector<int>(8);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceAdjacentDifference::SubtractLeftCopy(
     input.begin(), output.begin(), input.size(), cuda::std::minus{}, stream_ref);
@@ -31,7 +31,7 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeftCopy accepts stream", "[adj
     std::cerr << "cub::DeviceAdjacentDifference::SubtractLeftCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   // example-end subtract-left-copy-env-stream
   stream.sync();
   REQUIRE(error == cudaSuccess);
@@ -43,8 +43,8 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacen
   // example-begin subtract-left-env-stream
   auto data = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceAdjacentDifference::SubtractLeft(data.begin(), data.size(), cuda::std::minus{}, stream_ref);
   if (error != cudaSuccess)
@@ -52,7 +52,7 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractLeft accepts stream", "[adjacen
     std::cerr << "cub::DeviceAdjacentDifference::SubtractLeft failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
+  const thrust::device_vector<int> expected{1, 1, -1, 1, -1, 1, -1, 1};
   // example-end subtract-left-env-stream
   stream.sync();
 
@@ -66,8 +66,8 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[ad
   auto input  = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
   auto output = thrust::device_vector<int>(8);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceAdjacentDifference::SubtractRightCopy(
     input.begin(), output.begin(), input.size(), cuda::std::minus{}, stream_ref);
@@ -76,7 +76,7 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractRightCopy accepts stream", "[ad
     std::cerr << "cub::DeviceAdjacentDifference::SubtractRightCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const thrust::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   // example-end subtract-right-copy-env-stream
   stream.sync();
 
@@ -89,8 +89,8 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjace
   // example-begin subtract-right-env-stream
   auto data = thrust::device_vector<int>{1, 2, 1, 2, 1, 2, 1, 2};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceAdjacentDifference::SubtractRight(data.begin(), data.size(), cuda::std::minus{}, stream_ref);
   if (error != cudaSuccess)
@@ -98,7 +98,7 @@ CUB_TEST("cub::DeviceAdjacentDifference::SubtractRight accepts stream", "[adjace
     std::cerr << "cub::DeviceAdjacentDifference::SubtractRight failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
+  const thrust::device_vector<int> expected{-1, 1, -1, 1, -1, 1, -1, 2};
   // example-end subtract-right-env-stream
   stream.sync();
 

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -68,7 +68,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input",
   c2h::device_vector<type> in(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
   adjacent_difference_subtract_left_copy(in.begin(), cuda::discard_iterator(), num_items, cuda::std::minus<>{});
 
   REQUIRE(reference == in);
@@ -125,26 +125,26 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with user provided memory
 
   SECTION("DeviceAdjacentDifference::SubtractLeft works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_left(stream.get());
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeft works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_left(stream);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeft works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_subtract_left(stream_ref);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeft works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_subtract_left(env);
   }
 
@@ -156,7 +156,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with user provided memory
 
   SECTION("DeviceAdjacentDifference::SubtractLeft works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_subtract_left(policy);
   }
@@ -233,26 +233,26 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with user provided me
 
   SECTION("DeviceAdjacentDifference::SubtractLeftCopy works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_left_copy(stream.get());
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeftCopy works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_left_copy(stream);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeftCopy works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_subtract_left_copy(stream_ref);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractLeftCopy works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_subtract_left_copy(env);
   }
 
@@ -264,7 +264,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with user provided me
 
   SECTION("DeviceAdjacentDifference::SubtractLeftCopy works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_subtract_left_copy(policy);
   }
@@ -276,7 +276,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy accepts cuda::device_buffer
 {
   using type = std::int32_t;
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto input = cuda::make_device_buffer<type>(stream, cuda::devices[0], {2, 5, 9, 14, 20});
   c2h::device_vector<type> output(input.size(), thrust::no_init);
   const auto output_it = thrust::raw_pointer_cast(output.data());

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -67,7 +67,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input"
   c2h::device_vector<type> in(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
   adjacent_difference_subtract_right_copy(in.begin(), cuda::discard_iterator(), num_items, cuda::std::minus<>{});
 
   REQUIRE(reference == in);
@@ -110,7 +110,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memor
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
   c2h::device_vector<type> in(num_items, thrust::default_init);
-  c2h::device_vector<type> out(num_items, thrust::default_init);
+  const c2h::device_vector<type> out(num_items, thrust::default_init);
   c2h::gen(C2H_SEED(2), in);
 
   c2h::host_vector<type> h_in = in;
@@ -154,26 +154,26 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memor
 
   SECTION("DeviceAdjacentDifference::SubtractRight works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_right(stream.get());
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_right(stream);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_subtract_right(stream_ref);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_subtract_right(env);
   }
 
@@ -185,7 +185,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with user provided memor
 
   SECTION("DeviceAdjacentDifference::SubtractRight works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_subtract_right(policy);
   }
@@ -199,7 +199,7 @@ CUB_TEST(
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
   c2h::device_vector<type> in(num_items);
-  c2h::device_vector<type> out(num_items);
+  const c2h::device_vector<type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
   c2h::host_vector<type> h_in = in;
@@ -267,26 +267,26 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided m
 
   SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_right_copy(stream.get());
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_subtract_right_copy(stream);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_subtract_right_copy(stream_ref);
   }
 
   SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_subtract_right_copy(env);
   }
 
@@ -298,7 +298,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with user provided m
 
   SECTION("DeviceAdjacentDifference::SubtractRightCopy works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_subtract_right_copy(policy);
   }

--- a/cub/test/catch2_test_device_batched_topk_env_api.cu
+++ b/cub/test/catch2_test_device_batched_topk_env_api.cu
@@ -37,7 +37,7 @@ CUB_TEST("cub::DeviceBatchedTopK::MaxKeys env-alloc example", "[batched_topk][de
   auto d_keys_out =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed,
                              cuda::execution::tie_break::unspecified,
@@ -80,7 +80,7 @@ CUB_TEST("cub::DeviceBatchedTopK::MinKeys env-alloc example", "[batched_topk][de
   auto d_keys_out =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(keys_out.data())), k);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed,
                              cuda::execution::tie_break::unspecified,
@@ -126,7 +126,7 @@ CUB_TEST("cub::DeviceBatchedTopK::MaxPairs env-alloc example", "[batched_topk][d
   auto d_values_out =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(values_out.data())), k);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed,
                              cuda::execution::tie_break::unspecified,
@@ -192,7 +192,7 @@ CUB_TEST("cub::DeviceBatchedTopK::MinPairs env-alloc example", "[batched_topk][d
   auto d_values_out =
     cuda::make_strided_iterator(cuda::make_counting_iterator(thrust::raw_pointer_cast(values_out.data())), k);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed,
                              cuda::execution::tie_break::unspecified,

--- a/cub/test/catch2_test_device_copy_batched.cu
+++ b/cub/test/catch2_test_device_copy_batched.cu
@@ -123,8 +123,8 @@ try
     take(c2h::adjust_seed_count(4),
          map(
            [](const std::vector<range_size_t>& chunk) {
-             range_size_t lhs = chunk[0];
-             range_size_t rhs = chunk[1];
+             const range_size_t lhs = chunk[0];
+             const range_size_t rhs = chunk[1];
              // Optionally ensure lhs < rhs, for example:
              return (lhs < rhs) ? std::make_tuple(lhs, rhs) : std::make_tuple(rhs, lhs);
            },
@@ -138,7 +138,7 @@ try
   // Generate the range sizes: Make sure range sizes are a multiple of the most granular unit (one AtomicT) being
   // copied (round down)
   c2h::gen(C2H_SEED(2), d_range_sizes, min_range_size, max_range_size);
-  item_offset_t num_total_items = thrust::reduce(d_range_sizes.cbegin(), d_range_sizes.cend());
+  const item_offset_t num_total_items = thrust::reduce(d_range_sizes.cbegin(), d_range_sizes.cend());
 
   // Shuffle output range destination-offsets
   auto d_range_dst_offsets = get_shuffled_buffer_offsets<range_offset_t, item_offset_t>(d_range_sizes, C2H_SEED(1));
@@ -149,17 +149,17 @@ try
   c2h::gen(C2H_SEED(1), d_in);
 
   // Prepare host-side input data for verification
-  c2h::host_vector<std::uint8_t> h_in(d_in);
+  const c2h::host_vector<std::uint8_t> h_in(d_in);
   c2h::host_vector<std::uint8_t> h_out(num_total_items);
   c2h::host_vector<range_size_t> h_range_sizes(d_range_sizes);
   c2h::host_vector<item_offset_t> h_dst_offsets(d_range_dst_offsets);
 
   // Prepare d_range_srcs
-  offset_to_constant_it<std::uint8_t> offset_to_index_op{};
+  const offset_to_constant_it<std::uint8_t> offset_to_index_op{};
   auto d_range_srcs = cuda::transform_iterator(cuda::counting_iterator(range_offset_t{0}), offset_to_index_op);
 
   // Prepare d_range_dsts
-  offset_to_transform_it<std::uint8_t*> dst_transform_op{
+  const offset_to_transform_it<std::uint8_t*> dst_transform_op{
     static_cast<std::uint8_t*>(thrust::raw_pointer_cast(d_out.data()))};
   auto d_range_dsts = cuda::transform_iterator(d_range_dst_offsets.begin(), dst_transform_op);
 
@@ -214,26 +214,26 @@ try
 
     SECTION("DeviceCopy::Batched works with cudaStream_t")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_copy_batched(stream.get());
     }
 
     SECTION("DeviceCopy::Batched works with cuda::stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_copy_batched(stream);
     }
 
     SECTION("DeviceCopy::Batched works with cuda::stream_ref")
     {
-      cuda::stream stream{cuda::devices[current_device]};
-      cuda::stream_ref stream_ref{stream};
+      const cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream_ref stream_ref{stream};
       test_copy_batched(stream_ref);
     }
 
     SECTION("DeviceCopy::Batched works with cuda::std::execution::env")
     {
-      cuda::std::execution::env env{};
+      const cuda::std::execution::env env{};
       test_copy_batched(env);
     }
 
@@ -245,7 +245,7 @@ try
 
     SECTION("DeviceCopy::Batched works with cuda::execution::gpu with stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
       test_copy_batched(policy);
     }
@@ -266,8 +266,9 @@ try
   using byte_offset_t = uint64_t;
   using buffer_size_t = uint64_t;
 
-  byte_offset_t large_target_copy_size = static_cast<byte_offset_t>(std::numeric_limits<uint32_t>::max()) + (32 << 20);
-  byte_offset_t num_items              = large_target_copy_size;
+  const byte_offset_t large_target_copy_size =
+    static_cast<byte_offset_t>(std::numeric_limits<uint32_t>::max()) + (32 << 20);
+  const byte_offset_t num_items = large_target_copy_size;
 
   // Input iterator for the items of a single range
   auto input_data_it = cuda::counting_iterator(data_t{42});
@@ -329,7 +330,7 @@ try
   const item_offset_t num_total_items = thrust::reduce(d_range_sizes.cbegin(), d_range_sizes.cend());
 
   // Prepare iterator that returns empty ranges for the first num_empty_ranges
-  prepend_n_constants_op<decltype(d_range_sizes.cbegin()), range_size_t> skip_first_n_sizes_op{
+  const prepend_n_constants_op<decltype(d_range_sizes.cbegin()), range_size_t> skip_first_n_sizes_op{
     d_range_sizes.cbegin(), range_size_t{0}, num_empty_ranges};
   auto d_range_sizes_it_skipped =
     cuda::transform_iterator(cuda::counting_iterator(range_offset_t{0}), skip_first_n_sizes_op);
@@ -343,11 +344,11 @@ try
   thrust::exclusive_scan(d_range_sizes.cbegin(), d_range_sizes.cend(), d_range_offsets.begin());
 
   // Use the offsets to generate an iterator over the ranges, where each range is an iterator into in_it
-  offset_to_ptr_op<range_it_t> src_transform_op{in_it};
+  const offset_to_ptr_op<range_it_t> src_transform_op{in_it};
   auto d_ranges_src_it = cuda::transform_iterator(thrust::raw_pointer_cast(d_range_offsets.data()), src_transform_op);
 
   // Wrap the iterator into an iterator that returns empty ranges for the first num_empty_ranges
-  prepend_n_constants_op<decltype(d_ranges_src_it), range_it_t> src_skip_first_n_op{
+  const prepend_n_constants_op<decltype(d_ranges_src_it), range_it_t> src_skip_first_n_op{
     d_ranges_src_it, in_it, num_empty_ranges};
   auto d_ranges_src_it_skipped =
     cuda::transform_iterator(cuda::counting_iterator(range_offset_t{0}), src_skip_first_n_op);
@@ -358,9 +359,9 @@ try
   using range_out_it_t     = decltype(check_result_it);
 
   // Helper iterator that offsets the checking output iterator by the offset for a given range
-  offset_to_ptr_op<decltype(check_result_it)> dst_transform_op{check_result_it};
+  const offset_to_ptr_op<decltype(check_result_it)> dst_transform_op{check_result_it};
   auto ranges_dst_it = cuda::transform_iterator(d_range_offsets.cbegin(), dst_transform_op);
-  prepend_n_constants_op<decltype(ranges_dst_it), range_out_it_t> dst_skip_first_n_op{
+  const prepend_n_constants_op<decltype(ranges_dst_it), range_out_it_t> dst_skip_first_n_op{
     ranges_dst_it, check_result_it, num_empty_ranges};
   auto d_ranges_dst_it_skipped =
     cuda::transform_iterator(cuda::counting_iterator(range_offset_t{0}), dst_skip_first_n_op);

--- a/cub/test/catch2_test_device_copy_env.cu
+++ b/cub/test/catch2_test_device_copy_env.cu
@@ -57,9 +57,9 @@ CUB_TEST_CASE("DeviceCopy::Batched works with default environment", "[copy][devi
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_ranges = 3;
+  const int num_ranges = 3;
 
-  thrust::counting_iterator<int> iota(0);
+  const thrust::counting_iterator<int> iota(0);
   auto input_it = thrust::make_transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = thrust::make_transform_iterator(
@@ -80,9 +80,9 @@ CUB_TEST("DeviceCopy::Batched uses environment", "[copy][device]", CUB_SMALL)
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_ranges = 3;
+  const int num_ranges = 3;
 
-  thrust::counting_iterator<int> iota(0);
+  const thrust::counting_iterator<int> iota(0);
   auto input_it = thrust::make_transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = thrust::make_transform_iterator(
@@ -107,9 +107,9 @@ CUB_TEST_CASE("DeviceCopy::Batched uses custom stream", "[copy][device]", CUB_SM
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_ranges = 3;
+  const int num_ranges = 3;
 
-  thrust::counting_iterator<int> iota(0);
+  const thrust::counting_iterator<int> iota(0);
   auto input_it = thrust::make_transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = thrust::make_transform_iterator(
@@ -162,17 +162,17 @@ CUB_TEST("DeviceCopy::Batched can be tuned", "[copy][device]", CUB_SMALL, block_
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 4, 6};
 
-  int num_ranges                = 3;
+  const int num_ranges          = 3;
   constexpr int items_per_range = 2;
 
-  cuda::counting_iterator<int> iota(0);
+  const cuda::counting_iterator<int> iota(0);
   auto input_it = cuda::make_transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = thrust::make_transform_iterator(
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator sizes(items_per_range, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator sizes(items_per_range, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(batch_copy_tuning<target_block_size>{});
 

--- a/cub/test/catch2_test_device_copy_env_api.cu
+++ b/cub/test/catch2_test_device_copy_env_api.cu
@@ -38,8 +38,8 @@ CUB_TEST("cub::DeviceCopy::Batched accepts env with stream", "[copy][env]", CUB_
   thrust::device_vector<int*> d_output_ptrs{dst_base, dst_base + range_size, dst_base + 2 * range_size};
   thrust::device_vector<int> d_sizes{range_size, range_size, range_size};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceCopy::Batched(
     thrust::raw_pointer_cast(d_input_ptrs.data()),
@@ -143,11 +143,11 @@ CUB_TEST("cub::DeviceCopy::Copy mdspan accepts env with stream", "[copy][env]", 
   using extents_t = cuda::std::extents<int, N, M>;
   using mdspan_t  = cuda::std::mdspan<float, extents_t, cuda::std::layout_right>; // row-major
 
-  mdspan_t mdspan_in(thrust::raw_pointer_cast(d_input.data()), extents_t{});
-  mdspan_t mdspan_out(thrust::raw_pointer_cast(d_output.data()), extents_t{});
+  const mdspan_t mdspan_in(thrust::raw_pointer_cast(d_input.data()), extents_t{});
+  const mdspan_t mdspan_out(thrust::raw_pointer_cast(d_output.data()), extents_t{});
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceCopy::Copy(mdspan_in, mdspan_out, stream_ref);
   if (error != cudaSuccess)

--- a/cub/test/catch2_test_device_copy_mdspan.cu
+++ b/cub/test/catch2_test_device_copy_mdspan.cu
@@ -111,26 +111,26 @@ CUB_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts and user pro
 
   SECTION("DeviceCopy::Copy works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_mdspan_copy(stream.get());
   }
 
   SECTION("DeviceCopy::Copy works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_mdspan_copy(stream);
   }
 
   SECTION("DeviceCopy::Copy works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_mdspan_copy(stream_ref);
   }
 
   SECTION("DeviceCopy::Copy works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_mdspan_copy(env);
   }
 
@@ -142,7 +142,7 @@ CUB_TEST("DeviceCopy::Copy: 1D, 2D, 4D mdspan with matching layouts and user pro
 
   SECTION("DeviceCopy::Copy works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_mdspan_copy(policy);
   }
@@ -161,7 +161,7 @@ CUB_TEST("DeviceCopy::Copy: 2D, 4D mdspan with compatible layouts", "[copy][mdsp
   using cuda::std::layout_stride;
   using mdspan_2d_left_t  = cuda::std::mdspan<int, dims_2d_t, layout_left>;
   using mdspan_strided_2d = cuda::std::mdspan<int, dims_2d_t, layout_stride>;
-  layout_stride::mapping<dims_2d_t> map_out{dims_2d_t{100, 100}, cuda::std::array{1, 100}};
+  const layout_stride::mapping<dims_2d_t> map_out{dims_2d_t{100, 100}, cuda::std::array{1, 100}};
 
   auto d_mdspan_in2  = mdspan_2d_left_t(thrust::raw_pointer_cast(d_input.data()), dims_2d_t{100, 100});
   auto d_mdspan_out2 = mdspan_strided_2d(thrust::raw_pointer_cast(d_output.data()), map_out);
@@ -187,8 +187,8 @@ CUB_TEST("DeviceCopy::Copy: 2D strided mdspan", "[copy][mdspan]", CUB_SMALL)
   using cuda::std::layout_stride;
   using mdspan_strided_2d = cuda::std::mdspan<int, dims_2d_t, layout_stride>;
 
-  layout_stride::mapping<dims_2d_t> map_in{dims_2d_t{100, 100}, cuda::std::array{2, 220}};
-  layout_stride::mapping<dims_2d_t> map_out{dims_2d_t{100, 100}, cuda::std::array{220, 2}};
+  const layout_stride::mapping<dims_2d_t> map_in{dims_2d_t{100, 100}, cuda::std::array{2, 220}};
+  const layout_stride::mapping<dims_2d_t> map_out{dims_2d_t{100, 100}, cuda::std::array{220, 2}};
   auto d_mdspan_in  = mdspan_strided_2d(thrust::raw_pointer_cast(d_input.data()), map_in);
   auto d_mdspan_out = mdspan_strided_2d(thrust::raw_pointer_cast(d_output.data()), map_out);
   device_copy_mdspan(d_mdspan_in, d_mdspan_out);
@@ -221,7 +221,7 @@ CUB_TEST("DeviceCopy::Copy: 2D strided mdspan + contiguous mdspan", "[copy][mdsp
   using cuda::std::layout_stride;
   using mdspan_strided_2d    = cuda::std::mdspan<int, dims_2d_t, layout_stride>;
   using mdspan_contiguous_2d = cuda::std::mdspan<int, dims_2d_t>;
-  layout_stride::mapping<dims_2d_t> map_in{dims_2d_t{100, 100}, cuda::std::array{2, 220}};
+  const layout_stride::mapping<dims_2d_t> map_in{dims_2d_t{100, 100}, cuda::std::array{2, 220}};
   auto d_mdspan_in  = mdspan_strided_2d(thrust::raw_pointer_cast(d_input.data()), map_in);
   auto d_mdspan_out = mdspan_contiguous_2d(thrust::raw_pointer_cast(d_output.data()), dims_2d_t{100, 100});
   device_copy_mdspan(d_mdspan_in, d_mdspan_out);

--- a/cub/test/catch2_test_device_copy_mdspan_api.cu
+++ b/cub/test/catch2_test_device_copy_mdspan_api.cu
@@ -31,8 +31,8 @@ CUB_TEST("DeviceCopy::Copy Mdspan API example", "[copy][mdspan]", CUB_SMALL)
   using mdspan_in_t  = cuda::std::mdspan<float, extents_t, cuda::std::layout_right>; // row-major
   using mdspan_out_t = cuda::std::mdspan<float, extents_t, cuda::std::layout_left>; // column-major
   // Create mdspans with different layouts
-  mdspan_in_t mdspan_in(thrust::raw_pointer_cast(d_input.data()), extents_t{});
-  mdspan_out_t mdspan_out(thrust::raw_pointer_cast(d_output.data()), extents_t{});
+  const mdspan_in_t mdspan_in(thrust::raw_pointer_cast(d_input.data()), extents_t{});
+  const mdspan_out_t mdspan_out(thrust::raw_pointer_cast(d_output.data()), extents_t{});
 
   // Determine temporary device storage requirements
   void*  d_temp_storage     = nullptr;

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -107,7 +107,7 @@ CUB_TEST(
   message_t* d_tile_data = thrust::raw_pointer_cast(tile_data.data());
 
   c2h::gen(C2H_SEED(2), tile_data);
-  c2h::host_vector<message_t> reference = compute_reference(tile_data);
+  const c2h::host_vector<message_t> reference = compute_reference(tile_data);
 
   // Query temporary storage requirements
   std::size_t temp_storage_bytes{};
@@ -119,7 +119,7 @@ CUB_TEST(
 
   // Initialize temporary storage
   scan_tile_state_t tile_status;
-  cudaError_t status = tile_status.Init(num_tiles, d_temp_storage, temp_storage_bytes);
+  const cudaError_t status = tile_status.Init(num_tiles, d_temp_storage, temp_storage_bytes);
   REQUIRE(status == cudaSuccess);
 
   constexpr unsigned int threads_in_init_block = 256;

--- a/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_exclusive_scan_noncommutative.cu
@@ -145,7 +145,7 @@ CUB_TEST("Device exclusive scan works with non-commutative bicyclic monoid opera
   const pair_t init_value{0, 0}; // identity element of the bicyclic monoid
 
   size_t tmp_size{};
-  cudaError_t status1 =
+  const cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op_t{}, init_value, num_items);
   REQUIRE(cudaSuccess == status1);
   REQUIRE(tmp_size > 0);
@@ -155,13 +155,13 @@ CUB_TEST("Device exclusive scan works with non-commutative bicyclic monoid opera
   c2h::device_vector<byte> tmp(tmp_size);
   byte* d_tmp = thrust::raw_pointer_cast(tmp.data());
 
-  cudaError_t status2 =
+  const cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op_t{}, init_value, num_items);
   REQUIRE(cudaSuccess == status2);
 
   // transfer to host_vector is synchronizing
-  c2h::host_vector<pair_t> h_output(output);
-  c2h::host_vector<pair_t> h_input(input);
+  const c2h::host_vector<pair_t> h_output(output);
+  const c2h::host_vector<pair_t> h_input(input);
   c2h::host_vector<pair_t> h_expected(num_items);
 
   compute_exclusive_scan_reference(h_input.cbegin(), h_input.cend(), h_expected.begin(), init_value, op_t{});
@@ -202,7 +202,7 @@ CUB_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan]
   symbol_t* d_output = thrust::raw_pointer_cast(output.data());
 
   size_t tmp_size{};
-  cudaError_t status1 =
+  const cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op, empty_stack_symbol, num_items);
   REQUIRE(cudaSuccess == status1);
   REQUIRE(tmp_size > 0);
@@ -212,13 +212,13 @@ CUB_TEST("Device exclusive scan works with PropagateLastWrite operator", "[scan]
   c2h::device_vector<byte> tmp(tmp_size);
   byte* d_tmp = thrust::raw_pointer_cast(tmp.data());
 
-  cudaError_t status2 =
+  const cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op, empty_stack_symbol, num_items);
   REQUIRE(cudaSuccess == status2);
 
   // transfer to host_vector is synchronizing
-  c2h::host_vector<symbol_t> h_output(output);
-  c2h::host_vector<symbol_t> h_input(input);
+  const c2h::host_vector<symbol_t> h_output(output);
+  const c2h::host_vector<symbol_t> h_input(input);
   c2h::host_vector<symbol_t> h_expected(num_items);
 
   compute_exclusive_scan_reference(h_input.cbegin(), h_input.cend(), h_expected.begin(), empty_stack_symbol, op);
@@ -270,7 +270,7 @@ CUB_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-repor
   symbol_t* d_output = thrust::raw_pointer_cast(output.data());
 
   size_t tmp_size{};
-  cudaError_t status1 =
+  const cudaError_t status1 =
     cub::DeviceScan::ExclusiveScan(nullptr, tmp_size, d_input, d_output, op, empty_stack_symbol, num_elements);
   REQUIRE(cudaSuccess == status1);
 
@@ -279,10 +279,10 @@ CUB_TEST("Device exclusive scan PropagateLastWrite reproduces original bug-repor
   c2h::device_vector<byte> tmp(tmp_size);
   byte* d_tmp = thrust::raw_pointer_cast(tmp.data());
 
-  cudaError_t status2 =
+  const cudaError_t status2 =
     cub::DeviceScan::ExclusiveScan(d_tmp, tmp_size, d_input, d_output, op, empty_stack_symbol, num_elements);
   REQUIRE(cudaSuccess == status2);
 
-  c2h::host_vector<symbol_t> h_output(output);
+  const c2h::host_vector<symbol_t> h_output(output);
   REQUIRE(h_expected == h_output);
 }

--- a/cub/test/catch2_test_device_find.cu
+++ b/cub/test/catch2_test_device_find.cu
@@ -169,7 +169,7 @@ CUB_TEST("Device find_if works with non primitive iterator", "[device][find_if]"
   constexpr offset_t min_items = 1;
   constexpr offset_t max_items = 10000000; // 10M items for reasonable test time
 
-  input_t val_to_find = static_cast<input_t>(GENERATE_COPY(take(1, random(min_items, max_items))));
+  const input_t val_to_find = static_cast<input_t>(GENERATE_COPY(take(1, random(min_items, max_items))));
   // Generate the input sizes to test for
   const offset_t num_items = GENERATE_COPY(
     take(1, random(min_items, max_items)),
@@ -322,7 +322,7 @@ void test_vectorized(Variant variant, HostVariant host_variant, std::size_t num_
   c2h::host_vector<Value> target_values_h = target_values_d;
   c2h::host_vector<Value> values_h        = values_d;
 
-  c2h::host_vector<Result> offsets_h = offsets_d;
+  const c2h::host_vector<Result> offsets_h = offsets_d;
 
   c2h::host_vector<std::ptrdiff_t> offsets_ref(offsets_h.size(), thrust::default_init);
 

--- a/cub/test/catch2_test_device_find_api.cu
+++ b/cub/test/catch2_test_device_find_api.cu
@@ -26,7 +26,7 @@ CUB_TEST("cub::DeviceFind::FindIf works with int data elements", "[find][device]
   constexpr int num_items         = 8;
   thrust::device_vector<int> d_in = {0, 1, 2, 3, 4, 5, 6, 7};
   thrust::device_vector<int> d_out(1, thrust::no_init);
-  is_greater_than_t predicate{4};
+  const is_greater_than_t predicate{4};
 
   size_t temp_storage_bytes = 0;
   cub::DeviceFind::FindIf(nullptr, temp_storage_bytes, d_in.begin(), d_out.begin(), predicate, num_items);
@@ -41,7 +41,7 @@ CUB_TEST("cub::DeviceFind::FindIf works with int data elements", "[find][device]
     predicate,
     num_items);
 
-  int expected = 5;
+  const int expected = 5;
   // example-end device-find-if
 
   REQUIRE(d_out[0] == expected);
@@ -77,7 +77,7 @@ CUB_TEST("cub::DeviceFind::LowerBound works with int data elements", "[find][dev
     d_output.begin(),
     cuda::std::less{});
 
-  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  const thrust::device_vector<int> expected = {1, 2, 3, 4};
   // example-end device-lower-bound
 
   REQUIRE(d_output == expected);
@@ -113,7 +113,7 @@ CUB_TEST("cub::DeviceFind::UpperBound works with int data elements", "[find][dev
     d_output.begin(),
     cuda::std::less{});
 
-  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  const thrust::device_vector<int> expected = {1, 2, 3, 4};
   // example-end device-upper-bound
 
   REQUIRE(d_output == expected);
@@ -129,19 +129,19 @@ CUB_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]"
   int* d_in    = nullptr;
   int* d_out   = nullptr;
   size_t bytes = 0;
-  int n        = 0;
+  const int n  = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceFind::FindIf(nullptr, bytes, d_in, d_out, is_greater_than_t{0}, n));
 }
 
 CUB_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
-  int* d_range  = nullptr;
-  int* d_values = nullptr;
-  int* d_output = nullptr;
-  size_t bytes  = 0;
-  int range_n   = 0;
-  int values_n  = 0;
+  int* d_range       = nullptr;
+  int* d_values      = nullptr;
+  int* d_output      = nullptr;
+  size_t bytes       = 0;
+  const int range_n  = 0;
+  const int values_n = 0;
 
   REQUIRE(
     cudaSuccess
@@ -150,12 +150,12 @@ CUB_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][devi
 
 CUB_TEST("DeviceFind::UpperBound legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
-  int* d_range  = nullptr;
-  int* d_values = nullptr;
-  int* d_output = nullptr;
-  size_t bytes  = 0;
-  int range_n   = 0;
-  int values_n  = 0;
+  int* d_range       = nullptr;
+  int* d_values      = nullptr;
+  int* d_output      = nullptr;
+  size_t bytes       = 0;
+  const int range_n  = 0;
+  const int values_n = 0;
 
   REQUIRE(
     cudaSuccess

--- a/cub/test/catch2_test_device_find_api.cu
+++ b/cub/test/catch2_test_device_find_api.cu
@@ -136,12 +136,12 @@ CUB_TEST("DeviceFind::FindIf legacy size-query is unambiguous", "[find][device]"
 
 CUB_TEST("DeviceFind::LowerBound legacy size-query is unambiguous", "[find][device]", CUB_SMALL)
 {
-  int* d_range       = nullptr;
-  int* d_values      = nullptr;
-  int* d_output      = nullptr;
-  size_t bytes       = 0;
-  const int range_n  = 0;
-  const int values_n = 0;
+  int* const d_range  = nullptr;
+  int* const d_values = nullptr;
+  int* const d_output = nullptr;
+  size_t bytes        = 0;
+  const int range_n   = 0;
+  const int values_n  = 0;
 
   REQUIRE(
     cudaSuccess

--- a/cub/test/catch2_test_device_find_bound_sorted_values.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values.cu
@@ -63,9 +63,9 @@ void test_sorted(Variant variant,
           thrust::raw_pointer_cast(offsets_d.data()),
           compare_op);
 
-  c2h::host_vector<Value> range_h    = range_d;
-  c2h::host_vector<Value> values_h   = values_d;
-  c2h::host_vector<Result> offsets_h = offsets_d;
+  c2h::host_vector<Value> range_h          = range_d;
+  c2h::host_vector<Value> values_h         = values_d;
+  const c2h::host_vector<Result> offsets_h = offsets_d;
 
   c2h::host_vector<Result> offsets_ref(values_num_items);
   for (auto i = 0u; i < values_num_items; ++i)
@@ -119,9 +119,9 @@ CUB_TEST("DeviceFind::LowerBoundSortedValues works with a transform output itera
     offsets_out,
     cuda::std::less<value_type>{});
 
-  c2h::host_vector<value_type> range_h  = range_d;
-  c2h::host_vector<value_type> values_h = values_d;
-  c2h::host_vector<Result> offsets_h    = offsets_d;
+  c2h::host_vector<value_type> range_h     = range_d;
+  c2h::host_vector<value_type> values_h    = values_d;
+  const c2h::host_vector<Result> offsets_h = offsets_d;
 
   c2h::host_vector<Result> offsets_ref(values_num_items);
   for (auto i = 0u; i < values_num_items; ++i)

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env.cu
@@ -41,7 +41,7 @@ CUB_TEST_CASE("Device LowerBoundSortedValues works with default environment", "[
     cuda::std::less{});
   REQUIRE(error == cudaSuccess);
 
-  c2h::device_vector<int> expected = {0, 2, 2, 4};
+  const c2h::device_vector<int> expected = {0, 2, 2, 4};
   REQUIRE(d_output == expected);
 }
 
@@ -60,7 +60,7 @@ CUB_TEST_CASE("Device UpperBoundSortedValues works with default environment", "[
     cuda::std::less{});
   REQUIRE(error == cudaSuccess);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 
@@ -96,7 +96,7 @@ CUB_TEST("Device LowerBoundSortedValues uses environment", "[find][device][binar
     cuda::std::less{},
     env);
 
-  c2h::device_vector<int> expected = {0, 2, 2, 4};
+  const c2h::device_vector<int> expected = {0, 2, 2, 4};
   REQUIRE(d_output == expected);
 }
 
@@ -130,7 +130,7 @@ CUB_TEST("Device UpperBoundSortedValues uses environment", "[find][device][binar
     cuda::std::less{},
     env);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 

--- a/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
+++ b/cub/test/catch2_test_device_find_bound_sorted_values_env_api.cu
@@ -22,8 +22,8 @@ CUB_TEST("cub::DeviceFind::LowerBoundSortedValues accepts env with stream", "[fi
   thrust::device_vector<int> d_values = {0, 3, 4, 7};
   thrust::device_vector<int> d_output(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFind::LowerBoundSortedValues(
     d_range.begin(),
@@ -38,7 +38,7 @@ CUB_TEST("cub::DeviceFind::LowerBoundSortedValues accepts env with stream", "[fi
     std::cerr << "cub::DeviceFind::LowerBoundSortedValues failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected = {0, 2, 2, 4};
+  const thrust::device_vector<int> expected = {0, 2, 2, 4};
   // example-end lower-bound-sorted-values-env
   stream.sync();
 
@@ -53,8 +53,8 @@ CUB_TEST("cub::DeviceFind::UpperBoundSortedValues accepts env with stream", "[fi
   thrust::device_vector<int> d_values = {0, 3, 4, 7};
   thrust::device_vector<int> d_output(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFind::UpperBoundSortedValues(
     d_range.begin(),
@@ -69,7 +69,7 @@ CUB_TEST("cub::DeviceFind::UpperBoundSortedValues accepts env with stream", "[fi
     std::cerr << "cub::DeviceFind::UpperBoundSortedValues failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  const thrust::device_vector<int> expected = {1, 2, 3, 4};
   // example-end upper-bound-sorted-values-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_find_env.cu
+++ b/cub/test/catch2_test_device_find_env.cu
@@ -61,7 +61,7 @@ CUB_TEST_CASE("Device FindIf works with default environment", "[find][device]", 
   constexpr int num_items = 8;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
   auto d_out              = c2h::device_vector<int>(1);
-  is_greater_than_t predicate{4};
+  const is_greater_than_t predicate{4};
 
   SECTION("Without provided memory")
   {
@@ -97,7 +97,7 @@ CUB_TEST_CASE("Device FindIf no match returns num_items with default environment
   constexpr int num_items = 5;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4};
   auto d_out              = c2h::device_vector<int>(1);
-  is_greater_than_t predicate{100};
+  const is_greater_than_t predicate{100};
 
   SECTION("Without provided memory")
   {
@@ -143,7 +143,7 @@ CUB_TEST_CASE("Device LowerBound works with default environment", "[find][device
     cuda::std::less{});
   REQUIRE(error == cudaSuccess);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 
@@ -162,7 +162,7 @@ CUB_TEST_CASE("Device UpperBound works with default environment", "[find][device
     cuda::std::less{});
   REQUIRE(error == cudaSuccess);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 
@@ -173,7 +173,7 @@ CUB_TEST("Device FindIf uses environment", "[find][device]", CUB_SMALL)
   constexpr int num_items = 8;
   auto d_in               = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7};
   auto d_out              = c2h::device_vector<int>(1);
-  is_greater_than_t predicate{4};
+  const is_greater_than_t predicate{4};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -220,26 +220,26 @@ CUB_TEST("Device FindIf works with user provided memory and environment", "[find
 
   SECTION("find_if works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_find_if(stream.get());
   }
 
   SECTION("find_if works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_find_if(stream);
   }
 
   SECTION("find_if works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_find_if(stream_ref);
   }
 
   SECTION("find_if works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_find_if(env);
   }
 
@@ -251,7 +251,7 @@ CUB_TEST("Device FindIf works with user provided memory and environment", "[find
 
   SECTION("find_if works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_find_if(policy);
   }
@@ -287,16 +287,16 @@ CUB_TEST("Device LowerBound uses environment", "[find][device]", CUB_SMALL)
     cuda::std::less{},
     env);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 
 CUB_TEST("Device LowerBound works with user provided memory and environment", "[find][device]", CUB_SMALL)
 {
-  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
-  auto d_values                    = c2h::device_vector<int>{1, 3, 5, 7};
-  auto d_output                    = c2h::device_vector<int>(4);
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  auto d_range                           = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                          = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output                          = c2h::device_vector<int>(4);
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
   auto error = cub::DeviceFind::LowerBound(
@@ -351,26 +351,26 @@ CUB_TEST("Device LowerBound works with user provided memory and environment", "[
 
   SECTION("lower_bound works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_lower_bound(stream.get());
   }
 
   SECTION("lower_bound works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_lower_bound(stream);
   }
 
   SECTION("lower_bound works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_lower_bound(stream_ref);
   }
 
   SECTION("lower_bound works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_lower_bound(env);
   }
 
@@ -382,7 +382,7 @@ CUB_TEST("Device LowerBound works with user provided memory and environment", "[
 
   SECTION("lower_bound works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_lower_bound(policy);
   }
@@ -418,16 +418,16 @@ CUB_TEST("Device UpperBound uses environment", "[find][device]", CUB_SMALL)
     cuda::std::less{},
     env);
 
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
   REQUIRE(d_output == expected);
 }
 
 CUB_TEST("Device UpperBound works with user provided memory and environment", "[find][device]", CUB_SMALL)
 {
-  auto d_range                     = c2h::device_vector<int>{0, 2, 4, 6, 8};
-  auto d_values                    = c2h::device_vector<int>{1, 3, 5, 7};
-  auto d_output                    = c2h::device_vector<int>(4);
-  c2h::device_vector<int> expected = {1, 2, 3, 4};
+  auto d_range                           = c2h::device_vector<int>{0, 2, 4, 6, 8};
+  auto d_values                          = c2h::device_vector<int>{1, 3, 5, 7};
+  auto d_output                          = c2h::device_vector<int>(4);
+  const c2h::device_vector<int> expected = {1, 2, 3, 4};
 
   size_t expected_bytes_allocated{};
   auto error = cub::DeviceFind::UpperBound(
@@ -482,26 +482,26 @@ CUB_TEST("Device UpperBound works with user provided memory and environment", "[
 
   SECTION("upper_bound works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_upper_bound(stream.get());
   }
 
   SECTION("upper_bound works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_upper_bound(stream);
   }
 
   SECTION("upper_bound works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_upper_bound(stream_ref);
   }
 
   SECTION("upper_bound works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_upper_bound(env);
   }
 
@@ -513,7 +513,7 @@ CUB_TEST("Device UpperBound works with user provided memory and environment", "[
 
   SECTION("upper_bound works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_upper_bound(policy);
   }
@@ -529,7 +529,7 @@ CUB_TEST("Device FindIf can be tuned", "[find][device]", CUB_SMALL, block_sizes)
   auto d_out              = c2h::device_vector<int>(1, thrust::no_init);
   auto d_block_size       = c2h::device_vector<unsigned int>(1, 0);
 
-  block_size_extracting_predicate_t predicate{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_predicate_t predicate{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(find_tuning<static_cast<int>(target_block_size)>{});
 

--- a/cub/test/catch2_test_device_find_env_api.cu
+++ b/cub/test/catch2_test_device_find_env_api.cu
@@ -32,10 +32,10 @@ CUB_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]", CUB_S
   constexpr int num_items         = 8;
   thrust::device_vector<int> d_in = {0, 1, 2, 3, 4, 5, 6, 7};
   thrust::device_vector<int> d_out(1);
-  is_greater_than_t predicate{4};
+  const is_greater_than_t predicate{4};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFind::FindIf(d_in.begin(), d_out.begin(), predicate, num_items, stream_ref);
   if (error != cudaSuccess)
@@ -43,7 +43,7 @@ CUB_TEST("cub::DeviceFind::FindIf accepts env with stream", "[find][env]", CUB_S
     std::cerr << "cub::DeviceFind::FindIf failed with status: " << error << '\n';
   }
 
-  int expected = 5;
+  const int expected = 5;
   // example-end find-if-env
   stream.sync();
 
@@ -58,8 +58,8 @@ CUB_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]", C
   thrust::device_vector<int> d_values = {1, 3, 5, 7};
   thrust::device_vector<int> d_output(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFind::LowerBound(
     d_range.begin(),
@@ -74,7 +74,7 @@ CUB_TEST("cub::DeviceFind::LowerBound accepts env with stream", "[find][env]", C
     std::cerr << "cub::DeviceFind::LowerBound failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  const thrust::device_vector<int> expected = {1, 2, 3, 4};
   // example-end lower-bound-env
   stream.sync();
 
@@ -89,8 +89,8 @@ CUB_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]", C
   thrust::device_vector<int> d_values = {1, 3, 5, 7};
   thrust::device_vector<int> d_output(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFind::UpperBound(
     d_range.begin(),
@@ -105,7 +105,7 @@ CUB_TEST("cub::DeviceFind::UpperBound accepts env with stream", "[find][env]", C
     std::cerr << "cub::DeviceFind::UpperBound failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected = {1, 2, 3, 4};
+  const thrust::device_vector<int> expected = {1, 2, 3, 4};
   // example-end upper-bound-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_for_api.cu
+++ b/cub/test/catch2_test_device_for_api.cu
@@ -76,7 +76,7 @@ CUB_TEST("Device bulk works with temporary storage", "[bulk][device]", CUB_SMALL
 {
   // example-begin bulk-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_t op{thrust::raw_pointer_cast(vec.data())};
+  const square_t op{thrust::raw_pointer_cast(vec.data())};
 
   // 1) Get temp storage size
   std::uint8_t* d_temp_storage{};
@@ -94,7 +94,7 @@ CUB_TEST("Device bulk works with temporary storage", "[bulk][device]", CUB_SMALL
     std::cerr << "Bulk operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end bulk-temp-storage
 
   REQUIRE(vec == expected);
@@ -104,7 +104,7 @@ CUB_TEST("Device bulk works without temporary storage", "[bulk][device]", CUB_SM
 {
   // example-begin bulk-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_t op{thrust::raw_pointer_cast(vec.data())};
+  const square_t op{thrust::raw_pointer_cast(vec.data())};
 
   auto result = cub::DeviceFor::Bulk(vec.size(), op);
   if (result != cudaSuccess)
@@ -112,7 +112,7 @@ CUB_TEST("Device bulk works without temporary storage", "[bulk][device]", CUB_SM
     std::cerr << "Bulk operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end bulk-wo-temp-storage
 
   REQUIRE(vec == expected);
@@ -122,7 +122,7 @@ CUB_TEST("Device for each n works with temporary storage", "[for_each][device]",
 {
   // example-begin for-each-n-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
   // 1) Get temp storage size
   std::uint8_t* d_temp_storage{};
@@ -144,7 +144,7 @@ CUB_TEST("Device for each n works with temporary storage", "[for_each][device]",
     std::cerr << "ForEachN operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end for-each-n-temp-storage
 
   REQUIRE(vec == expected);
@@ -154,7 +154,7 @@ CUB_TEST("Device for each n works without temporary storage", "[for_each][device
 {
   // example-begin for-each-n-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
   auto result = cub::DeviceFor::ForEachN(vec.begin(), vec.size(), op);
   if (result != cudaSuccess)
@@ -162,7 +162,7 @@ CUB_TEST("Device for each n works without temporary storage", "[for_each][device
     std::cerr << "ForEachN operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end for-each-n-wo-temp-storage
 
   REQUIRE(vec == expected);
@@ -210,7 +210,7 @@ CUB_TEST("Device for each works with temporary storage", "[for_each][device]", C
 {
   // example-begin for-each-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
   // 1) Get temp storage size
   std::uint8_t* d_temp_storage{};
@@ -232,7 +232,7 @@ CUB_TEST("Device for each works with temporary storage", "[for_each][device]", C
     std::cerr << "ForEach operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end for-each-temp-storage
 
   REQUIRE(vec == expected);
@@ -242,7 +242,7 @@ CUB_TEST("Device for each works without temporary storage", "[for_each][device]"
 {
   // example-begin for-each-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
   auto result = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op);
   if (result != cudaSuccess)
@@ -250,7 +250,7 @@ CUB_TEST("Device for each works without temporary storage", "[for_each][device]"
     std::cerr << "ForEach operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {1, 4, 9, 16};
+  const c2h::device_vector<int> expected = {1, 4, 9, 16};
   // example-end for-each-wo-temp-storage
 
   REQUIRE(vec == expected);
@@ -261,7 +261,7 @@ CUB_TEST("Device for each n copy works with temporary storage", "[for_each][devi
   // example-begin for-each-copy-n-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
   c2h::device_vector<int> count(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
   // 1) Get temp storage size
   std::uint8_t* d_temp_storage{};
@@ -283,7 +283,7 @@ CUB_TEST("Device for each n copy works with temporary storage", "[for_each][devi
     std::cerr << "ForEachCopyN operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {2};
+  const c2h::device_vector<int> expected = {2};
   // example-end for-each-copy-n-temp-storage
 
   REQUIRE(count == expected);
@@ -294,7 +294,7 @@ CUB_TEST("Device for each n copy works without temporary storage", "[for_each][d
   // example-begin for-each-copy-n-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
   c2h::device_vector<int> count(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
   auto result = cub::DeviceFor::ForEachCopyN(vec.begin(), vec.size(), op);
   if (result != cudaSuccess)
@@ -302,7 +302,7 @@ CUB_TEST("Device for each n copy works without temporary storage", "[for_each][d
     std::cerr << "ForEachCopyN operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {2};
+  const c2h::device_vector<int> expected = {2};
   // example-end for-each-copy-n-wo-temp-storage
 
   REQUIRE(count == expected);
@@ -313,7 +313,7 @@ CUB_TEST("Device for each copy works with temporary storage", "[for_each][device
   // example-begin for-each-copy-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
   c2h::device_vector<int> count(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
   // 1) Get temp storage size
   std::uint8_t* d_temp_storage{};
@@ -335,7 +335,7 @@ CUB_TEST("Device for each copy works with temporary storage", "[for_each][device
     std::cerr << "ForEachCopy operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {2};
+  const c2h::device_vector<int> expected = {2};
   // example-end for-each-copy-temp-storage
 
   REQUIRE(count == expected);
@@ -346,7 +346,7 @@ CUB_TEST("Device for each copy works without temporary storage", "[for_each][dev
   // example-begin for-each-copy-wo-temp-storage
   c2h::device_vector<int> vec = {1, 2, 3, 4};
   c2h::device_vector<int> count(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
   auto result = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op);
   if (result != cudaSuccess)
@@ -354,7 +354,7 @@ CUB_TEST("Device for each copy works without temporary storage", "[for_each][dev
     std::cerr << "ForEachCopy operation failed with error code: " << result << '\n';
   }
 
-  c2h::device_vector<int> expected = {2};
+  const c2h::device_vector<int> expected = {2};
   // example-end for-each-copy-wo-temp-storage
 
   REQUIRE(count == expected);
@@ -380,7 +380,7 @@ CUB_TEST("DeviceFor::Bulk legacy size-query is unambiguous", "[for][device]", CU
 {
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceFor::Bulk(d_temp_storage, temp_storage_bytes, n, noop_t{}));
 }
@@ -390,7 +390,7 @@ CUB_TEST("DeviceFor::ForEachN legacy size-query is unambiguous", "[for][device]"
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   int* d_in                 = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_temp_storage, temp_storage_bytes, d_in, n, noop_ref_t{}));
 }
@@ -410,7 +410,7 @@ CUB_TEST("DeviceFor::ForEachCopyN legacy size-query is unambiguous", "[for][devi
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   int* d_in                 = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopyN(d_temp_storage, temp_storage_bytes, d_in, n, noop_t{}));
 }

--- a/cub/test/catch2_test_device_for_each_in_extents.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents.cu
@@ -135,7 +135,7 @@ CUB_TEST("DeviceFor::ForEachInExtents static", "[ForEachInExtents][static][devic
   CAPTURE(c2h::type_name<index_type>());
 
   device_for_each_in_extents(ext, store_op_t{d_output_raw});
-  c2h::host_vector<data_t> h_output_gpu = d_output;
+  const c2h::host_vector<data_t> h_output_gpu = d_output;
   fill_linear(h_output, ext);
 // MSVC error: C3546: '...': there are no parameter packs available to expand in
 //             make_tuple_types.h:__make_tuple_types_flat
@@ -153,14 +153,14 @@ CUB_TEST("DeviceFor::ForEachInExtents 3D dynamic", "[ForEachInExtents][dynamic][
   auto X                              = GENERATE_COPY(take(3, random(2, 10)));
   auto Y                              = GENERATE_COPY(take(3, random(2, 10)));
   auto Z                              = GENERATE_COPY(take(3, random(2, 10)));
-  cuda::std::dextents<index_type, 3> ext{X, Y, Z};
+  const cuda::std::dextents<index_type, 3> ext{X, Y, Z};
   c2h::device_vector<data_t> d_output(cub::detail::size(ext), data_t{});
   c2h::host_vector<data_t> h_output(cub::detail::size(ext), data_t{});
   auto d_output_raw = cuda::std::span<data_t>{thrust::raw_pointer_cast(d_output.data()), cub::detail::size(ext)};
   CAPTURE(c2h::type_name<index_type>(), X, Y, Z);
 
   device_for_each_in_extents(ext, store_op_t{d_output_raw});
-  c2h::host_vector<data_t> h_output_gpu = d_output;
+  const c2h::host_vector<data_t> h_output_gpu = d_output;
   fill_linear(h_output, ext);
 #if !_CCCL_COMPILER(MSVC)
   REQUIRE(h_output == h_output_gpu);

--- a/cub/test/catch2_test_device_for_each_in_extents_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents_api.cu
@@ -45,14 +45,14 @@ CUB_TEST("Device ForEachInExtents", "[ForEachInExtents][device]", CUB_SMALL)
 {
   // example-begin for-each-in-extents-example
   using                            data_t = cuda::std::array<int, 3>;
-  cuda::std::extents<int, 3, 2, 2> extents{};
+  const cuda::std::extents<int, 3, 2, 2> extents{};
   thrust::device_vector<data_t>    d_output1(cub::detail::size(extents), thrust::no_init);
   thrust::device_vector<data_t>    d_output2(cub::detail::size(extents), thrust::no_init);
   auto                             d_output1_raw = cuda::std::span<data_t>{thrust::raw_pointer_cast(d_output1.data()),
                                                                           3 * 2 * 2};
   auto                             d_output2_raw = cuda::std::span<data_t>{thrust::raw_pointer_cast(d_output2.data()),
                                                                           3 * 2 * 2};
-  thrust::host_vector<data_t>      expected = {{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1},
+  const thrust::host_vector<data_t>      expected = {{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1},
                                                {1, 0, 0}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1},
                                                {2, 0, 0}, {2, 0, 1}, {2, 1, 0}, {2, 1, 1}};
 

--- a/cub/test/catch2_test_device_for_each_in_layout.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout.cu
@@ -54,7 +54,7 @@ template <bool IsLayoutRight, typename T, typename IndexType, size_t... Extents>
 static void fill_linear([[maybe_unused]] c2h::host_vector<T>& vector,
                         [[maybe_unused]] const cuda::std::extents<IndexType, Extents...>& ext)
 {
-  [[maybe_unused]] size_t pos = 0;
+  [[maybe_unused]] size_t pos = 0; // NOLINT(misc-const-correctness)
   if constexpr (sizeof...(Extents) == 0)
   {
     return;
@@ -154,8 +154,8 @@ CUB_TEST(
   CAPTURE(c2h::type_name<index_type>(), c2h::type_name<dims>(), c2h::type_name<layout_t>());
 
   device_for_each_in_layout(mapping_t{ext}, store_op_t{d_output_raw});
-  c2h::host_vector<data_t> h_output_gpu = d_output;
-  constexpr bool is_layout_right        = cuda::std::is_same_v<layout_t, cuda::std::layout_right>;
+  const c2h::host_vector<data_t> h_output_gpu = d_output;
+  constexpr bool is_layout_right              = cuda::std::is_same_v<layout_t, cuda::std::layout_right>;
   fill_linear<is_layout_right>(h_output_expected, ext);
 // MSVC error: C3546: '...': there are no parameter packs available to expand in
 //             make_tuple_types.h:__make_tuple_types_flat
@@ -180,15 +180,15 @@ CUB_TEST("DeviceFor::ForEachInLayout 3D dynamic",
   auto X                              = GENERATE_COPY(take(3, random(2, 10)));
   auto Y                              = GENERATE_COPY(take(3, random(2, 10)));
   auto Z                              = GENERATE_COPY(take(3, random(2, 10)));
-  ext_t ext{X, Y, Z};
+  const ext_t ext{X, Y, Z};
   c2h::device_vector<data_t> d_output(cub::detail::size(ext), data_t{1});
   c2h::host_vector<data_t> h_output_expected(cub::detail::size(ext), data_t{2});
   auto d_output_raw = cuda::std::span<data_t>{thrust::raw_pointer_cast(d_output.data()), cub::detail::size(ext)};
   CAPTURE(c2h::type_name<index_type>(), X, Y, Z);
 
   device_for_each_in_layout(mapping_t{ext}, store_op_t{d_output_raw});
-  c2h::host_vector<data_t> h_output_gpu = d_output;
-  constexpr bool is_layout_right        = cuda::std::is_same_v<layout_t, cuda::std::layout_right>;
+  const c2h::host_vector<data_t> h_output_gpu = d_output;
+  constexpr bool is_layout_right              = cuda::std::is_same_v<layout_t, cuda::std::layout_right>;
   fill_linear<is_layout_right>(h_output_expected, ext);
 
 #if !_CCCL_COMPILER(MSVC)

--- a/cub/test/catch2_test_device_for_each_in_layout.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout.cu
@@ -54,18 +54,21 @@ template <bool IsLayoutRight, typename T, typename IndexType, size_t... Extents>
 static void fill_linear([[maybe_unused]] c2h::host_vector<T>& vector,
                         [[maybe_unused]] const cuda::std::extents<IndexType, Extents...>& ext)
 {
-  [[maybe_unused]] size_t pos = 0; // NOLINT(misc-const-correctness)
   if constexpr (sizeof...(Extents) == 0)
   {
     return;
   }
-  else if constexpr (IsLayoutRight)
-  {
-    fill_linear_impl<IsLayoutRight, 0>(vector, ext, pos);
-  }
   else
   {
-    fill_linear_impl<IsLayoutRight, (sizeof...(Extents) - 1)>(vector, ext, pos);
+    size_t pos = 0;
+    if constexpr (IsLayoutRight)
+    {
+      fill_linear_impl<IsLayoutRight, 0>(vector, ext, pos);
+    }
+    else
+    {
+      fill_linear_impl<IsLayoutRight, (sizeof...(Extents) - 1)>(vector, ext, pos);
+    }
   }
 }
 

--- a/cub/test/catch2_test_device_for_each_in_layout_api.cu
+++ b/cub/test/catch2_test_device_for_each_in_layout_api.cu
@@ -45,7 +45,7 @@ CUB_TEST("Device ForEachInLayout", "[ForEachInLayout][device]", CUB_SMALL)
   using data_t             = cuda::std::array<int, 3>;
   using extents_type       = cuda::std::extents<int, 3, 2, 2>;
   using mapping_left_type  = cuda::std::layout_left::mapping<extents_type>;
-  extents_type                  extents{};
+  const extents_type                  extents{};
   thrust::device_vector<data_t> d_output(cub::detail::size(extents), thrust::no_init);
   thrust::host_vector<data_t>   h_output(cub::detail::size(extents), thrust::no_init);
   auto                          d_output_raw = cuda::std::span<data_t>{thrust::raw_pointer_cast(d_output.data()),

--- a/cub/test/catch2_test_device_for_env.cu
+++ b/cub/test/catch2_test_device_for_env.cu
@@ -54,16 +54,16 @@ struct odd_count_op
 CUB_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_idx_op op{thrust::raw_pointer_cast(vec.data())};
+  const square_idx_op op{thrust::raw_pointer_cast(vec.data())};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
   auto error = cub::DeviceFor::Bulk(4, op, env);
   REQUIRE(error == cudaSuccess);
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
-  c2h::device_vector<int> expected{1, 4, 9, 16};
+  const c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
 }
 
@@ -74,16 +74,16 @@ CUB_TEST("DeviceFor::Bulk env uses custom stream", "[for][env]", CUB_SMALL)
 CUB_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_ref_op op{};
+  const square_ref_op op{};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
   auto error = cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, env);
   REQUIRE(error == cudaSuccess);
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
-  c2h::device_vector<int> expected{1, 4, 9, 16};
+  const c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
 }
 
@@ -94,16 +94,16 @@ CUB_TEST("DeviceFor::ForEachN env uses custom stream", "[for][env]", CUB_SMALL)
 CUB_TEST("DeviceFor::ForEach env uses custom stream", "[for][env]", CUB_SMALL)
 {
   auto vec = c2h::device_vector<int>{1, 2, 3, 4};
-  square_ref_op op{};
+  const square_ref_op op{};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
   auto error = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, env);
   REQUIRE(error == cudaSuccess);
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
-  c2h::device_vector<int> expected{1, 4, 9, 16};
+  const c2h::device_vector<int> expected{1, 4, 9, 16};
   REQUIRE(vec == expected);
 }
 
@@ -115,16 +115,16 @@ CUB_TEST("DeviceFor::ForEachCopyN env uses custom stream", "[for][env]", CUB_SMA
 {
   auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
   auto count = c2h::device_vector<int>(1);
-  odd_count_op op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_op op{thrust::raw_pointer_cast(count.data())};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
   auto error = cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, env);
   REQUIRE(error == cudaSuccess);
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
-  c2h::device_vector<int> expected_count{2};
+  const c2h::device_vector<int> expected_count{2};
   REQUIRE(count == expected_count);
 }
 
@@ -136,16 +136,16 @@ CUB_TEST("DeviceFor::ForEachCopy env uses custom stream", "[for][env]", CUB_SMAL
 {
   auto vec   = c2h::device_vector<int>{1, 2, 3, 4};
   auto count = c2h::device_vector<int>(1);
-  odd_count_op op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_op op{thrust::raw_pointer_cast(count.data())};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}};
 
   auto error = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, env);
   REQUIRE(error == cudaSuccess);
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
-  c2h::device_vector<int> expected_count{2};
+  const c2h::device_vector<int> expected_count{2};
   REQUIRE(count == expected_count);
 }
 
@@ -178,7 +178,7 @@ CUB_TEST("DeviceFor::Bulk can be tuned", "[for][device]", CUB_SMALL, block_sizes
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::Bulk(4, op, env));
@@ -190,7 +190,7 @@ CUB_TEST("DeviceFor::ForEachN can be tuned", "[for][device]", CUB_SMALL, block_s
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
@@ -202,7 +202,7 @@ CUB_TEST("DeviceFor::ForEach can be tuned", "[for][device]", CUB_SMALL, block_si
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEach(d_data.begin(), d_data.end(), op, env));
@@ -214,7 +214,7 @@ CUB_TEST("DeviceFor::ForEachCopyN can be tuned", "[for][device]", CUB_SMALL, blo
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopyN(d_data.begin(), static_cast<int>(d_data.size()), op, env));
@@ -226,7 +226,7 @@ CUB_TEST("DeviceFor::ForEachCopy can be tuned", "[for][device]", CUB_SMALL, bloc
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<int> d_data{1, 2, 3, 4};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(for_each_tuning<target_block_size>{});
 
   REQUIRE(cudaSuccess == cub::DeviceFor::ForEachCopy(d_data.begin(), d_data.end(), op, env));

--- a/cub/test/catch2_test_device_for_env_api.cu
+++ b/cub/test/catch2_test_device_for_env_api.cu
@@ -57,10 +57,10 @@ CUB_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin bulk-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
-  square_t op{thrust::raw_pointer_cast(vec.data())};
+  const square_t op{thrust::raw_pointer_cast(vec.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFor::Bulk(static_cast<int>(vec.size()), op, stream_ref);
   if (error != cudaSuccess)
@@ -68,7 +68,7 @@ CUB_TEST("cub::DeviceFor::Bulk env-based API", "[for][env]", CUB_SMALL)
     std::cerr << "cub::DeviceFor::Bulk failed: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 4, 9, 16};
+  const thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end bulk-env
 
   stream.sync();
@@ -80,10 +80,10 @@ CUB_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-n-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFor::ForEachN(vec.begin(), static_cast<int>(vec.size()), op, stream_ref);
   if (error != cudaSuccess)
@@ -91,7 +91,7 @@ CUB_TEST("cub::DeviceFor::ForEachN env-based API", "[for][env]", CUB_SMALL)
     std::cerr << "cub::DeviceFor::ForEachN failed: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 4, 9, 16};
+  const thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end for-each-n-env
 
   stream.sync();
@@ -103,10 +103,10 @@ CUB_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]", CUB_SMALL)
 {
   // example-begin for-each-env
   auto vec = thrust::device_vector<int>{1, 2, 3, 4};
-  square_ref_t op{};
+  const square_ref_t op{};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFor::ForEach(vec.begin(), vec.end(), op, stream_ref);
   if (error != cudaSuccess)
@@ -114,7 +114,7 @@ CUB_TEST("cub::DeviceFor::ForEach env-based API", "[for][env]", CUB_SMALL)
     std::cerr << "cub::DeviceFor::ForEach failed: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 4, 9, 16};
+  const thrust::device_vector<int> expected{1, 4, 9, 16};
   // example-end for-each-env
 
   stream.sync();
@@ -127,10 +127,10 @@ CUB_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]", CUB_SMALL)
   // example-begin for-each-copy-n-env
   auto vec   = thrust::device_vector<int>{1, 2, 3, 4};
   auto count = thrust::device_vector<int>(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFor::ForEachCopyN(vec.begin(), static_cast<int>(vec.size()), op, stream_ref);
   if (error != cudaSuccess)
@@ -138,7 +138,7 @@ CUB_TEST("cub::DeviceFor::ForEachCopyN env-based API", "[for][env]", CUB_SMALL)
     std::cerr << "cub::DeviceFor::ForEachCopyN failed: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_count{2};
+  const thrust::device_vector<int> expected_count{2};
   // example-end for-each-copy-n-env
 
   stream.sync();
@@ -151,10 +151,10 @@ CUB_TEST("cub::DeviceFor::ForEachCopy env-based API", "[for][env]", CUB_SMALL)
   // example-begin for-each-copy-env
   auto vec   = thrust::device_vector<int>{1, 2, 3, 4};
   auto count = thrust::device_vector<int>(1);
-  odd_count_t op{thrust::raw_pointer_cast(count.data())};
+  const odd_count_t op{thrust::raw_pointer_cast(count.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceFor::ForEachCopy(vec.begin(), vec.end(), op, stream_ref);
   if (error != cudaSuccess)
@@ -162,7 +162,7 @@ CUB_TEST("cub::DeviceFor::ForEachCopy env-based API", "[for][env]", CUB_SMALL)
     std::cerr << "cub::DeviceFor::ForEachCopy failed: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_count{2};
+  const thrust::device_vector<int> expected_count{2};
   // example-end for-each-copy-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -83,7 +83,7 @@ __attribute__((optimize("no-tree-vectorize")))
 #  endif
 auto cast_if_half(array<half_t, N> a)
 {
-  __half* p = cast_if_half_pointer(a.data()); // cast to avoid ambiguous conversion from half_t -> __half
+  const __half* p = cast_if_half_pointer(a.data()); // cast to avoid ambiguous conversion from half_t -> __half
   array<__half, N> r;
   for (size_t i = 0; i < N; i++)
   {
@@ -693,9 +693,9 @@ try
 
   auto sample_iterator = cuda::counting_iterator<sample_t>{0};
   array<counter_t*, 1> d_histogram_array{};
-  array<int, 1> num_levels_array  = {num_levels};
-  array<int, 1> lower_level_array = {0};
-  array<int, 1> upper_level_array = {num_bins};
+  const array<int, 1> num_levels_array  = {num_levels};
+  const array<int, 1> lower_level_array = {0};
+  const array<int, 1> upper_level_array = {num_bins};
 
   c2h::device_vector<counter_t> d_histogram(num_bins);
   d_histogram_array[0] = thrust::raw_pointer_cast(d_histogram.data());

--- a/cub/test/catch2_test_device_histogram_api.cu
+++ b/cub/test/catch2_test_device_histogram_api.cu
@@ -40,10 +40,10 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven non-env overload is not ambig
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
-  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
-  ::cuda::std::array<int, 1> num_levels{2};
-  ::cuda::std::array<int, 1> lower_level{0};
-  ::cuda::std::array<int, 1> upper_level{10};
+  const ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  const ::cuda::std::array<int, 1> num_levels{2};
+  const ::cuda::std::array<int, 1> lower_level{0};
+  const ::cuda::std::array<int, 1> upper_level{10};
   size_t temp_storage_bytes = 0;
   cub::DeviceHistogram::MultiHistogramEven<1, 1>(
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1);
@@ -55,10 +55,10 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven 2D non-env overload is not am
 {
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
-  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
-  ::cuda::std::array<int, 1> num_levels{2};
-  ::cuda::std::array<int, 1> lower_level{0};
-  ::cuda::std::array<int, 1> upper_level{10};
+  const ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  const ::cuda::std::array<int, 1> num_levels{2};
+  const ::cuda::std::array<int, 1> lower_level{0};
+  const ::cuda::std::array<int, 1> upper_level{10};
   size_t temp_storage_bytes = 0;
   cub::DeviceHistogram::MultiHistogramEven<1, 1>(
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, lower_level, upper_level, 1, 1, sizeof(int));
@@ -103,9 +103,9 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange non-env overload is not ambi
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
   thrust::device_vector<int> levels{0, 5, 10};
-  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
-  ::cuda::std::array<int, 1> num_levels{3};
-  ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
+  const ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  const ::cuda::std::array<int, 1> num_levels{3};
+  const ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
   size_t temp_storage_bytes = 0;
   cub::DeviceHistogram::MultiHistogramRange<1, 1>(
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1);
@@ -118,9 +118,9 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange 2D non-env overload is not a
   thrust::device_vector<int> samples(1);
   thrust::device_vector<int> histogram(1);
   thrust::device_vector<int> levels{0, 5, 10};
-  ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
-  ::cuda::std::array<int, 1> num_levels{3};
-  ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
+  const ::cuda::std::array<int*, 1> d_histogram{thrust::raw_pointer_cast(histogram.data())};
+  const ::cuda::std::array<int, 1> num_levels{3};
+  const ::cuda::std::array<const int*, 1> d_levels{thrust::raw_pointer_cast(levels.data())};
   size_t temp_storage_bytes = 0;
   cub::DeviceHistogram::MultiHistogramRange<1, 1>(
     nullptr, temp_storage_bytes, samples.begin(), d_histogram, num_levels, d_levels, 1, 1, sizeof(int));

--- a/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
@@ -51,10 +51,10 @@ CUB_TEST("DispatchHistogram::DispatchEven: custom policy hub", "[histogram][devi
   c2h::device_vector<sample_t> d_samples = h_samples;
   c2h::device_vector<counter_t> d_histogram(num_bins, 0);
 
-  cuda::std::array<counter_t*, num_active_channels> d_histograms{thrust::raw_pointer_cast(d_histogram.data())};
-  cuda::std::array<int, num_active_channels> num_levels{num_output_levels};
-  cuda::std::array<level_t, num_active_channels> lower_level{0};
-  cuda::std::array<level_t, num_active_channels> upper_level{num_bins};
+  const cuda::std::array<counter_t*, num_active_channels> d_histograms{thrust::raw_pointer_cast(d_histogram.data())};
+  const cuda::std::array<int, num_active_channels> num_levels{num_output_levels};
+  const cuda::std::array<level_t, num_active_channels> lower_level{0};
+  const cuda::std::array<level_t, num_active_channels> upper_level{num_bins};
 
   using policy_hub_t = my_policy_hub<sample_t, counter_t, num_channels, num_active_channels, /* is_even */ true>;
   using dispatch_t =
@@ -95,6 +95,6 @@ CUB_TEST("DispatchHistogram::DispatchEven: custom policy hub", "[histogram][devi
     ++expected_histogram[sample];
   }
 
-  c2h::host_vector<counter_t> h_histogram = d_histogram;
+  const c2h::host_vector<counter_t> h_histogram = d_histogram;
   REQUIRE(h_histogram == expected_histogram);
 }

--- a/cub/test/catch2_test_device_histogram_env.cu
+++ b/cub/test/catch2_test_device_histogram_env.cu
@@ -45,12 +45,12 @@ namespace stdexec = cuda::std::execution;
 
 CUB_TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
-  int num_samples  = static_cast<int>(d_samples.size());
-  int num_levels   = 6;
-  int lower_level  = 0;
-  int upper_level  = 5;
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
+  const int num_samples = static_cast<int>(d_samples.size());
+  const int num_levels  = 6;
+  const int lower_level = 0;
+  const int upper_level = 5;
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   REQUIRE(
     cudaSuccess
@@ -62,7 +62,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven works with default environment", "
       upper_level,
       num_samples));
 
-  c2h::device_vector<int> expected{2, 2, 2, 1, 1};
+  const c2h::device_vector<int> expected{2, 2, 2, 1, 1};
   REQUIRE(d_histogram == expected);
 }
 
@@ -137,26 +137,26 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory an
 
   SECTION("DeviceHistogram::HistogramEven works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_histogram_even(stream.get());
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_histogram_even(stream);
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_histogram_even(stream_ref);
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_histogram_even(env);
   }
 
@@ -168,7 +168,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory an
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_histogram_even(policy);
   }
@@ -176,11 +176,11 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven works with user provided memory an
 
 CUB_TEST_CASE("DeviceHistogram::HistogramRange works with default environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
-  int num_samples  = static_cast<int>(d_samples.size());
-  auto d_levels    = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  int num_levels   = static_cast<int>(d_levels.size());
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
+  const int num_samples = static_cast<int>(d_samples.size());
+  auto d_levels         = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  const int num_levels  = static_cast<int>(d_levels.size());
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   REQUIRE(cudaSuccess
           == cub::DeviceHistogram::HistogramRange(
@@ -190,7 +190,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange works with default environment", 
             thrust::raw_pointer_cast(d_levels.data()),
             num_samples));
 
-  c2h::device_vector<int> expected{1, 5, 0, 2};
+  const c2h::device_vector<int> expected{1, 5, 0, 2};
   REQUIRE(d_histogram == expected);
 }
 
@@ -261,26 +261,26 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange works with user provided memory a
 
   SECTION("DeviceHistogram::HistogramRange works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_histogram_range(stream.get());
   }
 
   SECTION("DeviceHistogram::HistogramRange works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_histogram_range(stream);
   }
 
   SECTION("DeviceHistogram::HistogramRange works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_histogram_range(stream_ref);
   }
 
   SECTION("DeviceHistogram::HistogramRange works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_histogram_range(env);
   }
 
@@ -292,7 +292,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange works with user provided memory a
 
   SECTION("DeviceHistogram::HistogramRange works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_histogram_range(policy);
   }
@@ -304,18 +304,18 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environmen
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
   // 2 pixels: (R=0, G=2, B=1, A=255), (R=3, G=4, B=2, A=128)
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -324,9 +324,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with default environmen
           == cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
             thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels));
 
-  c2h::device_vector<int> expected_r{1, 0, 0, 1};
-  c2h::device_vector<int> expected_g{0, 0, 1, 0};
-  c2h::device_vector<int> expected_b{0, 1, 1, 0};
+  const c2h::device_vector<int> expected_r{1, 0, 0, 1};
+  const c2h::device_vector<int> expected_g{0, 0, 1, 0};
+  const c2h::device_vector<int> expected_b{0, 1, 1, 0};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -338,16 +338,16 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environme
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
   // 2 pixels: (R=0, G=2, B=1, A=255), (R=3, G=4, B=2, A=128)
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -356,7 +356,7 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environme
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -365,9 +365,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environme
           == cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
             thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels));
 
-  c2h::device_vector<int> expected_r{1, 1};
-  c2h::device_vector<int> expected_g{1, 1};
-  c2h::device_vector<int> expected_b{0, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1};
+  const c2h::device_vector<int> expected_g{1, 1};
+  const c2h::device_vector<int> expected_b{0, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -376,14 +376,14 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange works with default environme
 CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
   // 2 rows, 3 samples per row, stride of 4 (1 padding element)
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  int num_levels          = 4;
-  int lower_level         = 0;
-  int upper_level         = 3;
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  const int num_levels          = 4;
+  const int lower_level         = 0;
+  const int upper_level         = 3;
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   REQUIRE(
     cudaSuccess
@@ -397,19 +397,19 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D works with default environment"
       num_rows,
       row_stride_bytes));
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 }
 
 CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
-  int num_levels          = static_cast<int>(d_levels.size());
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  auto d_levels                 = c2h::device_vector<int>{0, 1, 2, 3};
+  const int num_levels          = static_cast<int>(d_levels.size());
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   REQUIRE(
     cudaSuccess
@@ -422,7 +422,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D works with default environment
       num_rows,
       row_stride_bytes));
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 }
 
@@ -437,19 +437,19 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environ
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -467,11 +467,11 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D works with default environ
       row_stride_bytes));
 
   // R: 0,3,1,2 → bin[0]=1, bin[1]=1, bin[2]=1, bin[3]=1
-  c2h::device_vector<int> expected_r{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1, 1, 1};
   // G: 2,4,1,3 → bin[1]=1, bin[2]=1, bin[3]=1 (4 out of range)
-  c2h::device_vector<int> expected_g{0, 1, 1, 1};
+  const c2h::device_vector<int> expected_g{0, 1, 1, 1};
   // B: 1,2,3,0 → bin[0]=1, bin[1]=1, bin[2]=1, bin[3]=1
-  c2h::device_vector<int> expected_b{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_b{1, 1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -486,17 +486,17 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default enviro
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -505,7 +505,7 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default enviro
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -522,11 +522,11 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default enviro
       row_stride_bytes));
 
   // R: 0,3,1,2 → [0,2)=2, [2,4)=2
-  c2h::device_vector<int> expected_r{2, 2};
+  const c2h::device_vector<int> expected_r{2, 2};
   // G: 2,4,1,3 → [0,3)=2, [3,5)=2
-  c2h::device_vector<int> expected_g{2, 2};
+  const c2h::device_vector<int> expected_g{2, 2};
   // B: 1,2,3,0 → [0,1)=1, [1,2)=1, [2,3)=1 (3 out of range)
-  c2h::device_vector<int> expected_b{1, 1, 1};
+  const c2h::device_vector<int> expected_b{1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -536,12 +536,12 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D works with default enviro
 
 CUB_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
-  int num_samples  = static_cast<int>(d_samples.size());
-  int num_levels   = 6;
-  int lower_level  = 0;
-  int upper_level  = 5;
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
+  const int num_samples = static_cast<int>(d_samples.size());
+  const int num_levels  = 6;
+  const int lower_level = 0;
+  const int upper_level = 5;
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -567,18 +567,18 @@ CUB_TEST("DeviceHistogram::HistogramEven uses environment", "[histogram][device]
     num_samples,
     env);
 
-  c2h::device_vector<int> expected{2, 2, 2, 1, 1};
+  const c2h::device_vector<int> expected{2, 2, 2, 1, 1};
   REQUIRE(d_histogram == expected);
 }
 
 CUB_TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
-  int num_samples  = static_cast<int>(d_samples.size());
-  int num_levels   = 6;
-  int lower_level  = 0;
-  int upper_level  = 5;
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
+  const int num_samples = static_cast<int>(d_samples.size());
+  const int num_levels  = 6;
+  const int lower_level = 0;
+  const int upper_level = 5;
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -610,7 +610,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected{2, 2, 2, 1, 1};
+  const c2h::device_vector<int> expected{2, 2, 2, 1, 1};
   REQUIRE(d_histogram == expected);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -618,11 +618,11 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven uses custom stream", "[histogram][
 
 CUB_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
-  int num_samples  = static_cast<int>(d_samples.size());
-  auto d_levels    = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  int num_levels   = static_cast<int>(d_levels.size());
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
+  const int num_samples = static_cast<int>(d_samples.size());
+  auto d_levels         = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  const int num_levels  = static_cast<int>(d_levels.size());
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -646,17 +646,17 @@ CUB_TEST("DeviceHistogram::HistogramRange uses environment", "[histogram][device
     num_samples,
     env);
 
-  c2h::device_vector<int> expected{1, 5, 0, 2};
+  const c2h::device_vector<int> expected{1, 5, 0, 2};
   REQUIRE(d_histogram == expected);
 }
 
 CUB_TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples   = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
-  int num_samples  = static_cast<int>(d_samples.size());
-  auto d_levels    = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  int num_levels   = static_cast<int>(d_levels.size());
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = c2h::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
+  const int num_samples = static_cast<int>(d_samples.size());
+  auto d_levels         = c2h::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  const int num_levels  = static_cast<int>(d_levels.size());
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -686,7 +686,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange uses custom stream", "[histogram]
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected{1, 5, 0, 2};
+  const c2h::device_vector<int> expected{1, 5, 0, 2};
   REQUIRE(d_histogram == expected);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -697,18 +697,18 @@ CUB_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][de
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -731,9 +731,9 @@ CUB_TEST("DeviceHistogram::MultiHistogramEven uses environment", "[histogram][de
   multi_histogram_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, lower_level, upper_level, num_pixels, env);
 
-  c2h::device_vector<int> expected_r{1, 0, 0, 1};
-  c2h::device_vector<int> expected_g{0, 0, 1, 0};
-  c2h::device_vector<int> expected_b{0, 1, 1, 0};
+  const c2h::device_vector<int> expected_r{1, 0, 0, 1};
+  const c2h::device_vector<int> expected_g{0, 0, 1, 0};
+  const c2h::device_vector<int> expected_b{0, 1, 1, 0};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -744,18 +744,18 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histog
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -784,9 +784,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven uses custom stream", "[histog
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_r{1, 0, 0, 1};
-  c2h::device_vector<int> expected_g{0, 0, 1, 0};
-  c2h::device_vector<int> expected_b{0, 1, 1, 0};
+  const c2h::device_vector<int> expected_r{1, 0, 0, 1};
+  const c2h::device_vector<int> expected_g{0, 0, 1, 0};
+  const c2h::device_vector<int> expected_b{0, 1, 1, 0};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -825,9 +825,9 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory a
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  c2h::device_vector<int> expected_r{1, 1};
-  c2h::device_vector<int> expected_g{1, 1};
-  c2h::device_vector<int> expected_b{0, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1};
+  const c2h::device_vector<int> expected_g{1, 1};
+  const c2h::device_vector<int> expected_b{0, 1, 1};
 
   size_t expected_bytes_allocated{};
   auto error = cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
@@ -879,26 +879,26 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory a
 
   SECTION("DeviceHistogram::MultiHistogramRange works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_multi_histogram_range(stream.get());
   }
 
   SECTION("DeviceHistogram::MultiHistogramRange works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_multi_histogram_range(stream);
   }
 
   SECTION("DeviceHistogram::MultiHistogramRange works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_multi_histogram_range(stream_ref);
   }
 
   SECTION("DeviceHistogram::MultiHistogramRange works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_multi_histogram_range(env);
   }
 
@@ -910,7 +910,7 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange works with user provided memory a
 
   SECTION("DeviceHistogram::MultiHistogramRange works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_multi_histogram_range(policy);
   }
@@ -922,16 +922,16 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][d
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -940,7 +940,7 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][d
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -962,9 +962,9 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange uses environment", "[histogram][d
   multi_histogram_range<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels, env);
 
-  c2h::device_vector<int> expected_r{1, 1};
-  c2h::device_vector<int> expected_g{1, 1};
-  c2h::device_vector<int> expected_b{0, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1};
+  const c2h::device_vector<int> expected_g{1, 1};
+  const c2h::device_vector<int> expected_b{0, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -975,16 +975,16 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histo
   [[maybe_unused]] constexpr int NUM_CHANNELS        = 4;
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
-  auto d_samples = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -993,7 +993,7 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histo
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1021,9 +1021,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histo
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_r{1, 1};
-  c2h::device_vector<int> expected_g{1, 1};
-  c2h::device_vector<int> expected_b{0, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1};
+  const c2h::device_vector<int> expected_g{1, 1};
+  const c2h::device_vector<int> expected_b{0, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -1033,14 +1033,14 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange uses custom stream", "[histo
 
 CUB_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  int num_levels          = 4;
-  int lower_level         = 0;
-  int upper_level         = 3;
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  const int num_levels          = 4;
+  const int lower_level         = 0;
+  const int upper_level         = 3;
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -1070,20 +1070,20 @@ CUB_TEST("DeviceHistogram::HistogramEven 2D uses environment", "[histogram][devi
     row_stride_bytes,
     env);
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 }
 
 CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  int num_levels          = 4;
-  int lower_level         = 0;
-  int upper_level         = 3;
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  const int num_levels          = 4;
+  const int lower_level         = 0;
+  const int upper_level         = 3;
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -1119,7 +1119,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogra
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -1127,13 +1127,13 @@ CUB_TEST_CASE("DeviceHistogram::HistogramEven 2D uses custom stream", "[histogra
 
 CUB_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
-  int num_levels          = static_cast<int>(d_levels.size());
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  auto d_levels                 = c2h::device_vector<int>{0, 1, 2, 3};
+  const int num_levels          = static_cast<int>(d_levels.size());
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -1161,19 +1161,19 @@ CUB_TEST("DeviceHistogram::HistogramRange 2D uses environment", "[histogram][dev
     row_stride_bytes,
     env);
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 }
 
 CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogram][device]", CUB_SMALL)
 {
-  auto d_samples          = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  auto d_levels           = c2h::device_vector<int>{0, 1, 2, 3};
-  int num_levels          = static_cast<int>(d_levels.size());
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
-  auto d_histogram        = c2h::device_vector<int>(num_levels - 1, 0);
+  auto d_samples                = c2h::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  auto d_levels                 = c2h::device_vector<int>{0, 1, 2, 3};
+  const int num_levels          = static_cast<int>(d_levels.size());
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_histogram              = c2h::device_vector<int>(num_levels - 1, 0);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -1207,7 +1207,7 @@ CUB_TEST_CASE("DeviceHistogram::HistogramRange 2D uses custom stream", "[histogr
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected{2, 2, 2};
+  const c2h::device_vector<int> expected{2, 2, 2};
   REQUIRE(d_histogram == expected);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -1221,19 +1221,19 @@ CUB_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram]
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1266,9 +1266,9 @@ CUB_TEST("DeviceHistogram::MultiHistogramEven 2D uses environment", "[histogram]
     row_stride_bytes,
     env);
 
-  c2h::device_vector<int> expected_r{1, 1, 1, 1};
-  c2h::device_vector<int> expected_g{0, 1, 1, 1};
-  c2h::device_vector<int> expected_b{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_g{0, 1, 1, 1};
+  const c2h::device_vector<int> expected_b{1, 1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -1282,19 +1282,19 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[his
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1333,9 +1333,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven 2D uses custom stream", "[his
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_r{1, 1, 1, 1};
-  c2h::device_vector<int> expected_g{0, 1, 1, 1};
-  c2h::device_vector<int> expected_b{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_r{1, 1, 1, 1};
+  const c2h::device_vector<int> expected_g{0, 1, 1, 1};
+  const c2h::device_vector<int> expected_b{1, 1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -1441,26 +1441,26 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memo
 
   SECTION("DeviceHistogram::HistogramEven works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_multi_histogram_even(stream.get());
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_multi_histogram_even(stream);
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_multi_histogram_even(stream_ref);
   }
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_multi_histogram_even(env);
   }
 
@@ -1472,7 +1472,7 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramEven works with user provided memo
 
   SECTION("DeviceHistogram::HistogramEven works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_multi_histogram_even(policy);
   }
@@ -1487,17 +1487,17 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -1506,7 +1506,7 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1537,9 +1537,9 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange 2D uses environment", "[histogram
     row_stride_bytes,
     env);
 
-  c2h::device_vector<int> expected_r{2, 2};
-  c2h::device_vector<int> expected_g{2, 2};
-  c2h::device_vector<int> expected_b{1, 1, 1};
+  const c2h::device_vector<int> expected_r{2, 2};
+  const c2h::device_vector<int> expected_g{2, 2};
+  const c2h::device_vector<int> expected_b{1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -1553,17 +1553,17 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[hi
   auto d_samples =
     c2h::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char);
 
   auto d_levels_r = c2h::device_vector<unsigned char>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<unsigned char>{0, 3, 5};
   auto d_levels_b = c2h::device_vector<unsigned char>{0, 1, 2, 3};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -1572,7 +1572,7 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[hi
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1609,9 +1609,9 @@ CUB_TEST_CASE("DeviceHistogram::MultiHistogramRange 2D uses custom stream", "[hi
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_r{2, 2};
-  c2h::device_vector<int> expected_g{2, 2};
-  c2h::device_vector<int> expected_b{1, 1, 1};
+  const c2h::device_vector<int> expected_r{2, 2};
+  const c2h::device_vector<int> expected_g{2, 2};
+  const c2h::device_vector<int> expected_b{1, 1, 1};
   REQUIRE(d_histogram_r == expected_r);
   REQUIRE(d_histogram_g == expected_g);
   REQUIRE(d_histogram_b == expected_b);
@@ -1637,12 +1637,12 @@ CUB_TEST("DeviceHistogram::HistogramEven can be tuned", "[histogram][device]", C
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
-  int num_samples  = 256;
-  int num_levels   = 257;
-  int lower_level  = 0;
-  int upper_level  = 256;
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  const block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  const int num_samples = 256;
+  const int num_levels  = 257;
+  const int lower_level = 0;
+  const int upper_level = 256;
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
 
@@ -1655,11 +1655,11 @@ CUB_TEST("DeviceHistogram::HistogramRange can be tuned", "[histogram][device]", 
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
-  int num_samples  = 256;
-  auto d_levels    = c2h::device_vector<int>{0, 128, 256};
-  int num_levels   = static_cast<int>(d_levels.size());
-  auto d_histogram = c2h::device_vector<int>(num_levels - 1, 0);
+  const block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  const int num_samples = 256;
+  auto d_levels         = c2h::device_vector<int>{0, 128, 256};
+  const int num_levels  = static_cast<int>(d_levels.size());
+  auto d_histogram      = c2h::device_vector<int>(num_levels - 1, 0);
 
   auto env = cuda::execution::tune(histogram_tuning<target_block_size>{});
 
@@ -1680,18 +1680,18 @@ CUB_TEST("DeviceHistogram::MultiHistogramEven can be tuned", "[histogram][device
   constexpr int NUM_ACTIVE_CHANNELS        = 3;
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
-  int num_pixels = 64;
+  const block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  const int num_pixels = 64;
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels  = {5, 5, 5};
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels  = {5, 5, 5};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = c2h::device_vector<int>(4, 0);
   auto d_histogram_g = c2h::device_vector<int>(4, 0);
   auto d_histogram_b = c2h::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
@@ -1710,16 +1710,16 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][devic
   constexpr int NUM_ACTIVE_CHANNELS        = 3;
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
-  int num_pixels = 64;
+  const block_size_extracting_constant_iterator d_samples(0, thrust::raw_pointer_cast(d_block_size.data()));
+  const int num_pixels = 64;
 
   auto d_levels_r = c2h::device_vector<int>{0, 2, 4};
   auto d_levels_g = c2h::device_vector<int>{0, 2, 4};
   auto d_levels_b = c2h::device_vector<int>{0, 2, 4};
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 3};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 3};
 
-  cuda::std::array<const int*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const int*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -1728,7 +1728,7 @@ CUB_TEST("DeviceHistogram::MultiHistogramRange can be tuned", "[histogram][devic
   auto d_histogram_g = c2h::device_vector<int>(2, 0);
   auto d_histogram_b = c2h::device_vector<int>(2, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};

--- a/cub/test/catch2_test_device_histogram_env_api.cu
+++ b/cub/test/catch2_test_device_histogram_env_api.cu
@@ -19,15 +19,15 @@
 CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-even-env
-  auto d_samples   = thrust::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
-  int num_samples  = static_cast<int>(d_samples.size());
-  int num_levels   = 6;
-  int lower_level  = 0;
-  int upper_level  = 5;
-  auto d_histogram = thrust::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = thrust::device_vector<int>{0, 2, 1, 0, 3, 4, 2, 1};
+  const int num_samples = static_cast<int>(d_samples.size());
+  const int num_levels  = 6;
+  const int lower_level = 0;
+  const int upper_level = 5;
+  auto d_histogram      = thrust::device_vector<int>(num_levels - 1, 0);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::HistogramEven(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -42,7 +42,7 @@ CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream", "[histog
     std::cerr << "cub::DeviceHistogram::HistogramEven failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{2, 2, 2, 1, 1};
+  const thrust::device_vector<int> expected{2, 2, 2, 1, 1};
   // example-end histogram-even-env
 
   stream.sync();
@@ -55,18 +55,18 @@ CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
   // example-begin histogram-even-2d-env
   // 2D region of interest: 2 rows, 3 samples per row, row stride includes 1 padding element
   // Row 0: [0, 1, 2, PAD]   Row 1: [1, 2, 0, PAD]
-  auto d_samples          = thrust::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  int num_levels          = 4; // 3 bins: [0,1), [1,2), [2,3)
-  int lower_level         = 0;
-  int upper_level         = 3;
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_samples                = thrust::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  const int num_levels          = 4; // 3 bins: [0,1), [1,2), [2,3)
+  const int lower_level         = 0;
+  const int upper_level         = 3;
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
 
   auto d_histogram = thrust::device_vector<int>(num_levels - 1, 0);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::HistogramEven(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -84,7 +84,7 @@ CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
   }
 
   // Samples: 0,1,2, 1,2,0 → bin[0]=2, bin[1]=2, bin[2]=2
-  thrust::device_vector<int> expected{2, 2, 2};
+  const thrust::device_vector<int> expected{2, 2, 2};
   // example-end histogram-even-2d-env
 
   stream.sync();
@@ -95,14 +95,14 @@ CUB_TEST("cub::DeviceHistogram::HistogramEven accepts env with stream (2D)", "[h
 CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histogram][env]", CUB_SMALL)
 {
   // example-begin histogram-range-env
-  auto d_samples   = thrust::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
-  int num_samples  = static_cast<int>(d_samples.size());
-  auto d_levels    = thrust::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  int num_levels   = static_cast<int>(d_levels.size());
-  auto d_histogram = thrust::device_vector<int>(num_levels - 1, 0);
+  auto d_samples        = thrust::device_vector<float>{2.2f, 6.1f, 7.5f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f};
+  const int num_samples = static_cast<int>(d_samples.size());
+  auto d_levels         = thrust::device_vector<float>{0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  const int num_levels  = static_cast<int>(d_levels.size());
+  auto d_histogram      = thrust::device_vector<int>(num_levels - 1, 0);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::HistogramRange(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -116,7 +116,7 @@ CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream", "[histo
     std::cerr << "cub::DeviceHistogram::HistogramRange failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 5, 0, 2};
+  const thrust::device_vector<int> expected{1, 5, 0, 2};
   // example-end histogram-range-env
 
   stream.sync();
@@ -129,17 +129,17 @@ CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
   // example-begin histogram-range-2d-env
   // 2D region of interest: 2 rows, 3 samples per row, row stride includes 1 padding element
   // Row 0: [0, 1, 2, PAD]   Row 1: [1, 2, 0, PAD]
-  auto d_samples          = thrust::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
-  auto d_levels           = thrust::device_vector<int>{0, 1, 2, 3}; // 3 bins: [0,1), [1,2), [2,3)
-  int num_levels          = static_cast<int>(d_levels.size());
-  int num_row_samples     = 3;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 4 * sizeof(int);
+  auto d_samples                = thrust::device_vector<int>{0, 1, 2, -1, 1, 2, 0, -1};
+  auto d_levels                 = thrust::device_vector<int>{0, 1, 2, 3}; // 3 bins: [0,1), [1,2), [2,3)
+  const int num_levels          = static_cast<int>(d_levels.size());
+  const int num_row_samples     = 3;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 4 * sizeof(int);
 
   auto d_histogram = thrust::device_vector<int>(num_levels - 1, 0);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::HistogramRange(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -156,7 +156,7 @@ CUB_TEST("cub::DeviceHistogram::HistogramRange accepts env with stream (2D)", "[
   }
 
   // Samples: 0,1,2, 1,2,0 → bin[0]=2, bin[1]=2, bin[2]=2
-  thrust::device_vector<int> expected{2, 2, 2};
+  const thrust::device_vector<int> expected{2, 2, 2};
   // example-end histogram-range-2d-env
 
   stream.sync();
@@ -175,24 +175,24 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)"
   // 2 pixels: (R=0, G=2, B=1, A=255), (R=3, G=4, B=2, A=128)
   auto d_samples = thrust::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
   // clang-format on
-  int num_pixels = 2;
+  const int num_pixels = 2;
 
   // 5 levels per channel → 4 bins per channel: [0,1), [1,2), [2,3), [3,4)
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = thrust::device_vector<int>(4, 0);
   auto d_histogram_g = thrust::device_vector<int>(4, 0);
   auto d_histogram_b = thrust::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -208,11 +208,11 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (1D)"
   }
 
   // R: 0→bin[0], 3→bin[3]
-  thrust::device_vector<int> expected_r{1, 0, 0, 1};
+  const thrust::device_vector<int> expected_r{1, 0, 0, 1};
   // G: 2→bin[2], 4→out of range
-  thrust::device_vector<int> expected_g{0, 0, 1, 0};
+  const thrust::device_vector<int> expected_g{0, 0, 1, 0};
   // B: 1→bin[1], 2→bin[2]
-  thrust::device_vector<int> expected_b{0, 1, 1, 0};
+  const thrust::device_vector<int> expected_b{0, 1, 1, 0};
   // example-end multi-histogram-even-1d-env
 
   stream.sync();
@@ -235,25 +235,25 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
   auto d_samples = thrust::device_vector<unsigned char>{
     0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
-  cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels            = {5, 5, 5};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> lower_level = {0, 0, 0};
+  const cuda::std::array<unsigned char, NUM_ACTIVE_CHANNELS> upper_level = {4, 4, 4};
 
   auto d_histogram_r = thrust::device_vector<int>(4, 0);
   auto d_histogram_g = thrust::device_vector<int>(4, 0);
   auto d_histogram_b = thrust::device_vector<int>(4, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -271,11 +271,11 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramEven accepts env with stream (2D)"
   }
 
   // R: 0, 3, 1, 2 → bin[0]=1, bin[1]=1, bin[2]=1, bin[3]=1
-  thrust::device_vector<int> expected_r{1, 1, 1, 1};
+  const thrust::device_vector<int> expected_r{1, 1, 1, 1};
   // G: 2, 4, 1, 3 → bin[1]=1, bin[2]=1, bin[3]=1 (4 is out of range)
-  thrust::device_vector<int> expected_g{0, 1, 1, 1};
+  const thrust::device_vector<int> expected_g{0, 1, 1, 1};
   // B: 1, 2, 3, 0 → bin[0]=1, bin[1]=1, bin[2]=1, bin[3]=1
-  thrust::device_vector<int> expected_b{1, 1, 1, 1};
+  const thrust::device_vector<int> expected_b{1, 1, 1, 1};
   // example-end multi-histogram-even-2d-env
 
   stream.sync();
@@ -293,17 +293,17 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
   [[maybe_unused]] constexpr int NUM_ACTIVE_CHANNELS = 3;
 
   // 2 pixels: (R=0, G=2, B=1, A=255), (R=3, G=4, B=2, A=128)
-  auto d_samples = thrust::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
-  int num_pixels = 2;
+  auto d_samples       = thrust::device_vector<unsigned char>{0, 2, 1, 255, 3, 4, 2, 128};
+  const int num_pixels = 2;
 
   // Custom bin boundaries per channel
   auto d_levels_r = thrust::device_vector<unsigned char>{0, 2, 4}; // 2 bins: [0,2), [2,4)
   auto d_levels_g = thrust::device_vector<unsigned char>{0, 3, 5}; // 2 bins: [0,3), [3,5)
   auto d_levels_b = thrust::device_vector<unsigned char>{0, 1, 2, 3}; // 3 bins: [0,1), [1,2), [2,3)
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -312,13 +312,13 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
   auto d_histogram_g = thrust::device_vector<int>(2, 0);
   auto d_histogram_b = thrust::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()), d_histogram, num_levels, d_levels, num_pixels, stream_ref);
@@ -328,11 +328,11 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (1D)
   }
 
   // R: 0→[0,2), 3→[2,4)
-  thrust::device_vector<int> expected_r{1, 1};
+  const thrust::device_vector<int> expected_r{1, 1};
   // G: 2→[0,3), 4→[3,5)
-  thrust::device_vector<int> expected_g{1, 1};
+  const thrust::device_vector<int> expected_g{1, 1};
   // B: 1→[1,2), 2→[2,3)
-  thrust::device_vector<int> expected_b{0, 1, 1};
+  const thrust::device_vector<int> expected_b{0, 1, 1};
   // example-end multi-histogram-range-1d-env
 
   stream.sync();
@@ -355,17 +355,17 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
   auto d_samples = thrust::device_vector<unsigned char>{
     0, 2, 1, 255, 3, 4, 2, 128, 0, 0, 0, 0, 1, 1, 3, 200, 2, 3, 0, 100, 0, 0, 0, 0};
 
-  int num_row_pixels      = 2;
-  int num_rows            = 2;
-  size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
+  const int num_row_pixels      = 2;
+  const int num_rows            = 2;
+  const size_t row_stride_bytes = 3 * NUM_CHANNELS * sizeof(unsigned char); // 3 pixels wide, 2 used
 
   auto d_levels_r = thrust::device_vector<unsigned char>{0, 2, 4}; // 2 bins: [0,2), [2,4)
   auto d_levels_g = thrust::device_vector<unsigned char>{0, 3, 5}; // 2 bins: [0,3), [3,5)
   auto d_levels_b = thrust::device_vector<unsigned char>{0, 1, 2, 3}; // 3 bins: [0,1), [1,2), [2,3)
 
-  cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
+  const cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_levels = {3, 3, 4};
 
-  cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
+  const cuda::std::array<const unsigned char*, NUM_ACTIVE_CHANNELS> d_levels = {
     thrust::raw_pointer_cast(d_levels_r.data()),
     thrust::raw_pointer_cast(d_levels_g.data()),
     thrust::raw_pointer_cast(d_levels_b.data())};
@@ -374,13 +374,13 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
   auto d_histogram_g = thrust::device_vector<int>(2, 0);
   auto d_histogram_b = thrust::device_vector<int>(3, 0);
 
-  cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
+  const cuda::std::array<int*, NUM_ACTIVE_CHANNELS> d_histogram = {
     thrust::raw_pointer_cast(d_histogram_r.data()),
     thrust::raw_pointer_cast(d_histogram_g.data()),
     thrust::raw_pointer_cast(d_histogram_b.data())};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
     thrust::raw_pointer_cast(d_samples.data()),
@@ -397,11 +397,11 @@ CUB_TEST("cub::DeviceHistogram::MultiHistogramRange accepts env with stream (2D)
   }
 
   // R: 0, 3, 1, 2 → [0,2)=2, [2,4)=2
-  thrust::device_vector<int> expected_r{2, 2};
+  const thrust::device_vector<int> expected_r{2, 2};
   // G: 2, 4, 1, 3 → [0,3)=2, [3,5)=2
-  thrust::device_vector<int> expected_g{2, 2};
+  const thrust::device_vector<int> expected_g{2, 2};
   // B: 1, 2, 3, 0 → [0,1)=1, [1,2)=1, [2,3)=1 (3 is out of range)
-  thrust::device_vector<int> expected_b{1, 1, 1};
+  const thrust::device_vector<int> expected_b{1, 1, 1};
   // example-end multi-histogram-range-2d-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_memcpy_batched.cu
+++ b/cub/test/catch2_test_device_memcpy_batched.cu
@@ -51,8 +51,8 @@ try
     take(c2h::adjust_seed_count(4),
          map(
            [](const std::vector<buffer_size_t>& chunk) {
-             buffer_size_t lhs = chunk[0];
-             buffer_size_t rhs = chunk[1];
+             const buffer_size_t lhs = chunk[0];
+             const buffer_size_t rhs = chunk[1];
              // Optionally ensure lhs < rhs, for example:
              return (lhs < rhs) ? std::make_tuple(lhs, rhs) : std::make_tuple(rhs, lhs);
            },
@@ -66,7 +66,7 @@ try
   // Generate the buffer sizes: Make sure buffer sizes are a multiple of the most granular unit (one AtomicT) being
   // copied (round down)
   c2h::gen(C2H_SEED(2), d_buffer_sizes, min_buffer_size, max_buffer_size);
-  byte_offset_t num_total_bytes = thrust::reduce(d_buffer_sizes.cbegin(), d_buffer_sizes.cend());
+  const byte_offset_t num_total_bytes = thrust::reduce(d_buffer_sizes.cbegin(), d_buffer_sizes.cend());
 
   // Shuffle input buffer source-offsets
   auto d_buffer_src_offsets = get_shuffled_buffer_offsets<buffer_offset_t, byte_offset_t>(d_buffer_sizes, C2H_SEED(1));
@@ -87,12 +87,12 @@ try
   c2h::host_vector<byte_offset_t> h_dst_offsets(d_buffer_dst_offsets);
 
   // Prepare d_buffer_srcs
-  offset_to_ptr_op<src_ptr_t> src_transform_op{thrust::raw_pointer_cast(d_in.data())};
+  const offset_to_ptr_op<src_ptr_t> src_transform_op{thrust::raw_pointer_cast(d_in.data())};
   auto d_buffer_srcs =
     cuda::transform_iterator(thrust::raw_pointer_cast(d_buffer_src_offsets.data()), src_transform_op);
 
   // Prepare d_buffer_dsts
-  offset_to_ptr_op<dst_ptr_t> dst_transform_op{thrust::raw_pointer_cast(d_out.data())};
+  const offset_to_ptr_op<dst_ptr_t> dst_transform_op{thrust::raw_pointer_cast(d_out.data())};
   auto d_buffer_dsts =
     cuda::transform_iterator(thrust::raw_pointer_cast(d_buffer_dst_offsets.data()), dst_transform_op);
 
@@ -121,10 +121,11 @@ try
   using byte_offset_t = uint64_t;
   using buffer_size_t = uint64_t;
 
-  byte_offset_t large_target_copy_size = static_cast<byte_offset_t>(std::numeric_limits<uint32_t>::max()) + (32 << 20);
-  constexpr auto data_type_size        = static_cast<byte_offset_t>(sizeof(data_t));
-  byte_offset_t num_items              = large_target_copy_size / data_type_size;
-  byte_offset_t num_bytes              = num_items * data_type_size;
+  const byte_offset_t large_target_copy_size =
+    static_cast<byte_offset_t>(std::numeric_limits<uint32_t>::max()) + (32 << 20);
+  constexpr auto data_type_size = static_cast<byte_offset_t>(sizeof(data_t));
+  const byte_offset_t num_items = large_target_copy_size / data_type_size;
+  const byte_offset_t num_bytes = num_items * data_type_size;
   c2h::device_vector<data_t> d_in(num_items);
   c2h::device_vector<data_t> d_out(num_items, 42);
 
@@ -160,13 +161,13 @@ try
   constexpr auto num_non_empty_buffers = buffer_offset_t{3 << 20};
   constexpr auto num_buffers           = num_empty_buffers + num_non_empty_buffers;
 
-  buffer_size_t min_buffer_size = 1;
-  buffer_size_t max_buffer_size = 100;
+  const buffer_size_t min_buffer_size = 1;
+  const buffer_size_t max_buffer_size = 100;
 
   // Generate the buffer sizes
   c2h::device_vector<buffer_size_t> d_buffer_sizes(num_non_empty_buffers);
   c2h::gen(C2H_SEED(2), d_buffer_sizes, min_buffer_size, max_buffer_size);
-  byte_offset_t num_total_bytes = thrust::reduce(d_buffer_sizes.cbegin(), d_buffer_sizes.cend());
+  const byte_offset_t num_total_bytes = thrust::reduce(d_buffer_sizes.cbegin(), d_buffer_sizes.cend());
 
   // Shuffle buffer offsets
   auto d_buffer_src_offsets = get_shuffled_buffer_offsets<buffer_offset_t, byte_offset_t>(d_buffer_sizes, C2H_SEED(1));
@@ -185,23 +186,23 @@ try
   c2h::host_vector<byte_offset_t> h_dst_offsets(d_buffer_dst_offsets);
 
   // Prepare d_buffer_srcs
-  offset_to_ptr_op<src_ptr_t> src_transform_op{thrust::raw_pointer_cast(d_in.data())};
+  const offset_to_ptr_op<src_ptr_t> src_transform_op{thrust::raw_pointer_cast(d_in.data())};
   auto d_buffer_srcs =
     cuda::transform_iterator(thrust::raw_pointer_cast(d_buffer_src_offsets.data()), src_transform_op);
 
   // Return nullptr for the first num_empty_buffers and only the actual destination pointers for the rest
-  prepend_n_constants_op<decltype(d_buffer_srcs), src_ptr_t> src_skip_first_n_op{
+  const prepend_n_constants_op<decltype(d_buffer_srcs), src_ptr_t> src_skip_first_n_op{
     d_buffer_srcs, nullptr, num_empty_buffers};
   auto d_buffer_srcs_skipped =
     cuda::transform_iterator(cuda::counting_iterator(buffer_offset_t{0}), src_skip_first_n_op);
 
   // Prepare d_buffer_dsts
-  offset_to_ptr_op<dst_ptr_t> dst_transform_op{thrust::raw_pointer_cast(d_out.data())};
-  cuda::transform_iterator<offset_to_ptr_op<dst_ptr_t>, byte_offset_t*> d_buffer_dsts(
+  const offset_to_ptr_op<dst_ptr_t> dst_transform_op{thrust::raw_pointer_cast(d_out.data())};
+  const cuda::transform_iterator<offset_to_ptr_op<dst_ptr_t>, byte_offset_t*> d_buffer_dsts(
     thrust::raw_pointer_cast(d_buffer_dst_offsets.data()), dst_transform_op);
 
   // Return nullptr for the first num_empty_buffers and only the actual destination pointers for the rest
-  prepend_n_constants_op<decltype(d_buffer_dsts), dst_ptr_t> dst_skip_first_n_op{
+  const prepend_n_constants_op<decltype(d_buffer_dsts), dst_ptr_t> dst_skip_first_n_op{
     d_buffer_dsts, nullptr, num_empty_buffers};
   auto d_buffer_dsts_skipped =
     cuda::transform_iterator(cuda::counting_iterator(buffer_offset_t{0}), dst_skip_first_n_op);

--- a/cub/test/catch2_test_device_memcpy_env.cu
+++ b/cub/test/catch2_test_device_memcpy_env.cu
@@ -60,9 +60,9 @@ CUB_TEST_CASE("DeviceMemcpy::Batched works with default environment", "[memcpy][
   auto d_dst     = c2h::device_vector<int>(6);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_buffers = 3;
+  const int num_buffers = 3;
 
-  cuda::counting_iterator<int> iota(0);
+  const cuda::counting_iterator<int> iota(0);
   auto input_it = cuda::transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = cuda::transform_iterator(
@@ -83,9 +83,9 @@ CUB_TEST("DeviceMemcpy::Batched uses environment", "[memcpy][device]", CUB_SMALL
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_buffers = 3;
+  const int num_buffers = 3;
 
-  cuda::counting_iterator<int> iota(0);
+  const cuda::counting_iterator<int> iota(0);
   auto input_it = cuda::transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = cuda::transform_iterator(
@@ -110,16 +110,16 @@ CUB_TEST_CASE("DeviceMemcpy::Batched uses custom stream", "[memcpy][device]", CU
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 5, 6};
 
-  int num_buffers = 3;
+  const int num_buffers = 3;
 
-  cuda::counting_iterator<int> iota(0);
+  const cuda::counting_iterator<int> iota(0);
   auto input_it = cuda::transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = cuda::transform_iterator(
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto sizes = cuda::transform_iterator(iota, get_size{thrust::raw_pointer_cast(d_offsets.data())});
 
-  cuda::stream custom_stream(cuda::device_ref{0});
+  const cuda::stream custom_stream(cuda::device_ref{0});
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess
@@ -163,17 +163,17 @@ CUB_TEST("DeviceMemcpy::Batched can be tuned", "[memcpy][device]", CUB_SMALL, bl
   auto d_dst     = c2h::device_vector<int>(6, 0);
   auto d_offsets = c2h::device_vector<int>{0, 2, 4, 6};
 
-  int num_buffers                = 3;
+  const int num_buffers          = 3;
   constexpr int bytes_per_buffer = 2 * static_cast<int>(sizeof(int));
 
-  cuda::counting_iterator<int> iota(0);
+  const cuda::counting_iterator<int> iota(0);
   auto input_it = cuda::transform_iterator(
     iota, index_to_ptr<const int>{thrust::raw_pointer_cast(d_src.data()), thrust::raw_pointer_cast(d_offsets.data())});
   auto output_it = cuda::transform_iterator(
     iota, index_to_ptr<int>{thrust::raw_pointer_cast(d_dst.data()), thrust::raw_pointer_cast(d_offsets.data())});
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_constant_iterator sizes(bytes_per_buffer, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator sizes(bytes_per_buffer, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(batch_memcpy_tuning<target_block_size>{});
 

--- a/cub/test/catch2_test_device_memcpy_env_api.cu
+++ b/cub/test/catch2_test_device_memcpy_env_api.cu
@@ -43,10 +43,10 @@ CUB_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]", 
   auto d_sizes = thrust::device_vector<int>{
     2 * static_cast<int>(sizeof(int)), 3 * static_cast<int>(sizeof(int)), 1 * static_cast<int>(sizeof(int))};
 
-  int num_buffers = 3;
+  const int num_buffers = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMemcpy::Batched(
     thrust::raw_pointer_cast(d_src_ptrs.data()),
@@ -59,8 +59,8 @@ CUB_TEST("cub::DeviceMemcpy::Batched accepts env with stream", "[memcpy][env]", 
     std::cerr << "cub::DeviceMemcpy::Batched failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_a{10, 20, 30, 40, 50};
-  thrust::device_vector<int> expected_b{60};
+  const thrust::device_vector<int> expected_a{10, 20, 30, 40, 50};
+  const thrust::device_vector<int> expected_b{60};
   // example-end memcpy-batched-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -57,7 +57,7 @@ void test_keys(Offset size1 = 3623, Offset size2 = 6346, CompareOp compare_op = 
 
   // comparing std::vectors instead compiles in 1m19s, thrust::host_vector 1m23s, thrust::device_vector 1m38
   // let's pick the host_vector, so we don't stress device memory with another (potentially big) allocation
-  c2h::host_vector<Key> result_h(result_d); // perform copy outside CHECK() to propagate a potential bad_alloc
+  const c2h::host_vector<Key> result_h(result_d); // perform copy outside CHECK() to propagate a potential bad_alloc
   CHECK(reference_h == result_h);
 }
 

--- a/cub/test/catch2_test_device_merge_api.cu
+++ b/cub/test/catch2_test_device_merge_api.cu
@@ -41,7 +41,7 @@ CUB_TEST("DeviceMerge::MergeKeys API example", "[merge][device]", CUB_SMALL)
     static_cast<int>(keys2.size()),
     result.begin());
 
-  c2h::host_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::host_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   // example-end merge-keys
   CHECK(result == expected);
 }
@@ -86,8 +86,8 @@ CUB_TEST("DeviceMerge::MergePairs API example", "[merge][device]", CUB_SMALL)
     result_keys.begin(),
     result_values.begin());
 
-  c2h::host_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::host_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::host_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::host_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   // example-end merge-pairs
   CHECK(result_keys == expected_keys);
   CHECK(result_values == expected_values);

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -53,7 +53,7 @@ CUB_TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][
     == cub::DeviceMerge::MergeKeys(
       keys1.begin(), static_cast<int>(keys1.size()), keys2.begin(), static_cast<int>(keys2.size()), result.begin()));
 
-  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
 }
 
@@ -79,8 +79,8 @@ CUB_TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge]
       result_keys.begin(),
       result_values.begin()));
 
-  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -95,7 +95,7 @@ CUB_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", CUB_SMALL, bl
   auto result                              = c2h::device_vector<int>(7);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(merge_tuning<target_block_size>{});
 
@@ -110,7 +110,7 @@ CUB_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", CUB_SMALL, bl
       block_size_check,
       env));
 
-  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -126,7 +126,7 @@ CUB_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", CUB_SMALL, b
   auto result_values                       = c2h::device_vector<char>(7);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(merge_tuning<target_block_size>{});
 
@@ -144,8 +144,8 @@ CUB_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", CUB_SMALL, b
       block_size_check,
       env));
 
-  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
   REQUIRE(d_block_size[0] == target_block_size);
@@ -179,7 +179,7 @@ CUB_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]", CUB_SMALL
              cuda::std::less<>{},
              env);
 
-  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
 }
 
@@ -217,7 +217,7 @@ CUB_TEST_CASE("DeviceMerge::MergeKeys uses custom stream", "[merge][device]", CU
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -262,8 +262,8 @@ CUB_TEST("DeviceMerge::MergePairs uses environment", "[merge][device]", CUB_SMAL
     cuda::std::less<>{},
     env);
 
-  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -313,8 +313,8 @@ CUB_TEST_CASE("DeviceMerge::MergePairs uses custom stream", "[merge][device]", C
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 
@@ -347,7 +347,7 @@ CUB_TEST_CASE("DeviceMerge::MergeKeys works with unroll disabled", "[merge][devi
       cuda::std::less<>{},
       env));
 
-  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   REQUIRE(result == expected);
 }
 
@@ -376,8 +376,8 @@ CUB_TEST_CASE("DeviceMerge::MergePairs works with unroll disabled", "[merge][dev
       cuda::std::less<>{},
       env));
 
-  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }

--- a/cub/test/catch2_test_device_merge_env_api.cu
+++ b/cub/test/catch2_test_device_merge_env_api.cu
@@ -22,8 +22,8 @@ CUB_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]", 
   auto keys2  = thrust::device_vector<int>{0, 3, 3, 4};
   auto result = thrust::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMerge::MergeKeys(
     keys1.begin(),
@@ -38,7 +38,7 @@ CUB_TEST("cub::DeviceMerge::MergeKeys accepts env with stream", "[merge][env]", 
     std::cerr << "cub::DeviceMerge::MergeKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  const thrust::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   // example-end merge-keys-env
 
   stream.sync();
@@ -57,8 +57,8 @@ CUB_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]",
   auto result_keys   = thrust::device_vector<int>(7);
   auto result_values = thrust::device_vector<char>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMerge::MergePairs(
     keys1.begin(),
@@ -76,8 +76,8 @@ CUB_TEST("cub::DeviceMerge::MergePairs accepts env with stream", "[merge][env]",
     std::cerr << "cub::DeviceMerge::MergePairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
-  thrust::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  const thrust::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  const thrust::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   // example-end merge-pairs-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -164,7 +164,7 @@ public:
   {
     // The first (num_remainder_items * remainder_item_count) are items that appear once more often than the items that
     // follow remainder_items_offset
-    std::size_t remainder_items_offset = num_remainder_items * remainder_item_count;
+    const std::size_t remainder_items_offset = num_remainder_items * remainder_item_count;
 
     UnsignedIntegralKeyT target_item_index =
       (index <= remainder_items_offset)
@@ -217,9 +217,9 @@ CUB_TEST("DeviceMergeSort::SortKeysCopy works",
     thrust::raw_pointer_cast(keys_in.data()), thrust::raw_pointer_cast(keys_out.data()), num_items, custom_less_op_t{});
 
   // Verify results
-  auto key_ranks_it     = cuda::counting_iterator(offset_t{});
-  auto keys_expected_it = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
-  bool results_equal    = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
+  auto key_ranks_it        = cuda::counting_iterator(offset_t{});
+  auto keys_expected_it    = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
+  const bool results_equal = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
   REQUIRE(results_equal == true);
 }
 
@@ -243,7 +243,8 @@ CUB_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", CUB_SMALL, 
   // Verify results
   auto key_ranks_it     = cuda::counting_iterator(offset_t{});
   auto keys_expected_it = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
-  bool results_equal    = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool results_equal =
+    thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
   REQUIRE(results_equal == true);
 }
 
@@ -333,8 +334,9 @@ CUB_TEST("DeviceMergeSort::SortPairsCopy works",
   auto key_ranks_it       = cuda::counting_iterator(offset_t{});
   auto keys_expected_it   = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
   auto values_expected_it = cuda::counting_iterator(offset_t{});
-  bool keys_equal         = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
-  bool values_equal = thrust::equal(c2h::device_policy, values_out.cbegin(), values_out.cend(), values_expected_it);
+  const bool keys_equal   = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
+  const bool values_equal =
+    thrust::equal(c2h::device_policy, values_out.cbegin(), values_out.cend(), values_expected_it);
   REQUIRE(keys_equal == true);
   REQUIRE(values_equal == true);
 }
@@ -363,8 +365,8 @@ CUB_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", CUB_SMALL,
   auto key_ranks_it       = cuda::counting_iterator(offset_t{});
   auto keys_expected_it   = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
   auto values_expected_it = cuda::counting_iterator(offset_t{});
-  bool keys_equal   = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
-  bool values_equal = thrust::equal(c2h::device_policy, key_ranks.cbegin(), key_ranks.cend(), values_expected_it);
+  const bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool values_equal = thrust::equal(c2h::device_policy, key_ranks.cbegin(), key_ranks.cend(), values_expected_it);
   REQUIRE(keys_equal == true);
   REQUIRE(values_equal == true);
 }
@@ -419,7 +421,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
   // Clamp 64-bit offset type problem sizes to just slightly larger than 2^32 items
   auto num_items_ull = std::min(static_cast<std::size_t>(cuda::std::numeric_limits<offset_t>::max()) - 1,
                                 cuda::std::numeric_limits<std::uint32_t>::max() + static_cast<std::size_t>(2000000ULL));
-  offset_t num_items = static_cast<offset_t>(num_items_ull);
+  const offset_t num_items = static_cast<offset_t>(num_items_ull);
 
   SECTION("Random")
   {
@@ -463,7 +465,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
       // Perform comparison
       auto expected_result_it =
         cuda::transform_iterator(cuda::counting_iterator(std::size_t{}), index_to_expected_key_op<key_t>(num_items));
-      bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.begin());
+      const bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.begin());
       REQUIRE(is_correct == true);
     }
     catch (std::bad_alloc& e)
@@ -491,7 +493,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
       // Perform comparison
       auto expected_result_it =
         cuda::transform_iterator(cuda::counting_iterator(std::size_t{}), index_to_expected_key_op<key_t>(num_items));
-      bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.cbegin());
+      const bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.cbegin());
       REQUIRE(is_correct == true);
     }
     catch (std::bad_alloc& e)

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -217,9 +217,9 @@ CUB_TEST("DeviceMergeSort::SortKeysCopy works",
     thrust::raw_pointer_cast(keys_in.data()), thrust::raw_pointer_cast(keys_out.data()), num_items, custom_less_op_t{});
 
   // Verify results
-  auto key_ranks_it        = cuda::counting_iterator(offset_t{});
-  auto keys_expected_it    = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
-  const bool results_equal = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
+  const auto key_ranks_it     = cuda::counting_iterator(offset_t{});
+  const auto keys_expected_it = cuda::transform_iterator(key_ranks_it, rank_to_key_op_t<offset_t, key_t>{});
+  const bool results_equal    = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
   REQUIRE(results_equal == true);
 }
 

--- a/cub/test/catch2_test_device_merge_sort_env.cu
+++ b/cub/test/catch2_test_device_merge_sort_env.cu
@@ -54,8 +54,8 @@ CUB_TEST_CASE("DeviceMergeSort::SortPairs works with default environment", "[mer
           == cub::DeviceMergeSort::SortPairs(
             d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -68,7 +68,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeys works with default environment", "[merg
     cudaSuccess
     == cub::DeviceMergeSort::SortKeys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -81,8 +81,8 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortPairs works with default environment",
           == cub::DeviceMergeSort::StableSortPairs(
             d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -95,7 +95,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeys works with default environment", 
           == cub::DeviceMergeSort::StableSortKeys(
             d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -116,8 +116,8 @@ CUB_TEST_CASE("DeviceMergeSort::SortPairsCopy works with default environment", "
       static_cast<int>(d_keys_in.size()),
       cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys_out == expected_keys);
   REQUIRE(d_values_out == expected_values);
 }
@@ -132,7 +132,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy works with default environment", "[
     == cub::DeviceMergeSort::SortKeysCopy(
       d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -146,7 +146,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy works with default environmen
     == cub::DeviceMergeSort::StableSortKeysCopy(
       d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -173,8 +173,8 @@ CUB_TEST("DeviceMergeSort::SortPairs uses environment", "[merge_sort][device]", 
   device_merge_sort_pairs(
     d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -193,7 +193,7 @@ CUB_TEST("DeviceMergeSort::SortKeys uses environment", "[merge_sort][device]", C
 
   device_merge_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -218,8 +218,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs uses environment", "[merge_sort][devi
   device_merge_stable_sort_pairs(
     d_keys.data().get(), d_values.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
 }
@@ -238,7 +238,7 @@ CUB_TEST("DeviceMergeSort::StableSortKeys uses environment", "[merge_sort][devic
 
   device_merge_stable_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
 }
 
@@ -269,8 +269,8 @@ CUB_TEST_CASE("DeviceMergeSort::SortPairs uses custom stream", "[merge_sort][dev
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(d_values == expected_values);
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -296,7 +296,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeys uses custom stream", "[merge_sort
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
@@ -332,8 +332,8 @@ CUB_TEST("DeviceMergeSort::SortPairsCopy uses environment", "[merge_sort][device
     cuda::std::less<int>{},
     env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(d_keys_out == expected_keys);
   REQUIRE(d_values_out == expected_values);
 }
@@ -359,7 +359,7 @@ CUB_TEST("DeviceMergeSort::SortKeysCopy uses environment", "[merge_sort][device]
   device_merge_sort_keys_copy(
     d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -384,7 +384,7 @@ CUB_TEST("DeviceMergeSort::StableSortKeysCopy uses environment", "[merge_sort][d
   device_merge_stable_sort_keys_copy(
     d_keys_in.data().get(), d_keys_out.data().get(), static_cast<int>(d_keys_in.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -393,7 +393,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -406,7 +406,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][
       static_cast<int>(d_keys_in.size()),
       cuda::std::less<int>{}));
 
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_merge_sort_keys_copy(
@@ -414,7 +414,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeysCopy uses custom stream", "[merge_sort][
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -423,7 +423,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_
   auto d_keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = c2h::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -436,7 +436,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_
       static_cast<int>(d_keys_in.size()),
       cuda::std::less<int>{}));
 
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_merge_stable_sort_keys_copy(
@@ -444,7 +444,7 @@ CUB_TEST_CASE("DeviceMergeSort::StableSortKeysCopy uses custom stream", "[merge_
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys_out == expected_keys);
 }
 
@@ -573,7 +573,7 @@ CUB_TEST_CASE("DeviceMergeSort::SortKeys works with unroll disabled", "[merge_so
 
   device_merge_sort_keys(d_keys.data().get(), static_cast<int>(d_keys.size()), cuda::std::less<int>{}, env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(d_keys == expected_keys);
 }
 

--- a/cub/test/catch2_test_device_merge_sort_env_api.cu
+++ b/cub/test/catch2_test_device_merge_sort_env_api.cu
@@ -28,8 +28,8 @@ CUB_TEST("cub::DeviceMergeSort::SortPairs env-based API", "[merge_sort][env]", C
     std::cerr << "cub::DeviceMergeSort::SortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end sort-pairs-env
 
   REQUIRE(error == cudaSuccess);
@@ -49,7 +49,7 @@ CUB_TEST("cub::DeviceMergeSort::SortKeys env-based API", "[merge_sort][env]", CU
     std::cerr << "cub::DeviceMergeSort::SortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end sort-keys-env
 
   REQUIRE(error == cudaSuccess);
@@ -69,8 +69,8 @@ CUB_TEST("cub::DeviceMergeSort::StableSortPairs env-based API", "[merge_sort][en
     std::cerr << "cub::DeviceMergeSort::StableSortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
-  thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 6, 8, 9};
+  const thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end stable-sort-pairs-env
 
   REQUIRE(error == cudaSuccess);
@@ -90,7 +90,7 @@ CUB_TEST("cub::DeviceMergeSort::StableSortKeys env-based API", "[merge_sort][env
     std::cerr << "cub::DeviceMergeSort::StableSortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-env
 
   REQUIRE(error == cudaSuccess);
@@ -105,8 +105,8 @@ CUB_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]
   auto d_keys_out   = thrust::device_vector<int>(7);
   auto d_values_out = thrust::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMergeSort::SortPairsCopy(
     d_keys_in.data().get(),
@@ -121,8 +121,8 @@ CUB_TEST("cub::DeviceMergeSort::SortPairsCopy env-based API", "[merge_sort][env]
     std::cerr << "cub::DeviceMergeSort::SortPairsCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end sort-pairs-copy-env
   stream.sync();
 
@@ -137,8 +137,8 @@ CUB_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
   auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto d_keys_out = thrust::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMergeSort::SortKeysCopy(
     d_keys_in.data().get(),
@@ -151,7 +151,7 @@ CUB_TEST("cub::DeviceMergeSort::SortKeysCopy env-based API", "[merge_sort][env]"
     std::cerr << "cub::DeviceMergeSort::SortKeysCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end sort-keys-copy-env
   stream.sync();
 
@@ -165,8 +165,8 @@ CUB_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
   auto d_keys_in  = thrust::device_vector<int>{8, 6, 7, 5, 5, 3, 0, 9};
   auto d_keys_out = thrust::device_vector<int>(8);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceMergeSort::StableSortKeysCopy(
     d_keys_in.data().get(),
@@ -179,7 +179,7 @@ CUB_TEST("cub::DeviceMergeSort::StableSortKeysCopy env-based API", "[merge_sort]
     std::cerr << "cub::DeviceMergeSort::StableSortKeysCopy failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 5, 6, 7, 8, 9};
   // example-end stable-sort-keys-copy-env
   stream.sync();
 
@@ -199,8 +199,8 @@ CUB_TEST("cub::DeviceMergeSort::SortPairs env-based API with greater comparator"
     std::cerr << "cub::DeviceMergeSort::SortPairs (greater) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(d_keys == expected_keys);

--- a/cub/test/catch2_test_device_merge_sort_iterators.cu
+++ b/cub/test/catch2_test_device_merge_sort_iterators.cu
@@ -46,7 +46,7 @@ CUB_TEST("DeviceMergeSort::SortKeysCopy works with iterators", "[merge][sort][de
 
   // Verify results
   auto keys_expected_it = keys_counting_it;
-  bool keys_equal       = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
+  const bool keys_equal = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
   REQUIRE(keys_equal == true);
 }
 
@@ -91,7 +91,7 @@ CUB_TEST("DeviceMergeSort::SortKeys works with iterators", "[merge][sort][device
   // Verify results
   auto keys_counting_it = cuda::counting_iterator(key_t{});
   auto keys_expected_it = cuda::std::make_reverse_iterator(keys_counting_it + num_items);
-  bool keys_equal       = thrust::equal(keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool keys_equal = thrust::equal(keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
   REQUIRE(keys_equal == true);
 }
 
@@ -112,7 +112,7 @@ CUB_TEST("DeviceMergeSort::StableSortKeys works with iterators", "[merge][sort][
   // Verify results
   auto keys_counting_it = cuda::counting_iterator(key_t{});
   auto keys_expected_it = cuda::std::make_reverse_iterator(keys_counting_it + num_items);
-  bool keys_equal       = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
   REQUIRE(keys_equal == true);
 }
 
@@ -136,8 +136,9 @@ CUB_TEST("DeviceMergeSort::SortPairsCopy works with iterators", "[merge][sort][d
   // Verify results
   auto keys_expected_it   = key_counting_it;
   auto values_expected_it = cuda::std::make_reverse_iterator(values_in + num_items);
-  bool keys_equal         = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
-  bool values_equal = thrust::equal(c2h::device_policy, values_out.cbegin(), values_out.cend(), values_expected_it);
+  const bool keys_equal   = thrust::equal(c2h::device_policy, keys_out.cbegin(), keys_out.cend(), keys_expected_it);
+  const bool values_equal =
+    thrust::equal(c2h::device_policy, values_out.cbegin(), values_out.cend(), values_expected_it);
   REQUIRE(keys_equal == true);
   REQUIRE(values_equal == true);
 }
@@ -164,8 +165,8 @@ CUB_TEST("DeviceMergeSort::SortPairs works with iterators", "[merge][sort][devic
   auto keys_counting_it   = cuda::counting_iterator(key_t{});
   auto keys_expected_it   = cuda::std::make_reverse_iterator(keys_counting_it + num_items);
   auto values_expected_it = cuda::counting_iterator(data_t{});
-  bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
-  bool values_equal =
+  const bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool values_equal =
     thrust::equal(c2h::device_policy, values_in_out.cbegin(), values_in_out.cend(), values_expected_it);
   REQUIRE(keys_equal == true);
   REQUIRE(values_equal == true);
@@ -193,8 +194,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works with iterators", "[merge][sort]
   auto keys_counting_it   = cuda::counting_iterator(key_t{});
   auto keys_expected_it   = cuda::std::make_reverse_iterator(keys_counting_it + num_items);
   auto values_expected_it = cuda::counting_iterator(data_t{});
-  bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
-  bool values_equal =
+  const bool keys_equal = thrust::equal(c2h::device_policy, keys_in_out.cbegin(), keys_in_out.cend(), keys_expected_it);
+  const bool values_equal =
     thrust::equal(c2h::device_policy, values_in_out.cbegin(), values_in_out.cend(), values_expected_it);
   REQUIRE(keys_equal == true);
   REQUIRE(values_equal == true);

--- a/cub/test/catch2_test_device_partition_api.cu
+++ b/cub/test/catch2_test_device_partition_api.cu
@@ -19,7 +19,7 @@ CUB_TEST("DevicePartition::Flagged legacy size-query is unambiguous", "[partitio
   int* d_out          = nullptr;
   int* d_num_selected = nullptr;
   size_t bytes        = 0;
-  int n               = 0;
+  const int n         = 0;
 
   REQUIRE(cudaSuccess == cub::DevicePartition::Flagged(nullptr, bytes, d_in, d_flags, d_out, d_num_selected, n));
 }
@@ -30,7 +30,7 @@ CUB_TEST("DevicePartition::If legacy size-query is unambiguous", "[partition][de
   int* d_out          = nullptr;
   int* d_num_selected = nullptr;
   size_t bytes        = 0;
-  int n               = 0;
+  const int n         = 0;
 
   REQUIRE(
     cudaSuccess == cub::DevicePartition::If(nullptr, bytes, d_in, d_out, d_num_selected, n, ::cuda::always_true{}));
@@ -44,7 +44,7 @@ CUB_TEST("DevicePartition::If three-way legacy size-query is unambiguous", "[par
   int* d_unselected   = nullptr;
   int* d_num_selected = nullptr;
   size_t bytes        = 0;
-  int n               = 0;
+  const int n         = 0;
 
   REQUIRE(
     cudaSuccess

--- a/cub/test/catch2_test_device_partition_env.cu
+++ b/cub/test/catch2_test_device_partition_env.cu
@@ -47,19 +47,19 @@ CUB_TEST_CASE("Device partition works with default environment", "[partition][de
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
-  less_than_t<value_t> select_op{5};
+  const less_than_t<value_t> select_op{5};
 
   // launch wrapper always assumes the last argument is the environment
   REQUIRE(
     cudaSuccess == cub::DevicePartition::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
@@ -70,19 +70,19 @@ CUB_TEST_CASE("Device partition flagged works with default environment", "[parti
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
   // launch wrapper always assumes the last argument is the environment
   REQUIRE(
     cudaSuccess
     == cub::DevicePartition::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
@@ -96,8 +96,8 @@ CUB_TEST_CASE("Device partition three-way works with default environment", "[par
   auto d_unselected_out = c2h::device_vector<int>(8);
   auto d_num_selected   = c2h::device_vector<int>(2);
 
-  less_than_t<int> small_selector{7};
-  greater_than_t<int> large_selector{50};
+  const less_than_t<int> small_selector{7};
+  const greater_than_t<int> large_selector{50};
 
   auto error = cub::DevicePartition::If(
     d_in.begin(),
@@ -114,8 +114,8 @@ CUB_TEST_CASE("Device partition three-way works with default environment", "[par
   REQUIRE(d_num_selected[1] == 1);
   d_small_out.resize(d_num_selected[0]);
   d_large_out.resize(d_num_selected[1]);
-  c2h::device_vector<int> expected_small{0, 2, 3, 5, 2};
-  c2h::device_vector<int> expected_large{81};
+  const c2h::device_vector<int> expected_small{0, 2, 3, 5, 2};
+  const c2h::device_vector<int> expected_large{81};
   REQUIRE(d_small_out == expected_small);
   REQUIRE(d_large_out == expected_large);
 }
@@ -127,12 +127,12 @@ CUB_TEST("Device partition uses environment", "[partition][device]", CUB_SMALL)
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
-  less_than_t<value_t> select_op{6};
+  const less_than_t<value_t> select_op{6};
 
   size_t expected_bytes_allocated{};
   // calculate expected_bytes_allocated - call CUB API directly, not through wrapper
@@ -146,8 +146,8 @@ CUB_TEST("Device partition uses environment", "[partition][device]", CUB_SMALL)
   device_partition_if(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
   // Items < 6: {1, 2, 3, 4, 5} at front, items >= 6: {6, 7, 8, 9, 10} at back in reverse order
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5, 10, 9, 8, 7, 6};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5, 10, 9, 8, 7, 6};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
@@ -158,11 +158,11 @@ CUB_TEST("Device partition flagged uses environment", "[partition][device]", CUB
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -181,8 +181,8 @@ CUB_TEST("Device partition flagged uses environment", "[partition][device]", CUB
   device_partition_flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, env);
 
   // Flagged: {1, 3, 5, 7, 9} at front, unflagged: {2, 4, 6, 8, 10} at back in reverse order
-  c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9, 10, 8, 6, 4, 2};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9, 10, 8, 6, 4, 2};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
@@ -196,8 +196,8 @@ CUB_TEST("Device partition three-way uses environment", "[partition][device]", C
   auto d_unselected_out = c2h::device_vector<int>(8);
   auto d_num_selected   = c2h::device_vector<int>(2);
 
-  less_than_t<int> small_selector{7};
-  greater_than_t<int> large_selector{50};
+  const less_than_t<int> small_selector{7};
+  const greater_than_t<int> large_selector{50};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -231,8 +231,8 @@ CUB_TEST("Device partition three-way uses environment", "[partition][device]", C
   REQUIRE(d_num_selected[1] == 1);
   d_small_out.resize(d_num_selected[0]);
   d_large_out.resize(d_num_selected[1]);
-  c2h::device_vector<int> expected_small{0, 2, 3, 5, 2};
-  c2h::device_vector<int> expected_large{81};
+  const c2h::device_vector<int> expected_small{0, 2, 3, 5, 2};
+  const c2h::device_vector<int> expected_large{81};
   REQUIRE(d_small_out == expected_small);
   REQUIRE(d_large_out == expected_large);
 }
@@ -242,12 +242,12 @@ CUB_TEST_CASE("Device partition uses custom stream", "[partition][device]", CUB_
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
-  less_than_t<value_t> select_op{5};
+  const less_than_t<value_t> select_op{5};
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -265,8 +265,8 @@ CUB_TEST_CASE("Device partition uses custom stream", "[partition][device]", CUB_
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   REQUIRE(d_out == expected_output);
@@ -325,7 +325,7 @@ CUB_TEST("DevicePartition::If can be tuned", "[partition][device]", CUB_SMALL, b
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(partition_policy_selector<target_block_size>{});
 
@@ -342,7 +342,7 @@ CUB_TEST("DevicePartition::Flagged can be tuned", "[partition][device]", CUB_SMA
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(partition_policy_selector<target_block_size>{});
 
@@ -369,8 +369,8 @@ CUB_TEST("DevicePartition::If three-way can be tuned", "[partition][device]", CU
   auto d_num_selected                      = c2h::device_vector<int>(2);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<less_than_7_t> small_selector{thrust::raw_pointer_cast(d_block_size.data())};
-  greater_than_t<int> large_selector{50};
+  const block_size_extracting_op<less_than_7_t> small_selector{thrust::raw_pointer_cast(d_block_size.data())};
+  const greater_than_t<int> large_selector{50};
 
   auto env = cuda::execution::tune(three_way_partition_policy_selector<target_block_size>{});
 

--- a/cub/test/catch2_test_device_partition_env_api.cu
+++ b/cub/test/catch2_test_device_partition_env_api.cu
@@ -33,10 +33,10 @@ CUB_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]",
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
   auto output       = thrust::device_vector<int>(8);
   auto num_selected = thrust::device_vector<int>(1);
-  less_than_t<int> le{5};
+  const less_than_t<int> le{5};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error =
     cub::DevicePartition::If(input.begin(), output.begin(), num_selected.begin(), input.size(), le, stream_ref);
@@ -46,8 +46,8 @@ CUB_TEST("cub::DevicePartition::If accepts env with stream", "[partition][env]",
   }
 
   // Selected items (< 5) at front, unselected items (>= 5) at back in reverse order
-  thrust::device_vector<int> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 2, 3, 4, 8, 7, 6, 5};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-if-env
   stream.sync();
 
@@ -64,8 +64,8 @@ CUB_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
   auto output       = thrust::device_vector<int>(8);
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DevicePartition::Flagged(
     input.begin(), flags.begin(), output.begin(), num_selected.begin(), input.size(), stream_ref);
@@ -75,8 +75,8 @@ CUB_TEST("cub::DevicePartition::Flagged accepts env with stream", "[partition][e
   }
 
   // Selected items (flagged) at front, unselected items at back in reverse order
-  thrust::device_vector<int> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 4, 6, 7, 8, 5, 3, 2};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end partition-flagged-env
   stream.sync();
 
@@ -94,11 +94,11 @@ CUB_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partiti
   auto unselected_out   = thrust::device_vector<int>(8);
   auto num_selected_out = thrust::device_vector<int>(2);
 
-  less_than_t<int> small_selector{7};
-  greater_than_t<int> large_selector{50};
+  const less_than_t<int> small_selector{7};
+  const greater_than_t<int> large_selector{50};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DevicePartition::If(
     input.begin(),
@@ -115,8 +115,8 @@ CUB_TEST("cub::DevicePartition::If three-way accepts env with stream", "[partiti
     std::cerr << "cub::DevicePartition::If three-way failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_small{0, 2, 3, 5, 2};
-  thrust::device_vector<int> expected_large{81};
+  const thrust::device_vector<int> expected_small{0, 2, 3, 5, 2};
+  const thrust::device_vector<int> expected_large{81};
   // example-end partition-three-way-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -171,7 +171,7 @@ CUB_TEST("DevicePartition::Flagged does not change input", "[device][partition_f
   int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
 
   partition_flagged(in.begin(), flags.begin(), out.begin(), d_num_selected_out, num_items);
 
@@ -268,26 +268,26 @@ CUB_TEST("DevicePartition::Flagged works with user provided memory and environme
 
   SECTION("DevicePartition::Flagged works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_partition_flagged(stream.get());
   }
 
   SECTION("DevicePartition::Flagged works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_partition_flagged(stream);
   }
 
   SECTION("DevicePartition::Flagged works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_partition_flagged(stream_ref);
   }
 
   SECTION("DevicePartition::Flagged works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_partition_flagged(env);
   }
 
@@ -299,7 +299,7 @@ CUB_TEST("DevicePartition::Flagged works with user provided memory and environme
 
   SECTION("DevicePartition::Flagged works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_partition_flagged(policy);
   }

--- a/cub/test/catch2_test_device_partition_if.cu
+++ b/cub/test/catch2_test_device_partition_if.cu
@@ -130,14 +130,14 @@ CUB_TEST("DevicePartition::If does not change input", "[device][partition_if]", 
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
 
   partition_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, le);
 
@@ -154,7 +154,7 @@ CUB_TEST("DevicePartition::If is stable", "[device][partition_if]", CUB_SMALL)
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -239,26 +239,26 @@ CUB_TEST(
 
   SECTION("DevicePartition::If works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_partition_if(stream.get());
   }
 
   SECTION("DevicePartition::If works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_partition_if(stream);
   }
 
   SECTION("DevicePartition::If works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_partition_if(stream_ref);
   }
 
   SECTION("DevicePartition::If works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_partition_if(env);
   }
 
@@ -270,7 +270,7 @@ CUB_TEST(
 
   SECTION("DevicePartition::If works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_partition_if(policy);
   }
@@ -287,7 +287,7 @@ CUB_TEST("DevicePartition::If works with iterators", "[device][partition_if]", C
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -316,7 +316,7 @@ CUB_TEST("DevicePartition::If works with pointers", "[device][partition_if]", CU
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -366,7 +366,7 @@ CUB_TEST("DevicePartition::If works with a different output type", "[device][par
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);

--- a/cub/test/catch2_test_device_radix_sort_custom.cu
+++ b/cub/test/catch2_test_device_radix_sort_custom.cu
@@ -119,8 +119,8 @@ get_permutation(const c2h::host_vector<key>& h_keys, bool is_descending, int beg
 static c2h::device_vector<key>
 reference_sort_keys(const c2h::device_vector<key>& d_keys, bool is_descending, int begin_bit, int end_bit)
 {
-  c2h::host_vector<key> h_keys(d_keys);
-  c2h::host_vector<std::size_t> h_permutation = get_permutation(h_keys, is_descending, begin_bit, end_bit);
+  const c2h::host_vector<key> h_keys(d_keys);
+  const c2h::host_vector<std::size_t> h_permutation = get_permutation(h_keys, is_descending, begin_bit, end_bit);
   c2h::host_vector<key> result(d_keys.size());
   thrust::gather(h_permutation.cbegin(), h_permutation.cend(), h_keys.cbegin(), result.begin());
   return result;
@@ -133,9 +133,9 @@ static std::pair<c2h::device_vector<key>, c2h::device_vector<value>> reference_s
   int begin_bit,
   int end_bit)
 {
-  c2h::host_vector<key> h_keys(d_keys);
-  c2h::host_vector<value> h_values(d_values);
-  c2h::host_vector<std::size_t> h_permutation = get_permutation(h_keys, is_descending, begin_bit, end_bit);
+  const c2h::host_vector<key> h_keys(d_keys);
+  const c2h::host_vector<value> h_values(d_values);
+  const c2h::host_vector<std::size_t> h_permutation = get_permutation(h_keys, is_descending, begin_bit, end_bit);
 
   c2h::host_vector<key> result_keys(d_keys.size());
   c2h::host_vector<value> result_values(d_values.size());
@@ -262,7 +262,7 @@ CUB_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][devic
   keys.selector = action.selector();
   action.finalize();
 
-  c2h::device_vector<key>& out_keys = keys.Current() == d_keys_1 ? keys_1 : keys_2;
+  const c2h::device_vector<key>& out_keys = keys.Current() == d_keys_1 ? keys_1 : keys_2;
 
   REQUIRE(reference_keys == out_keys);
 }
@@ -302,8 +302,8 @@ CUB_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][
   values.selector = action.selector();
   action.finalize();
 
-  c2h::device_vector<key>& out_keys     = keys.Current() == d_keys_1 ? keys_1 : keys_2;
-  c2h::device_vector<value>& out_values = values.Current() == d_values_1 ? values_1 : values_2;
+  const c2h::device_vector<key>& out_keys     = keys.Current() == d_keys_1 ? keys_1 : keys_2;
+  const c2h::device_vector<value>& out_values = values.Current() == d_values_1 ? values_1 : values_2;
 
   REQUIRE(reference_keys.first == out_keys);
   REQUIRE(reference_keys.second == out_values);
@@ -425,7 +425,7 @@ CUB_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sor
   keys.selector = action.selector();
   action.finalize();
 
-  c2h::device_vector<key>& out_keys = keys.Current() == d_keys_1 ? keys_1 : keys_2;
+  const c2h::device_vector<key>& out_keys = keys.Current() == d_keys_1 ? keys_1 : keys_2;
 
   REQUIRE(reference_keys == out_keys);
 }
@@ -466,8 +466,8 @@ CUB_TEST("Device radix sort works with bits of custom i128_t keys (db)", "[radix
   values.selector = action.selector();
   action.finalize();
 
-  c2h::device_vector<key>& out_keys     = keys.Current() == d_keys_1 ? keys_1 : keys_2;
-  c2h::device_vector<value>& out_values = values.Current() == d_values_1 ? values_1 : values_2;
+  const c2h::device_vector<key>& out_keys     = keys.Current() == d_keys_1 ? keys_1 : keys_2;
+  const c2h::device_vector<value>& out_values = values.Current() == d_values_1 ? values_1 : values_2;
 
   REQUIRE(reference_keys.first == out_keys);
   REQUIRE(reference_keys.second == out_values);
@@ -543,7 +543,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
     // 3) Sort keys
     cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2}, //
@@ -585,7 +585,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
 
     cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {+3.7f, 0}, //
       {+2.5f, 1}, //
       {+1.1f, 2}, //
@@ -635,7 +635,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
     cub::DeviceRadixSort::SortPairs(
       d_temp_storage, temp_storage_bytes, d_keys_in, d_keys_out, d_vals_in, d_vals_out, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2}, //
@@ -644,7 +644,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
       {+3.7f, 5} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1, 2, 3, 4, 5};
+    const c2h::device_vector<int> expected_vals = {0, 1, 2, 3, 4, 5};
     // example-end pairs
 
     REQUIRE(expected_keys == keys_out);
@@ -688,7 +688,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
     cub::DeviceRadixSort::SortPairsDescending(
       d_temp_storage, temp_storage_bytes, d_keys_in, d_keys_out, d_vals_in, d_vals_out, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {+3.7f, 0}, //
       {+2.5f, 1}, //
       {+1.1f, 2}, //
@@ -697,7 +697,7 @@ CUB_TEST("Device radix sort works against some corner cases", "[radix][sort][dev
       {-2.5f, 5} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1, 2, 4, 3, 5};
+    const c2h::device_vector<int> expected_vals = {0, 1, 2, 4, 3, 5};
     // example-end pairs-descending
 
     REQUIRE(expected_keys == keys_out);
@@ -738,10 +738,10 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
 
     cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t>& current = //
+    const c2h::device_vector<custom_t>& current = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2}, //
@@ -785,10 +785,10 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
 
     cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes, d_keys, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t>& current = //
+    const c2h::device_vector<custom_t>& current = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {+3.7f, 0}, //
       {+2.5f, 1}, //
       {+1.1f, 2}, //
@@ -839,13 +839,13 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
 
     cub::DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, d_keys, d_vals, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<int>& current_vals = //
+    const c2h::device_vector<int>& current_vals = //
       d_vals.Current() == d_vals_buf ? vals_buf : vals_alt_buf;
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2}, //
@@ -854,7 +854,7 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
       {+3.7f, 5} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1, 2, 3, 4, 5};
+    const c2h::device_vector<int> expected_vals = {0, 1, 2, 3, 4, 5};
     // example-end pairs-db
 
     REQUIRE(expected_keys == current_keys);
@@ -901,13 +901,13 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
     cub::DeviceRadixSort::SortPairsDescending(
       d_temp_storage, temp_storage_bytes, d_keys, d_vals, num_items, decomposer_t{});
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<int>& current_vals = //
+    const c2h::device_vector<int>& current_vals = //
       d_vals.Current() == d_vals_buf ? vals_buf : vals_alt_buf;
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {+3.7f, 0}, //
       {+2.5f, 1}, //
       {+1.1f, 2}, //
@@ -916,7 +916,7 @@ CUB_TEST("Device radix sort works against some corner cases (db)", "[radix][sort
       {-2.5f, 5} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1, 2, 4, 3, 5};
+    const c2h::device_vector<int> expected_vals = {0, 1, 2, 4, 3, 5};
     // example-end pairs-descending-db
 
     REQUIRE(expected_keys == current_keys);
@@ -972,7 +972,7 @@ CUB_TEST("Device radix sort works against some corner cases (bits)", "[radix][so
     cub::DeviceRadixSort::SortKeys(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {42.4f, 1ll << 60}, //
       {24.2f, 1ll << 61} //
     };
@@ -1024,7 +1024,7 @@ CUB_TEST("Device radix sort works against some corner cases (bits)", "[radix][so
     cub::DeviceRadixSort::SortKeysDescending(
       d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {24.2f, 1ll << 61}, //
       {42.4f, 1ll << 60} //
     };
@@ -1102,12 +1102,12 @@ CUB_TEST("Device radix sort works against some corner cases (bits)", "[radix][so
       begin_bit,
       end_bit);
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {42.4f, 1ll << 60}, //
       {24.2f, 1ll << 61} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1};
+    const c2h::device_vector<int> expected_vals = {0, 1};
     // example-end pairs-bits
 
     REQUIRE(expected_keys == keys_out);
@@ -1183,12 +1183,12 @@ CUB_TEST("Device radix sort works against some corner cases (bits)", "[radix][so
       begin_bit,
       end_bit);
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {24.2f, 1ll << 61}, //
       {42.4f, 1ll << 60} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1};
+    const c2h::device_vector<int> expected_vals = {0, 1};
     // example-end pairs-descending-bits
 
     REQUIRE(expected_keys == keys_out);
@@ -1247,10 +1247,10 @@ CUB_TEST("Device radix sort works against some corner cases (bits) (db)", "[radi
     cub::DeviceRadixSort::SortKeys(
       d_temp_storage, temp_storage_bytes, d_keys, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {42.4f, 1ll << 60}, //
       {24.2f, 1ll << 61} //
     };
@@ -1308,10 +1308,10 @@ CUB_TEST("Device radix sort works against some corner cases (bits) (db)", "[radi
     cub::DeviceRadixSort::SortKeysDescending(
       d_temp_storage, temp_storage_bytes, d_keys, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<custom_t> expected_output = {
+    const c2h::device_vector<custom_t> expected_output = {
       {24.2f, 1ll << 61}, //
       {42.4f, 1ll << 60} //
     };
@@ -1374,18 +1374,18 @@ CUB_TEST("Device radix sort works against some corner cases (bits) (db)", "[radi
     cub::DeviceRadixSort::SortPairs(
       d_temp_storage, temp_storage_bytes, d_keys, d_vals, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<int>& current_vals = //
+    const c2h::device_vector<int>& current_vals = //
       d_vals.Current() == d_vals_buf ? vals_buf : vals_alt_buf;
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {42.4f, 1ll << 60}, //
       {24.2f, 1ll << 61} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1};
+    const c2h::device_vector<int> expected_vals = {0, 1};
     // example-end pairs-bits-db
 
     REQUIRE(expected_keys == current_keys);
@@ -1447,18 +1447,18 @@ CUB_TEST("Device radix sort works against some corner cases (bits) (db)", "[radi
     cub::DeviceRadixSort::SortPairsDescending(
       d_temp_storage, temp_storage_bytes, d_keys, d_vals, num_items, decomposer_t{}, begin_bit, end_bit);
 
-    c2h::device_vector<custom_t>& current_keys = //
+    const c2h::device_vector<custom_t>& current_keys = //
       d_keys.Current() == d_keys_buf ? keys_buf : keys_alt_buf;
 
-    c2h::device_vector<int>& current_vals = //
+    const c2h::device_vector<int>& current_vals = //
       d_vals.Current() == d_vals_buf ? vals_buf : vals_alt_buf;
 
-    c2h::device_vector<custom_t> expected_keys = {
+    const c2h::device_vector<custom_t> expected_keys = {
       {24.2f, 1ll << 61}, //
       {42.4f, 1ll << 60} //
     };
 
-    c2h::device_vector<int> expected_vals = {0, 1};
+    const c2h::device_vector<int> expected_vals = {0, 1};
     // example-end pairs-descending-bits-db
 
     REQUIRE(expected_keys == current_keys);

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -103,8 +103,8 @@ CUB_TEST_CASE("Device radix sort pairs works with default environment", "[radix_
             values_out.data().get(),
             static_cast<int>(keys_in.size())));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -125,8 +125,8 @@ CUB_TEST_CASE("Device radix sort pairs descending works with default environment
             values_out.data().get(),
             static_cast<int>(keys_in.size())));
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -145,7 +145,7 @@ CUB_TEST_CASE("Device radix sort keys works with default environment", "[radix_s
             0,
             static_cast<int>(static_cast<int>(sizeof(int) * 8))));
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
 
   REQUIRE(keys_out == expected_keys);
 }
@@ -159,7 +159,7 @@ CUB_TEST_CASE("Device radix sort keys descending works with default environment"
           == cub::DeviceRadixSort::SortKeysDescending(
             keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
 
   REQUIRE(keys_out == expected_keys);
 }
@@ -179,7 +179,7 @@ CUB_TEST_CASE("Device radix sort keys decomposer+bits works with default environ
       0,
       static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
 }
 
@@ -192,7 +192,7 @@ CUB_TEST_CASE("Device radix sort keys decomposer works with default environment"
           == cub::DeviceRadixSort::SortKeys(
             keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
 }
 
@@ -206,7 +206,7 @@ CUB_TEST_CASE("Device radix sort keys DB decomposer works with default environme
   REQUIRE(
     cudaSuccess == cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -224,7 +224,7 @@ CUB_TEST_CASE("Device radix sort keys DB decomposer+bits works with default envi
           == cub::DeviceRadixSort::SortKeys(
             d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -246,9 +246,9 @@ CUB_TEST_CASE("Device radix sort pairs decomposer works with default environment
       static_cast<int>(keys_in.size()),
       pairs_decomposer_t{}));
 
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values_out == expected_values);
 }
 
@@ -273,9 +273,9 @@ CUB_TEST_CASE("Device radix sort pairs decomposer with bits works with default e
       0,
       sizeof(int) * 8));
 
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values_out == expected_values);
 }
 
@@ -296,7 +296,7 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer+bits works with defa
       0,
       static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
 }
 
@@ -311,7 +311,7 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer works with default e
           == cub::DeviceRadixSort::SortKeysDescending(
             keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
 }
 
@@ -327,7 +327,7 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer works with defaul
   REQUIRE(cudaSuccess
           == cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -345,7 +345,7 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer+bits works with d
           == cub::DeviceRadixSort::SortKeysDescending(
             d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -371,8 +371,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer+bits works with def
       0,
       static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -396,8 +396,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer works with default 
       static_cast<int>(keys_in.size()),
       keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -418,8 +418,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer works with defau
           == cub::DeviceRadixSort::SortPairsDescending(
             d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}));
 
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);
@@ -443,8 +443,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer+bits works with 
     == cub::DeviceRadixSort::SortPairsDescending(
       d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8)));
 
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);
@@ -485,8 +485,8 @@ CUB_TEST("Device radix sort pairs uses environment", "[radix_sort][device]", CUB
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -523,8 +523,8 @@ CUB_TEST("Device radix sort pairs descending uses environment", "[radix_sort][de
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -551,7 +551,7 @@ CUB_TEST("Device radix sort keys uses environment", "[radix_sort][device]", CUB_
     static_cast<int>(static_cast<int>(sizeof(int) * 8)),
     env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
 
   REQUIRE(keys_out == expected_keys);
 }
@@ -583,7 +583,7 @@ CUB_TEST("Device radix sort keys descending uses environment", "[radix_sort][dev
     static_cast<int>(static_cast<int>(sizeof(int) * 8)),
     env);
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
 
   REQUIRE(keys_out == expected_keys);
 }
@@ -595,7 +595,7 @@ CUB_TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -609,7 +609,7 @@ CUB_TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device
       values_out.data().get(),
       static_cast<int>(keys_in.size())));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_pairs(
@@ -624,8 +624,8 @@ CUB_TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device
 
   custom_stream.sync();
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -638,7 +638,7 @@ CUB_TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_s
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -652,7 +652,7 @@ CUB_TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_s
       values_out.data().get(),
       static_cast<int>(keys_in.size())));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_pairs_descending(
@@ -667,8 +667,8 @@ CUB_TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_s
 
   custom_stream.sync();
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
@@ -679,7 +679,7 @@ CUB_TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -687,7 +687,7 @@ CUB_TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]
     == cub::DeviceRadixSort::SortKeys(
       nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_keys(
@@ -699,7 +699,7 @@ CUB_TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]
     env);
 
   custom_stream.sync();
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -708,7 +708,7 @@ CUB_TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_so
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -716,7 +716,7 @@ CUB_TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_so
     == cub::DeviceRadixSort::SortKeysDescending(
       nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_keys_descending(
@@ -728,7 +728,7 @@ CUB_TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_so
     env);
 
   custom_stream.sync();
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -739,8 +739,8 @@ CUB_TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_s
   auto values_in  = c2h::device_vector<int>{0, 1, 2};
   auto values_out = c2h::device_vector<int>(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   REQUIRE(
     cudaSuccess
@@ -755,9 +755,9 @@ CUB_TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_s
 
   stream.sync();
 
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values_out == expected_values);
 }
 
@@ -778,10 +778,10 @@ CUB_TEST_CASE("Device radix sort pairs DB decomposer works with default environm
     == cub::DeviceRadixSort::SortPairs(d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}));
 
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values == expected_values);
 }
 
@@ -802,10 +802,10 @@ CUB_TEST_CASE("Device radix sort pairs DB decomposer with bits works with defaul
             d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, 0, sizeof(int) * 8));
 
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values == expected_values);
 }
 
@@ -821,8 +821,8 @@ CUB_TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radi
   cub::DoubleBuffer<custom_pair_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   REQUIRE(cudaSuccess
           == cub::DeviceRadixSort::SortPairs(
@@ -831,10 +831,10 @@ CUB_TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radi
   stream.sync();
 
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
-  c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const c2h::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
-  c2h::device_vector<int> expected_values{1, 2, 0};
+  const c2h::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values == expected_values);
 }
 
@@ -843,8 +843,8 @@ CUB_TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[rad
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -859,7 +859,7 @@ CUB_TEST_CASE("Device radix sort keys decomposer+bits uses custom stream", "[rad
       env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
 }
 
@@ -868,8 +868,8 @@ CUB_TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_so
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(cudaSuccess
@@ -877,7 +877,7 @@ CUB_TEST_CASE("Device radix sort keys decomposer uses custom stream", "[radix_so
             keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   REQUIRE(keys_out == expected);
 }
 
@@ -888,15 +888,15 @@ CUB_TEST_CASE("Device radix sort keys DB decomposer uses custom stream", "[radix
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(cudaSuccess
           == cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -908,8 +908,8 @@ CUB_TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -918,7 +918,7 @@ CUB_TEST_CASE("Device radix sort keys DB decomposer+bits uses custom stream", "[
       d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const c2h::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -928,8 +928,8 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer+bits uses custom str
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -944,7 +944,7 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer+bits uses custom str
       env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
 }
 
@@ -953,8 +953,8 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer uses custom stream",
   auto keys_in  = c2h::device_vector<custom_key_t>{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   auto keys_out = c2h::device_vector<custom_key_t>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(cudaSuccess
@@ -962,7 +962,7 @@ CUB_TEST_CASE("Device radix sort keys descending decomposer uses custom stream",
             keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   REQUIRE(keys_out == expected);
 }
 
@@ -973,8 +973,8 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer uses custom strea
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -982,7 +982,7 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer uses custom strea
     == cub::DeviceRadixSort::SortKeysDescending(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -996,8 +996,8 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom 
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -1006,7 +1006,7 @@ CUB_TEST_CASE("Device radix sort keys descending DB decomposer+bits uses custom 
       d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, static_cast<int>(sizeof(int) * 8), env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected);
 }
@@ -1018,8 +1018,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom st
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -1036,8 +1036,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer+bits uses custom st
       env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -1049,8 +1049,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer uses custom stream"
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -1065,8 +1065,8 @@ CUB_TEST_CASE("Device radix sort pairs descending decomposer uses custom stream"
       env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -1081,8 +1081,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stre
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(cudaSuccess
@@ -1090,8 +1090,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer uses custom stre
             d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);
@@ -1110,8 +1110,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = stdexec::env{stream_ref};
 
   REQUIRE(
@@ -1126,8 +1126,8 @@ CUB_TEST_CASE("Device radix sort pairs descending DB decomposer+bits uses custom
       env));
 
   stream.sync();
-  c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   auto& keys   = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
   REQUIRE(keys == expected_keys);
@@ -1164,7 +1164,7 @@ struct tiny_onesweep_policy_selector
 template <typename CallableT, typename PolicySelector>
 std::size_t measure_allocated_bytes(CallableT&& run, PolicySelector policy_selector)
 {
-  cuda::stream_ref stream{cudaStream_t{}};
+  const cuda::stream_ref stream{cudaStream_t{}};
   size_t bytes_allocated   = 0;
   size_t bytes_deallocated = 0;
   auto env                 = stdexec::env{device_memory_resource{stream.get(), &bytes_allocated, &bytes_deallocated},

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -98,8 +98,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]", C
     std::cerr << "cub::DeviceRadixSort::SortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end radix-sort-pairs-env
 
   REQUIRE(error == cudaSuccess);
@@ -127,8 +127,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort
     std::cerr << "cub::DeviceRadixSort::SortPairsDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-env
 
   REQUIRE(error == cudaSuccess);
@@ -150,7 +150,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys env-based API", "[radix_sort][env]", CU
     std::cerr << "cub::DeviceRadixSort::SortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end radix-sort-keys-env
 
   REQUIRE(error == cudaSuccess);
@@ -172,7 +172,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_so
     std::cerr << "cub::DeviceRadixSort::SortKeys (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   // example-end radix-sort-keys-db-env
 
   REQUIRE(error == cudaSuccess);
@@ -194,7 +194,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort]
     std::cerr << "cub::DeviceRadixSort::SortKeysDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   // example-end radix-sort-keys-descending-env
 
   REQUIRE(error == cudaSuccess);
@@ -216,7 +216,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", 
     std::cerr << "cub::DeviceRadixSort::SortKeysDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const thrust::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   // example-end radix-sort-keys-descending-db-env
 
   REQUIRE(error == cudaSuccess);
@@ -232,8 +232,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "
   auto values_in  = thrust::device_vector<int>{0, 1, 2};
   auto values_out = thrust::device_vector<int>(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairs(
     keys_in.data().get(),
@@ -253,9 +253,9 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
-  thrust::device_vector<int> expected_values{1, 2, 0};
+  const thrust::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values_out == expected_values);
 }
 
@@ -267,8 +267,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sor
   auto values_in  = thrust::device_vector<int>{0, 1, 2};
   auto values_out = thrust::device_vector<int>(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairs(
     keys_in.data().get(),
@@ -286,9 +286,9 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sor
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys_out == expected_keys);
-  thrust::device_vector<int> expected_values{1, 2, 0};
+  const thrust::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values_out == expected_values);
 }
 
@@ -303,8 +303,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API"
   cub::DoubleBuffer<custom_pair_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairs(
     d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, stream_ref);
@@ -317,10 +317,10 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API"
 
   REQUIRE(error == cudaSuccess);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
-  thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
-  thrust::device_vector<int> expected_values{1, 2, 0};
+  const thrust::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values == expected_values);
 }
 
@@ -337,8 +337,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-
   cub::DoubleBuffer<custom_pair_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairs(
     d_keys, d_values, static_cast<int>(keys_buf0.size()), pairs_decomposer_t{}, 0, sizeof(int) * 8, stream_ref);
@@ -351,10 +351,10 @@ CUB_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-
 
   REQUIRE(error == cudaSuccess);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
-  thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
+  const thrust::device_vector<custom_pair_key_t> expected_keys{{1, 200}, {2, 300}, {3, 100}};
   REQUIRE(keys == expected_keys);
   auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
-  thrust::device_vector<int> expected_values{1, 2, 0};
+  const thrust::device_vector<int> expected_values{1, 2, 0};
   REQUIRE(values == expected_values);
 }
 
@@ -364,8 +364,8 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   thrust::device_vector<custom_key_t> keys_out(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeys(
     keys_in.data().get(),
@@ -376,7 +376,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys decomposer+bits env-based API", "[radix
     sizeof(int) * 8,
     stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   // example-end radix-sort-keys-decomposer-bits-env
   stream.sync();
 
@@ -390,13 +390,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys decomposer env-based API", "[radix_sort
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   thrust::device_vector<custom_key_t> keys_out(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeys(
     keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   // example-end radix-sort-keys-decomposer-env
   stream.sync();
 
@@ -412,13 +412,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys DB decomposer env-based API", "[radix_s
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error =
     cub::DeviceRadixSort::SortKeys(d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   // example-end radix-sort-keys-db-decomposer-env
   stream.sync();
 
@@ -435,13 +435,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeys DB decomposer+bits env-based API", "[ra
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeys(
     d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, sizeof(int) * 8, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
+  const thrust::device_vector<custom_key_t> expected{{0}, {3}, {5}, {6}, {7}, {8}, {9}};
   // example-end radix-sort-keys-db-decomposer-bits-env
   stream.sync();
 
@@ -456,8 +456,8 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   thrust::device_vector<custom_key_t> keys_out(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeysDescending(
     keys_in.data().get(),
@@ -468,7 +468,7 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer+bits env-based API
     sizeof(int) * 8,
     stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   // example-end radix-sort-keys-descending-decomposer-bits-env
   stream.sync();
 
@@ -482,13 +482,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending decomposer env-based API", "[
   thrust::device_vector<custom_key_t> keys_in{{8}, {6}, {7}, {5}, {3}, {0}, {9}};
   thrust::device_vector<custom_key_t> keys_out(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeysDescending(
     keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size()), keys_decomposer_t{}, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   // example-end radix-sort-keys-descending-decomposer-env
   stream.sync();
 
@@ -504,13 +504,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer env-based API",
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeysDescending(
     d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   // example-end radix-sort-keys-descending-db-decomposer-env
   stream.sync();
 
@@ -527,13 +527,13 @@ CUB_TEST("cub::DeviceRadixSort::SortKeysDescending DB decomposer+bits env-based 
 
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortKeysDescending(
     d_keys, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, sizeof(int) * 8, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<custom_key_t> expected{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
   // example-end radix-sort-keys-descending-db-decomposer-bits-env
   stream.sync();
 
@@ -550,8 +550,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based AP
   auto values_in  = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = thrust::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairsDescending(
     keys_in.data().get(),
@@ -564,8 +564,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer+bits env-based AP
     sizeof(int) * 8,
     stream_ref);
 
-  thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-decomposer-bits-env
   stream.sync();
 
@@ -582,8 +582,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "
   auto values_in  = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = thrust::device_vector<int>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairsDescending(
     keys_in.data().get(),
@@ -594,8 +594,8 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending decomposer env-based API", "
     keys_decomposer_t{},
     stream_ref);
 
-  thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-decomposer-env
   stream.sync();
 
@@ -615,14 +615,14 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer env-based API"
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairsDescending(
     d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-db-decomposer-env
   stream.sync();
 
@@ -644,14 +644,14 @@ CUB_TEST("cub::DeviceRadixSort::SortPairsDescending DB decomposer+bits env-based
   cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
   cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRadixSort::SortPairsDescending(
     d_keys, d_values, static_cast<int>(keys_buf0.size()), keys_decomposer_t{}, 0, sizeof(int) * 8, stream_ref);
 
-  thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
-  thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const thrust::device_vector<custom_key_t> expected_keys{{9}, {8}, {7}, {6}, {5}, {3}, {0}};
+  const thrust::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   // example-end radix-sort-pairs-descending-db-decomposer-bits-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -157,7 +157,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 
     // Prepare verification data
     using accum_t = cuda::std::__accumulator_t<op_t, item_t, output_t>;
-    output_t expected_result =
+    const output_t expected_result =
       static_cast<output_t>(compute_single_problem_reference(in_items, reduction_op, accum_t{}));
 
     // Run test
@@ -180,7 +180,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     using accum_t = cuda::std::__accumulator_t<op_t, item_t, output_t>;
 
     // Prepare verification data
-    output_t expected_result = static_cast<output_t>(compute_single_problem_reference(in_items, op_t{}, accum_t{}));
+    const output_t expected_result =
+      static_cast<output_t>(compute_single_problem_reference(in_items, op_t{}, accum_t{}));
 
     // Run test
     c2h::device_vector<output_t> out_result(num_segments);
@@ -195,7 +196,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("min")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = *std::min_element(host_items.cbegin(), host_items.cend());
 
     // Run test
@@ -210,7 +211,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("max")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = *std::max_element(host_items.cbegin(), host_items.cend());
 
     // Run test
@@ -226,7 +227,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("argmax")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = std::max_element(host_items.cbegin(), host_items.cend());
 
     // Run test
@@ -238,8 +239,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_max(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
 
     // Verify result
-    result_t gpu_result   = out_result[0];
-    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    const result_t gpu_result   = out_result[0];
+    const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_extremum);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }
@@ -283,8 +284,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
       REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
       // Verify result
-      result_t gpu_result   = out_result[0];
-      output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+      const result_t gpu_result   = out_result[0];
+      const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
       REQUIRE(expected_result[0] == gpu_extremum);
       REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
     };
@@ -295,26 +296,26 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 
     SECTION("DeviceReduce::ArgMax works with cudaStream_t")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_argmax(stream.get());
     }
 
     SECTION("DeviceReduce::ArgMax works with cuda::stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_argmax(stream);
     }
 
     SECTION("DeviceReduce::ArgMax works with cuda::stream_ref")
     {
-      cuda::stream stream{cuda::devices[current_device]};
-      cuda::stream_ref stream_ref{stream};
+      const cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream_ref stream_ref{stream};
       test_argmax(stream_ref);
     }
 
     SECTION("DeviceReduce::ArgMax works with cuda::std::execution::env")
     {
-      cuda::std::execution::env env{};
+      const cuda::std::execution::env env{};
       test_argmax(env);
     }
 
@@ -326,7 +327,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 
     SECTION("DeviceReduce::ArgMax works with cuda::execution::gpu with stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
       test_argmax(policy);
     }
@@ -335,7 +336,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("argmin")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = std::min_element(host_items.cbegin(), host_items.cend());
 
     // Run test
@@ -347,8 +348,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_min(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
 
     // Verify result
-    result_t gpu_result   = out_result[0];
-    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    const result_t gpu_result   = out_result[0];
+    const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_extremum);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }
@@ -392,8 +393,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
       REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
       // Verify result
-      result_t gpu_result   = out_result[0];
-      output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+      const result_t gpu_result   = out_result[0];
+      const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
       REQUIRE(expected_result[0] == gpu_extremum);
       REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
     };
@@ -404,26 +405,26 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 
     SECTION("DeviceReduce::ArgMin works with cudaStream_t")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_argmin(stream.get());
     }
 
     SECTION("DeviceReduce::ArgMin works with cuda::stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       test_argmin(stream);
     }
 
     SECTION("DeviceReduce::ArgMin works with cuda::stream_ref")
     {
-      cuda::stream stream{cuda::devices[current_device]};
-      cuda::stream_ref stream_ref{stream};
+      const cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream_ref stream_ref{stream};
       test_argmin(stream_ref);
     }
 
     SECTION("DeviceReduce::ArgMin works with cuda::std::execution::env")
     {
-      cuda::std::execution::env env{};
+      const cuda::std::execution::env env{};
       test_argmin(env);
     }
 
@@ -435,7 +436,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 
     SECTION("DeviceReduce::ArgMin works with cuda::execution::gpu with stream")
     {
-      cuda::stream stream{cuda::devices[current_device]};
+      const cuda::stream stream{cuda::devices[current_device]};
       const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
       test_argmin(policy);
     }
@@ -444,7 +445,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("argmax deprecated interface")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = std::max_element(host_items.cbegin(), host_items.cend());
 
     // Run test using the deprecated interface
@@ -453,8 +454,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_max_old(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
 
     // Verify result for the deprecated interface
-    result_t gpu_result = out_result[0];
-    output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
+    const result_t gpu_result = out_result[0];
+    const output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_value);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.key);
   }
@@ -462,7 +463,7 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
   SECTION("argmin deprecated interface")
   {
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = std::min_element(host_items.cbegin(), host_items.cend());
 
     // Run test using the deprecated interface
@@ -471,8 +472,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_min_old(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
 
     // Verify result for the deprecated interface
-    result_t gpu_result = out_result[0];
-    output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
+    const result_t gpu_result = out_result[0];
+    const output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_value);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.key);
   }
@@ -480,10 +481,10 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
 #  if TEST_TYPES < 2
   SECTION("argmin-abs_less_t")
   {
-    abs_less_t compare_op;
+    const abs_less_t compare_op;
 
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
 
     // Run test
@@ -495,18 +496,18 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_min(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, compare_op);
 
     // Verify result
-    result_t gpu_result   = out_result[0];
-    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    const result_t gpu_result   = out_result[0];
+    const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_extremum);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }
 
   SECTION("argmax-abs_less_t")
   {
-    abs_less_t compare_op;
+    const abs_less_t compare_op;
 
     // Prepare verification data
-    c2h::host_vector<item_t> host_items(in_items);
+    const c2h::host_vector<item_t> host_items(in_items);
     auto expected_result = cuda::std::max_element(host_items.cbegin(), host_items.cend(), compare_op);
 
     // Run test
@@ -518,8 +519,8 @@ CUB_TEST("Device reduce works with all device interfaces", "[reduce][device]", C
     device_arg_max(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items, compare_op);
 
     // Verify result
-    result_t gpu_result   = out_result[0];
-    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    const result_t gpu_result   = out_result[0];
+    const output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_extremum);
     REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -211,8 +211,8 @@ inline AccumulatorT
 compute_single_problem_reference(const c2h::device_vector<ItemT>& d_in, ReductionOpT reduction_op, AccumulatorT init)
 {
   constexpr std::size_t num_segments = 1;
-  c2h::host_vector<ItemT> h_items(d_in);
-  c2h::host_vector<AccumulatorT> h_results(num_segments);
+  const c2h::host_vector<ItemT> h_items(d_in);
+  const c2h::host_vector<AccumulatorT> h_results(num_segments);
 
   return compute_single_problem_reference(h_items.cbegin(), h_items.cend(), reduction_op, init);
 }
@@ -229,13 +229,13 @@ void compute_segmented_problem_reference(
   AccumulatorT init,
   ResultItT h_results)
 {
-  c2h::host_vector<ItemT> h_items(d_in);
-  c2h::host_vector<OffsetT> h_offsets(d_offsets);
+  const c2h::host_vector<ItemT> h_items(d_in);
+  const c2h::host_vector<OffsetT> h_offsets(d_offsets);
   auto offsets_it   = h_offsets.cbegin();
   auto seg_sizes_it = cuda::transform_iterator(cuda::counting_iterator(std::size_t{0}), [offsets_it](std::size_t i) {
     return offsets_it[i + 1] - offsets_it[i];
   });
-  std::size_t num_segments = h_offsets.size() - 1;
+  const std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(
     h_items.cbegin(), h_offsets.cbegin(), seg_sizes_it, num_segments, reduction_op, init, h_results);
@@ -253,12 +253,12 @@ void compute_segmented_problem_reference(
   AccumulatorT init,
   ResultItT h_results)
 {
-  c2h::host_vector<OffsetT> h_offsets(d_offsets);
+  const c2h::host_vector<OffsetT> h_offsets(d_offsets);
   auto offsets_it   = h_offsets.cbegin();
   auto seg_sizes_it = cuda::transform_iterator(cuda::counting_iterator(std::size_t{0}), [offsets_it](std::size_t i) {
     return offsets_it[i + 1] - offsets_it[i];
   });
-  std::size_t num_segments = h_offsets.size() - 1;
+  const std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(in_it, h_offsets.cbegin(), seg_sizes_it, num_segments, reduction_op, init, h_results);
 }
@@ -271,7 +271,7 @@ template <typename ItemT, typename OffsetT, typename ResultItT>
 void compute_segmented_argmin_reference(
   const c2h::device_vector<ItemT>& d_in, const c2h::device_vector<OffsetT>& d_offsets, ResultItT h_results)
 {
-  c2h::host_vector<ItemT> h_items(d_in);
+  const c2h::host_vector<ItemT> h_items(d_in);
   c2h::host_vector<OffsetT> h_offsets(d_offsets);
   const auto num_segments = h_offsets.size() - 1;
   for (std::size_t seg = 0; seg < num_segments; seg++)
@@ -284,7 +284,7 @@ void compute_segmented_argmin_reference(
     {
       auto expected_result_it =
         std::min_element(h_items.cbegin() + h_offsets[seg], h_items.cbegin() + h_offsets[seg + 1]);
-      int result_offset =
+      const int result_offset =
         static_cast<int>(cuda::std::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
       h_results[seg] = {result_offset, *expected_result_it};
     }
@@ -299,7 +299,7 @@ template <typename ItemT, typename OffsetT, typename ResultItT>
 void compute_segmented_argmax_reference(
   const c2h::device_vector<ItemT>& d_in, const c2h::device_vector<OffsetT>& d_offsets, ResultItT h_results)
 {
-  c2h::host_vector<ItemT> h_items(d_in);
+  const c2h::host_vector<ItemT> h_items(d_in);
   c2h::host_vector<OffsetT> h_offsets(d_offsets);
   const auto num_segments = h_offsets.size() - 1;
   for (std::size_t seg = 0; seg < num_segments; seg++)
@@ -312,7 +312,7 @@ void compute_segmented_argmax_reference(
     {
       auto expected_result_it =
         std::max_element(h_items.cbegin() + h_offsets[seg], h_items.cbegin() + h_offsets[seg + 1]);
-      int result_offset =
+      const int result_offset =
         static_cast<int>(cuda::std::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
       h_results[seg] = {result_offset, *expected_result_it};
     }
@@ -332,7 +332,7 @@ void compute_fixed_size_segmented_problem_reference(
   AccumulatorT init,
   ResultItT h_results)
 {
-  c2h::host_vector<ItemT> h_items(d_in);
+  const c2h::host_vector<ItemT> h_items(d_in);
   auto h_begin = h_items.cbegin();
 
   for (int segment = 0; segment < num_segments; segment++)
@@ -366,7 +366,7 @@ void compute_fixed_size_segmented_argmax_reference(
       auto seg_begin          = h_begin + static_cast<long>(seg) * segment_size;
       auto seg_end            = seg_begin + segment_size;
       auto expected_result_it = std::max_element(seg_begin, seg_end);
-      int result_offset       = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
+      const int result_offset = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
       h_results[seg]          = {result_offset, *expected_result_it};
     }
   }
@@ -394,7 +394,7 @@ void compute_fixed_size_segmented_argmin_reference(
       auto seg_begin          = h_begin + static_cast<long>(seg) * segment_size;
       auto seg_end            = seg_begin + segment_size;
       auto expected_result_it = std::min_element(seg_begin, seg_end);
-      int result_offset       = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
+      const int result_offset = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
       h_results[seg]          = {result_offset, *expected_result_it};
     }
   }
@@ -430,7 +430,7 @@ inline OutputItT compute_unique_keys_reference(InputItT h_in_begin, std::size_t 
 template <typename ItemT>
 inline c2h::host_vector<ItemT> compute_unique_keys_reference(const c2h::device_vector<ItemT>& d_keys)
 {
-  c2h::host_vector<ItemT> h_keys(d_keys);
+  const c2h::host_vector<ItemT> h_keys(d_keys);
   c2h::host_vector<ItemT> h_unique_keys_out(d_keys.size());
 
   auto end_it = compute_unique_keys_reference(h_keys.cbegin(), h_keys.size(), h_unique_keys_out.begin());

--- a/cub/test/catch2_test_device_reduce_arg_minmax.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax.cu
@@ -250,7 +250,7 @@ CUB_TEST(
   constexpr int num_segments = 1;
 
   // Precompute reference values shared by both APIs
-  c2h::host_vector<item_t> host_items(in_items);
+  const c2h::host_vector<item_t> host_items(in_items);
 
   auto expected_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend());
   const auto expected_min       = static_cast<output_t>(*expected_min_it);
@@ -286,8 +286,8 @@ CUB_TEST(
       d_max_index.data(),
       num_items);
 
-    output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-    output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+    const output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+    const output_t gpu_max = static_cast<output_t>(d_max_out[0]);
     REQUIRE(expected_min == gpu_min);
     REQUIRE(expected_min_index == d_min_index[0]);
     REQUIRE(expected_max == gpu_max);
@@ -300,7 +300,7 @@ CUB_TEST(
     SECTION("abs_less_t")
     {
       const bool last_max = GENERATE(false, true);
-      abs_less_t compare_op;
+      const abs_less_t compare_op;
 
       // First minimum by abs value: first element with smallest |value|
       auto exp_min_it          = cuda::std::min_element(host_items.cbegin(), host_items.cend(), compare_op);
@@ -331,8 +331,8 @@ CUB_TEST(
         num_items,
         compare_op);
 
-      output_t gpu_min = static_cast<output_t>(d_min_out[0]);
-      output_t gpu_max = static_cast<output_t>(d_max_out[0]);
+      const output_t gpu_min = static_cast<output_t>(d_min_out[0]);
+      const output_t gpu_max = static_cast<output_t>(d_max_out[0]);
       REQUIRE(exp_min == gpu_min);
       REQUIRE(exp_min_index == d_min_index[0]);
       REQUIRE(exp_max == gpu_max);

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env.cu
@@ -191,7 +191,7 @@ CUB_TEST("Device ArgMin[Last]Max uses custom stream", "[reduce][device]", CUB_SM
   const auto n                                = static_cast<::cuda::std::int64_t>(input.size());
   const cuda::std::int64_t expected_max_index = last_max ? 2 : 1;
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   const auto error = call_argminmax_api(
     last_max, input.begin(), min_out.begin(), min_index.begin(), max_out.begin(), max_index.begin(), n, stream);
   stream.sync();
@@ -213,7 +213,7 @@ CUB_TEST("Device ArgMin[Last]Max can be tuned", "[reduce][device]", CUB_SMALL, b
 
   c2h::device_vector<unsigned int> d_block_size(1);
   using compare_t = block_size_extracting_op<cuda::std::less<>>;
-  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   // The maximum value 4 appears twice, so first-max and last-max disagree on the reported index.
   auto input     = c2h::device_vector<int>{3, 4, 4, 0, 2};

--- a/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_arg_minmax_env_api.cu
@@ -23,7 +23,7 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax API example", "[reduce][env]", CUB_SMALL)
   auto max_output = thrust::device_vector<float>(1, thrust::no_init);
   auto max_index  = thrust::device_vector<cuda::std::int64_t>(1, thrust::no_init);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   auto error = cub::DeviceReduce::ArgMinMax(
     input.begin(),
@@ -38,10 +38,10 @@ CUB_TEST("cub::DeviceReduce::ArgMinMax API example", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::ArgMinMax failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_min{0.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
-  thrust::device_vector<float> expected_max{4.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
+  const thrust::device_vector<float> expected_min{0.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_min_index{3};
+  const thrust::device_vector<float> expected_max{4.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_max_index{2};
   // example-end argminmax-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -77,7 +77,7 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
 
   // Get array of keys from segment offsets
@@ -102,7 +102,7 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
     using accum_t = cuda::std::__accumulator_t<op_t, value_t, output_t>;
     c2h::host_vector<output_t> expected_result(num_segments);
     compute_segmented_problem_reference(in_values, segment_offsets, reduction_op, accum_t{}, expected_result.begin());
-    c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
+    const c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
 
     // Run test
     c2h::device_vector<offset_t> num_unique_keys(1);
@@ -133,7 +133,7 @@ CUB_TEST("Device reduce-by-key works", "[by_key][reduce][device]", CUB_SMALL, fu
     c2h::host_vector<output_t> expected_result(num_segments);
     compute_segmented_problem_reference(
       in_values, segment_offsets, op_t{}, cuda::std::numeric_limits<value_t>::max(), expected_result.begin());
-    c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
+    const c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
 
     // Run test
     c2h::device_vector<offset_t> num_unique_keys(1);

--- a/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_custom_policy_hub.cu
@@ -49,8 +49,8 @@ CUB_TEST("DispatchReduceByKey::Dispatch: custom policy hub", "[reduce_by_key][de
   c2h::device_vector<value_t> d_aggregates_out(h_values_in.size());
   c2h::device_vector<offset_t> d_num_runs(1);
 
-  c2h::host_vector<key_t> expected_keys{1, 2, 3};
-  c2h::host_vector<value_t> expected_values{3, 12, 13};
+  const c2h::host_vector<key_t> expected_keys{1, 2, 3};
+  const c2h::host_vector<value_t> expected_values{3, 12, 13};
 
   using policy_hub_t = my_policy_hub<reduction_op_t, accum_t, key_t>;
   using dispatch_t   = cub::DispatchReduceByKey<

--- a/cub/test/catch2_test_device_reduce_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_iterators.cu
@@ -48,7 +48,7 @@ CUB_TEST("Device reduce-by-key works with iterators", "[by_key][reduce][device]"
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
 
   // Get array of keys from segment offsets
@@ -68,7 +68,7 @@ CUB_TEST("Device reduce-by-key works with iterators", "[by_key][reduce][device]"
   using accum_t = cuda::std::__accumulator_t<op_t, value_t, output_t>;
   c2h::host_vector<output_t> expected_result(num_segments);
   compute_segmented_problem_reference(value_it, segment_offsets, op_t{}, accum_t{}, expected_result.begin());
-  c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
+  const c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
 
   // Run test
   c2h::device_vector<offset_t> num_unique_keys(1);

--- a/cub/test/catch2_test_device_reduce_by_key_vsmem.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_vsmem.cu
@@ -36,7 +36,7 @@ CUB_TEST("Device reduce-by-key works with huge keys", "[by_key][reduce][device]"
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
   const offset_t num_segments = static_cast<offset_t>(segment_offsets.size() - 1);
   c2h::device_vector<key_t> segment_keys(num_items);
@@ -55,7 +55,7 @@ CUB_TEST("Device reduce-by-key works with huge keys", "[by_key][reduce][device]"
   using accum_t = cuda::std::__accumulator_t<op_t, value_t, output_t>;
   c2h::host_vector<output_t> expected_result(num_segments);
   compute_segmented_problem_reference(in_values, segment_offsets, reduction_op, accum_t{}, expected_result.begin());
-  c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
+  const c2h::host_vector<key_t> expected_keys = compute_unique_keys_reference(segment_keys);
 
   // Run test
   c2h::device_vector<offset_t> num_unique_keys(1);

--- a/cub/test/catch2_test_device_reduce_deferred.cu
+++ b/cub/test/catch2_test_device_reduce_deferred.cu
@@ -504,8 +504,8 @@ CUB_TEST("DeviceReduce::Reduce consumes a deferred count produced in another str
 
   int current_device{};
   REQUIRE(cudaSuccess == cudaGetDevice(&current_device));
-  cuda::stream producer{cuda::devices[current_device]};
-  cuda::stream consumer{cuda::devices[current_device]};
+  const cuda::stream producer{cuda::devices[current_device]};
+  const cuda::stream consumer{cuda::devices[current_device]};
 
   const auto d_input = cuda::counting_iterator<value_t>{value_t{0}};
   c2h::device_vector<value_t> selected_items(capacity, value_t{capacity + 1});

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -105,7 +105,7 @@ CUB_TEST("Deterministic Device reduce works with float and double on gpu with la
     d_chunk.begin() + half_chunk_size,
     cuda::std::negate<type>{});
 
-  cyclic_chunk_accessor<type, decltype(d_chunk.data())> wrapper{d_chunk.data(), chunk_size};
+  const cyclic_chunk_accessor<type, decltype(d_chunk.data())> wrapper{d_chunk.data(), chunk_size};
   auto d_input = cuda::transform_iterator(cuda::counting_iterator<size_t>{}, wrapper);
   c2h::device_vector<type> d_output(1);
 
@@ -115,8 +115,8 @@ CUB_TEST("Deterministic Device reduce works with float and double on gpu with la
 
   // expected sum must be zero, as there would be equal number of positive and negative values
   // in the input and they will cancel each other out
-  c2h::host_vector<type> h_expected(1, type{});
-  c2h::host_vector<type> h_output = d_output;
+  const c2h::host_vector<type> h_expected(1, type{});
+  const c2h::host_vector<type> h_output = d_output;
 
   // output should be exactly equal to expected i.e 0.0
   REQUIRE_APPROX_EQ_ABS(h_expected, h_output, type{1e-10});
@@ -202,14 +202,14 @@ CUB_TEST("Deterministic Device reduce works with float and double on gpu with di
     // with the device RFA result.
     // NOTE: `cuda::std::reduce` is not equivalent
     h_expected[0] = cuda::std::accumulate(h_input.begin(), h_input.end(), type{}, cuda::std::plus<type>());
-    c2h::host_vector<type> h_output = d_output;
+    const c2h::host_vector<type> h_output = d_output;
 
     REQUIRE_APPROX_EQ_EPSILON(h_expected, h_output, type{0.01});
   }
 
   SECTION("constant iterator")
   {
-    cuda::constant_iterator<type> input(1.0f);
+    const cuda::constant_iterator<type> input(1.0f);
     c2h::device_vector<type> d_output(1);
 
     auto error = cub::DeviceReduce::Reduce(input, d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env);
@@ -221,7 +221,7 @@ CUB_TEST("Deterministic Device reduce works with float and double on gpu with di
     // NOTE: `cuda::std::reduce` is not equivalent
     h_expected[0] = cuda::std::accumulate(input, input + num_items, type{}, cuda::std::plus<type>());
 
-    c2h::host_vector<type> h_output = d_output;
+    const c2h::host_vector<type> h_output = d_output;
     REQUIRE_APPROX_EQ_EPSILON(h_expected, h_output, type{0.01});
   }
 }
@@ -278,7 +278,7 @@ CUB_TEST("Deterministic Device reduce works with float and double on gpu with di
 
   c2h::device_vector<type> d_output(1);
 
-  type init_value = GENERATE_COPY(
+  const type init_value = GENERATE_COPY(
     static_cast<type>(42), cuda::std::numeric_limits<type>::max(), cuda::std::numeric_limits<type>::min());
 
   const auto env = cuda::execution::require(cuda::execution::determinism::gpu_to_gpu);
@@ -345,7 +345,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
       // NOTE: `cuda::std::reduce` is not equivalent
       h_expected[0] = cuda::std::accumulate(h_input.begin(), h_input.end(), init_value_t{}, cuda::std::plus<type>{});
 
-      c2h::host_vector<type> h_output = d_output;
+      const c2h::host_vector<type> h_output = d_output;
       REQUIRE(h_expected == h_output);
     }
 
@@ -353,7 +353,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
     {
       c2h::device_vector<type> d_output(1);
 
-      init_value_t init_value{};
+      const init_value_t init_value{};
 
       auto error = cub::DeviceReduce::Reduce(
         d_input.begin(), d_output.begin(), num_items, cuda::std::bit_xor<>{}, init_value, env);
@@ -364,7 +364,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
       h_expected[0] =
         cuda::std::accumulate(h_input.begin(), h_input.end(), type{init_value}, cuda::std::bit_xor<type>{});
 
-      c2h::host_vector<type> h_output = d_output;
+      const c2h::host_vector<type> h_output = d_output;
       REQUIRE(h_expected == h_output);
     }
 
@@ -372,7 +372,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
     {
       c2h::device_vector<type> d_output(1);
 
-      init_value_t init_value{};
+      const init_value_t init_value{};
 
       auto error = cub::DeviceReduce::Reduce(
         d_input.begin(), d_output.begin(), num_items, cuda::std::logical_or<>{}, init_value, env);
@@ -383,7 +383,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
       h_expected[0] =
         cuda::std::accumulate(h_input.begin(), h_input.end(), type{init_value}, cuda::std::logical_or<>{});
 
-      c2h::host_vector<type> h_output = d_output;
+      const c2h::host_vector<type> h_output = d_output;
       REQUIRE(h_expected == h_output);
     }
   }
@@ -392,7 +392,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
   {
     c2h::device_vector<type> d_output(1);
 
-    init_value_t init_value{cuda::std::numeric_limits<init_value_t>::max()};
+    const init_value_t init_value{cuda::std::numeric_limits<init_value_t>::max()};
 
     auto error = cub::DeviceReduce::Reduce(
       d_input.begin(), d_output.begin(), num_items, cuda::minimum<init_value_t>{}, init_value, env);
@@ -402,7 +402,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
     c2h::host_vector<type> h_expected(1);
     h_expected[0] = cuda::std::accumulate(h_input.begin(), h_input.end(), type{init_value}, cuda::minimum<>{});
 
-    c2h::host_vector<type> h_output = d_output;
+    const c2h::host_vector<type> h_output = d_output;
     REQUIRE(h_expected == h_output);
   }
 
@@ -410,7 +410,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
   {
     c2h::device_vector<type> d_output(1);
 
-    init_value_t init_value{cuda::std::numeric_limits<init_value_t>::min()};
+    const init_value_t init_value{cuda::std::numeric_limits<init_value_t>::min()};
 
     auto error = cub::DeviceReduce::Reduce(
       d_input.begin(), d_output.begin(), num_items, cuda::maximum<init_value_t>{}, init_value, env);
@@ -420,7 +420,7 @@ CUB_TEST("Deterministic Device reduce works with integral types on gpu with diff
     c2h::host_vector<type> h_expected(1);
     h_expected[0] = cuda::std::accumulate(h_input.begin(), h_input.end(), type{init_value}, cuda::maximum<>{});
 
-    c2h::host_vector<type> h_output = d_output;
+    const c2h::host_vector<type> h_output = d_output;
     REQUIRE(h_expected == h_output);
   }
 }

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -82,13 +82,13 @@ CUB_TEST_CASE("Device reduce works with default environment", "[reduce][device]"
   cuda::compute_capability cc{};
   REQUIRE(cudaSuccess == cub::detail::ptx_compute_cap(cc, current_device));
 
-  unsigned int target_block_size =
+  const unsigned int target_block_size =
     cub::detail::reduce::policy_selector_from_types<value_t, offset_t, block_size_check_plus_t>{}(cc)
       .single_tile.threads_per_block;
 
-  num_items_t num_items = 1;
+  const num_items_t num_items = 1;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_plus_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_plus_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
@@ -101,9 +101,9 @@ CUB_TEST_CASE("Device reduce works with default environment", "[reduce][device]"
 
 CUB_TEST_CASE("Device Sum works with default environment", "[reduce][device]", CUB_SMALL)
 {
-  using num_items_t     = int;
-  using value_t         = int;
-  num_items_t num_items = 1;
+  using num_items_t           = int;
+  using value_t               = int;
+  const num_items_t num_items = 1;
 
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
@@ -241,7 +241,7 @@ CUB_TEST("Device ArgMin can be tuned", "[reduce][device]", CUB_SMALL, block_size
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
   using compare_t = block_size_extracting_op<cuda::std::less<>>;
-  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto input        = c2h::device_vector<int>{3, 1, 4, 0, 2};
   auto min_output   = c2h::device_vector<int>(1);
@@ -261,7 +261,7 @@ CUB_TEST("Device ArgMax can be tuned", "[reduce][device]", CUB_SMALL, block_size
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
   using compare_t = block_size_extracting_op<cuda::std::less<>>;
-  compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const compare_t compare_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto input        = c2h::device_vector<int>{3, 1, 4, 0, 2};
   auto max_output   = c2h::device_vector<int>(1);
@@ -305,7 +305,7 @@ CUB_TEST("Device ReduceByKey can be tuned", "[reduce][device]", CUB_SMALL, reduc
   auto d_num_runs_out                      = c2h::device_vector<int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_minimum_t reduction_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_minimum_t reduction_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(reduce_by_key_tuning<target_block_size>{});
 
   device_reduce_by_key(
@@ -319,8 +319,8 @@ CUB_TEST("Device ReduceByKey can be tuned", "[reduce][device]", CUB_SMALL, reduc
     env);
 
   REQUIRE(d_num_runs_out[0] == 5);
-  c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   d_unique_out.resize(5);
   d_aggregates_out.resize(5);
   REQUIRE(d_unique_out == expected_keys);
@@ -502,7 +502,7 @@ CUB_TEST("Device sum uses environment", "[reduce][device]", CUB_SMALL, requireme
   using input_it_t  = ::cuda::std::decay_t<decltype(d_in)>;
   using output_it_t = ::cuda::std::decay_t<decltype(d_out.begin())>;
 
-  [[maybe_unused]] init_value_t init = 0;
+  [[maybe_unused]] const init_value_t init = 0;
   size_t expected_bytes_allocated{};
 
   // To check if a given algorithm implementation is used, we check if associated kernels are invoked.
@@ -640,10 +640,10 @@ CUB_TEST("Device reduce not_guaranteed falls back when output type differs from 
   using offset_t      = cub::detail::choose_offset_t<num_items_t>;
   using transform_t   = cuda::std::identity;
 
-  auto d_in             = thrust::device_vector<input_t>{0, 1, 2, 3};
-  auto d_out            = thrust::device_vector<output_t>(1);
-  num_items_t num_items = static_cast<num_items_t>(d_in.size());
-  init_value_t init{};
+  auto d_in                   = thrust::device_vector<input_t>{0, 1, 2, 3};
+  auto d_out                  = thrust::device_vector<output_t>(1);
+  const num_items_t num_items = static_cast<num_items_t>(d_in.size());
+  const init_value_t init{};
   size_t expected_bytes_allocated{};
 
   REQUIRE(cudaSuccess
@@ -704,9 +704,9 @@ CUB_TEST("Device sum not_guaranteed falls back when output type differs from acc
   using offset_t      = cub::detail::choose_offset_t<num_items_t>;
   using transform_t   = cuda::std::identity;
 
-  auto d_in             = thrust::device_vector<input_t>{0, 1, 2, 3};
-  auto d_out            = thrust::device_vector<output_t>(1);
-  num_items_t num_items = static_cast<num_items_t>(d_in.size());
+  auto d_in                   = thrust::device_vector<input_t>{0, 1, 2, 3};
+  auto d_out                  = thrust::device_vector<output_t>(1);
+  const num_items_t num_items = static_cast<num_items_t>(d_in.size());
   size_t expected_bytes_allocated{};
 
   REQUIRE(
@@ -811,8 +811,8 @@ CUB_TEST_CASE("Device ReduceByKey works with default environment", "[reduce][dev
       static_cast<int>(d_keys_in.size())));
 
   REQUIRE(d_num_runs_out[0] == 5);
-  c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   d_unique_out.resize(5);
   d_aggregates_out.resize(5);
   REQUIRE(d_unique_out == expected_keys);
@@ -970,8 +970,8 @@ CUB_TEST("Device ReduceByKey uses environment", "[reduce][device]", CUB_SMALL)
     env);
 
   REQUIRE(d_num_runs_out[0] == 5);
-  c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const c2h::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   d_unique_out.resize(5);
   d_aggregates_out.resize(5);
   REQUIRE(d_unique_out == expected_keys);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -640,7 +640,7 @@ CUB_TEST("Device reduce not_guaranteed falls back when output type differs from 
   using offset_t      = cub::detail::choose_offset_t<num_items_t>;
   using transform_t   = cuda::std::identity;
 
-  auto d_in                   = thrust::device_vector<input_t>{0, 1, 2, 3};
+  const auto d_in             = thrust::device_vector<input_t>{0, 1, 2, 3};
   auto d_out                  = thrust::device_vector<output_t>(1);
   const num_items_t num_items = static_cast<num_items_t>(d_in.size());
   const init_value_t init{};

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -34,7 +34,7 @@ CUB_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements"
     std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end reduce-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -57,7 +57,7 @@ CUB_TEST("cub::DeviceReduce::Reduce accepts not_guaranteed determinism requireme
     std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end reduce-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -72,8 +72,8 @@ CUB_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]", CUB_SMALL)
   auto output = thrust::device_vector<float>(1);
   auto init   = 0.0f;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::Reduce(input.begin(), output.begin(), input.size(), op, init, stream_ref);
   if (error != cudaSuccess)
@@ -81,7 +81,7 @@ CUB_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::Reduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end reduce-env-stream
   stream.sync();
 
@@ -104,7 +104,7 @@ CUB_TEST("cub::DeviceReduce::Sum accepts run_to_run determinism requirements", "
     std::cerr << "cub::DeviceReduce::Sum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end sum-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -125,7 +125,7 @@ CUB_TEST("cub::DeviceReduce::Sum accepts not_guaranteed determinism requirements
     std::cerr << "cub::DeviceReduce::Sum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end sum-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -138,8 +138,8 @@ CUB_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]", CUB_SMALL)
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = thrust::device_vector<float>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::Sum(input.begin(), output.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
@@ -147,7 +147,7 @@ CUB_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::Sum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{6.0f};
+  const thrust::device_vector<float> expected{6.0f};
   // example-end sum-env-stream
   stream.sync();
 
@@ -169,7 +169,7 @@ CUB_TEST("cub::DeviceReduce::Min accepts run_to_run determinism requirements", "
     std::cerr << "cub::DeviceReduce::Min failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f};
+  const thrust::device_vector<float> expected{0.0f};
   // example-end min-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -190,7 +190,7 @@ CUB_TEST("cub::DeviceReduce::Min accepts not_guaranteed determinism requirements
     std::cerr << "cub::DeviceReduce::Min failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f};
+  const thrust::device_vector<float> expected{0.0f};
   // example-end min-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -203,8 +203,8 @@ CUB_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]", CUB_SMALL)
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = thrust::device_vector<float>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::Min(input.begin(), output.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
@@ -212,7 +212,7 @@ CUB_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::Min failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f};
+  const thrust::device_vector<float> expected{0.0f};
   // example-end min-env-stream
   stream.sync();
 
@@ -234,7 +234,7 @@ CUB_TEST("cub::DeviceReduce::Max accepts run_to_run determinism requirements", "
     std::cerr << "cub::DeviceReduce::Max failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{3.0f};
+  const thrust::device_vector<float> expected{3.0f};
   // example-end max-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -255,7 +255,7 @@ CUB_TEST("cub::DeviceReduce::Max accepts not_guaranteed determinism requirements
     std::cerr << "cub::DeviceReduce::Max failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{3.0f};
+  const thrust::device_vector<float> expected{3.0f};
   // example-end max-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -268,8 +268,8 @@ CUB_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]", CUB_SMALL)
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = thrust::device_vector<float>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::Max(input.begin(), output.begin(), input.size(), stream_ref);
   if (error != cudaSuccess)
@@ -277,7 +277,7 @@ CUB_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::Max failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{3.0f};
+  const thrust::device_vector<float> expected{3.0f};
   // example-end max-env-stream
   stream.sync();
 
@@ -301,8 +301,8 @@ CUB_TEST("cub::DeviceReduce::ArgMin accepts run_to_run determinism requirements"
     std::cerr << "cub::DeviceReduce::ArgMin failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_min{0.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{3};
+  const thrust::device_vector<float> expected_min{0.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{3};
   // example-end argmin-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -326,8 +326,8 @@ CUB_TEST("cub::DeviceReduce::ArgMin accepts not_guaranteed determinism requireme
     std::cerr << "cub::DeviceReduce::ArgMin failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_min{0.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{3};
+  const thrust::device_vector<float> expected_min{0.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{3};
   // example-end argmin-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -342,8 +342,8 @@ CUB_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]", CUB_SMALL)
   auto min_output   = thrust::device_vector<float>(1);
   auto index_output = thrust::device_vector<cuda::std::int64_t>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::ArgMin(
     input.begin(),
@@ -356,8 +356,8 @@ CUB_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::ArgMin failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_min{0.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{3};
+  const thrust::device_vector<float> expected_min{0.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{3};
   // example-end argmin-env-stream
   stream.sync();
 
@@ -382,8 +382,8 @@ CUB_TEST("cub::DeviceReduce::ArgMax accepts run_to_run determinism requirements"
     std::cerr << "cub::DeviceReduce::ArgMax failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_max{4.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{2};
+  const thrust::device_vector<float> expected_max{4.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -407,8 +407,8 @@ CUB_TEST("cub::DeviceReduce::ArgMax accepts not_guaranteed determinism requireme
     std::cerr << "cub::DeviceReduce::ArgMax failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_max{4.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{2};
+  const thrust::device_vector<float> expected_max{4.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -423,8 +423,8 @@ CUB_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]", CUB_SMALL)
   auto max_output   = thrust::device_vector<float>(1);
   auto index_output = thrust::device_vector<cuda::std::int64_t>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::ArgMax(
     input.begin(),
@@ -437,8 +437,8 @@ CUB_TEST("cub::DeviceReduce::ArgMax accepts stream", "[reduce][env]", CUB_SMALL)
     std::cerr << "cub::DeviceReduce::ArgMax failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected_max{4.0f};
-  thrust::device_vector<cuda::std::int64_t> expected_index{2};
+  const thrust::device_vector<float> expected_max{4.0f};
+  const thrust::device_vector<cuda::std::int64_t> expected_index{2};
   // example-end argmax-env-stream
 
   REQUIRE(error == cudaSuccess);
@@ -464,7 +464,7 @@ CUB_TEST("cub::DeviceReduce::TransformReduce accepts determinism requirements", 
     std::cerr << "cub::DeviceReduce::TransformReduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{-10.0f};
+  const thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -491,7 +491,7 @@ CUB_TEST("cub::DeviceReduce::TransformReduce accepts not_guaranteed determinism 
     std::cerr << "cub::DeviceReduce::TransformReduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{-10.0f};
+  const thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -507,8 +507,8 @@ CUB_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]", C
   auto output    = thrust::device_vector<float>(1);
   auto init      = 0.0f;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error =
     cub::DeviceReduce::TransformReduce(input.begin(), output.begin(), input.size(), op, transform, init, stream_ref);
@@ -517,7 +517,7 @@ CUB_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]", C
     std::cerr << "cub::DeviceReduce::TransformReduce failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{-10.0f};
+  const thrust::device_vector<float> expected{-10.0f};
   // example-end transform-reduce-env-stream
   stream.sync();
 
@@ -550,8 +550,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts run_to_run determinism requirem
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env
 
   REQUIRE(error == cudaSuccess);
@@ -587,8 +587,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts not_guaranteed determinism requ
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env-non-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -608,8 +608,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]", CUB_S
   auto aggregates_out  = thrust::device_vector<int>(5);
   auto num_runs_out    = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceReduce::ReduceByKey(
     keys_in.begin(),
@@ -625,8 +625,8 @@ CUB_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]", CUB_S
     std::cerr << "cub::DeviceReduce::ReduceByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
   // example-end reduce-by-key-env-stream
   stream.sync();
 
@@ -643,7 +643,7 @@ CUB_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed 
   auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};
   auto output = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t bytes_allocated{};
   size_t bytes_deallocated{};

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -30,11 +30,11 @@ using iterator_type_list = c2h::type_list<type_pair<custom_t>, type_pair<std::in
 template <typename T, typename offset_t>
 void test_big_indices_helper(offset_t num_items)
 {
-  cuda::constant_iterator<T> const_iter(T{1});
+  const cuda::constant_iterator<T> const_iter(T{1});
   c2h::device_vector<std::size_t> out(1);
   std::size_t* d_out = thrust::raw_pointer_cast(out.data());
   device_sum(const_iter, d_out, num_items);
-  std::size_t result = out[0];
+  const std::size_t result = out[0];
 
   REQUIRE(result == num_items);
 }
@@ -78,8 +78,8 @@ CUB_TEST("Device reduce works with fancy input iterators", "[reduce][device]", C
   auto reduction_op = op_t{};
 
   // Prepare verification data
-  using accum_t            = cuda::std::__accumulator_t<op_t, item_t, init_value_t>;
-  output_t expected_result = compute_single_problem_reference(in_it, in_it + num_items, reduction_op, accum_t{});
+  using accum_t                  = cuda::std::__accumulator_t<op_t, item_t, init_value_t>;
+  const output_t expected_result = compute_single_problem_reference(in_it, in_it + num_items, reduction_op, accum_t{});
 
   // Run test
   c2h::device_vector<output_t> out_result(num_segments);

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -53,7 +53,7 @@ CUB_TEST("Nondeterministic Device reduce works with float and double on gpu",
   const int num_items = GENERATE_COPY(values({0, 1, 20, 100, 2000, 1 << 20}));
   c2h::device_vector<type> d_input(num_items, thrust::no_init);
 
-  type amplitude = static_cast<type>(1);
+  const type amplitude = static_cast<type>(1);
   c2h::gen(C2H_SEED(2), d_input, -amplitude / (num_items + 1), 2 * amplitude / (num_items + 1));
 
   c2h::device_vector<type> d_output(1);
@@ -63,8 +63,8 @@ CUB_TEST("Nondeterministic Device reduce works with float and double on gpu",
     cudaSuccess
     == cub::DeviceReduce::Reduce(d_input.begin(), d_output.begin(), num_items, cuda::std::plus<type>{}, type{}, env));
 
-  c2h::host_vector<type> h_input  = d_input;
-  c2h::host_vector<type> h_actual = d_output;
+  c2h::host_vector<type> h_input        = d_input;
+  const c2h::host_vector<type> h_actual = d_output;
 
   c2h::host_vector<type> h_expected(1);
   // TODO: Use std::reduce once we drop support for GCC 7 and 8
@@ -75,7 +75,7 @@ CUB_TEST("Nondeterministic Device reduce works with float and double on gpu",
     const type ab = cuda::std::fabs(b);
     return cuda::std::plus<type>{}(aa, ab);
   };
-  type sum_abs = std::accumulate(h_input.begin(), h_input.end(), type{}, plus_abs);
+  const type sum_abs = std::accumulate(h_input.begin(), h_input.end(), type{}, plus_abs);
 
   // relative round-off error of recursive summation is proportional to n * type::epsilon,
   // see https://epubs.siam.org/doi/epdf/10.1137/19M1257780
@@ -176,15 +176,15 @@ CUB_TEST("Nondeterministic Device reduce works with float and double on gpu with
 
     c2h::host_vector<type> h_expected(1);
     // TODO: Use std::reduce once we drop support for GCC 7 and 8
-    h_expected[0]                   = std::accumulate(h_input.begin(), h_input.end(), type{}, cuda::std::plus<type>());
-    c2h::host_vector<type> h_output = d_output;
+    h_expected[0] = std::accumulate(h_input.begin(), h_input.end(), type{}, cuda::std::plus<type>());
+    const c2h::host_vector<type> h_output = d_output;
 
     REQUIRE_APPROX_EQ_EPSILON(h_expected, h_output, type{0.01});
   }
 
   SECTION("constant iterator")
   {
-    cuda::constant_iterator<type> input(1.0f);
+    const cuda::constant_iterator<type> input(1.0f);
     c2h::device_vector<type> d_output(1);
 
     REQUIRE(cudaSuccess
@@ -339,7 +339,7 @@ CUB_TEST("Nondeterministic Device reduce works with various types on gpu with di
   // TODO: Use std::reduce once we drop support for GCC 7 and 8
   h_expected[0] = std::accumulate(h_input.begin(), h_input.end(), type{}, cuda::std::plus<type>{});
 
-  c2h::host_vector<type> h_output = d_output;
+  const c2h::host_vector<type> h_output = d_output;
   if constexpr (cuda::std::is_integral_v<type>)
   {
     REQUIRE(h_expected == h_output);

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -241,8 +241,8 @@ CUB_TEST("DeviceRunLengthEncode::Encode can handle all unique", "[device][run_le
   c2h::device_vector<type> reference_unique(num_items);
   thrust::sequence(c2h::device_policy, reference_unique.begin(), reference_unique.end(), type{}); // [0, 1, 2, ...,
                                                                                                   // num_items -1]
-  c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
-  c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
+  const c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
+  const c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
 
   REQUIRE(out_unique == reference_unique);
   REQUIRE(out_counts == reference_counts);
@@ -261,9 +261,9 @@ CUB_TEST("DeviceRunLengthEncode::Encode can handle all equal", "[device][run_len
 
   run_length_encode(in.begin(), out_unique.begin(), out_counts.begin(), out_num_runs.begin(), num_items);
 
-  c2h::device_vector<type> reference_unique(1, type{1}); // [1]
-  c2h::device_vector<int> reference_counts(1, num_items); // [num_items]
-  c2h::device_vector<int> reference_num_runs(1, 1); // [1]
+  const c2h::device_vector<type> reference_unique(1, type{1}); // [1]
+  const c2h::device_vector<int> reference_counts(1, num_items); // [num_items]
+  const c2h::device_vector<int> reference_num_runs(1, 1); // [1]
 
   REQUIRE(out_unique == reference_unique);
   REQUIRE(out_counts == reference_counts);
@@ -375,8 +375,8 @@ CUB_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_l
 
   run_length_encode(in.begin(), out_unique.begin(), out_counts.begin(), out_num_runs.begin(), num_items);
 
-  c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
-  c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
+  const c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
+  const c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
 
   // turn the NaN into something else to make it comparable
   out_unique.front()       = 42.0;
@@ -407,9 +407,9 @@ CUB_TEST("DeviceRunLengthEncode::Encode works with non-default constructible ite
 
   run_length_encode(custom_it, out_unique.begin(), out_counts.begin(), out_num_runs.begin(), num_items);
 
-  c2h::device_vector<type> reference_unique{custom_it, custom_it + num_items};
-  c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
-  c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
+  const c2h::device_vector<type> reference_unique{custom_it, custom_it + num_items};
+  const c2h::device_vector<int> reference_counts(num_items, 1); // [1, 1, ..., 1]
+  const c2h::device_vector<int> reference_num_runs(1, num_items); // [num_items]
 
   REQUIRE(out_unique == reference_unique);
   REQUIRE(out_counts == reference_counts);
@@ -519,8 +519,8 @@ try
     static_cast<offset_type>(num_items));
 
   // Expected results
-  c2h::device_vector<item_t> expected_uniques{item_t{3}, item_t{42}};
-  c2h::device_vector<run_length_type> expected_run_lengths{first_run_size, second_run_size};
+  const c2h::device_vector<item_t> expected_uniques{item_t{3}, item_t{42}};
+  const c2h::device_vector<run_length_type> expected_run_lengths{first_run_size, second_run_size};
 
   // Verify result
   REQUIRE(out_num_runs[0] == num_uniques);

--- a/cub/test/catch2_test_device_run_length_encode_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_api.cu
@@ -19,7 +19,7 @@ CUB_TEST("DeviceRunLengthEncode::Encode legacy size-query is unambiguous", "[run
   int* d_lengths  = nullptr;
   int* d_num_runs = nullptr;
   size_t bytes    = 0;
-  int n           = 0;
+  const int n     = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceRunLengthEncode::Encode(nullptr, bytes, d_in, d_unique, d_lengths, d_num_runs, n));
 }
@@ -33,7 +33,7 @@ CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns legacy size-query is unambiguous
   int* d_lengths  = nullptr;
   int* d_num_runs = nullptr;
   size_t bytes    = 0;
-  int n           = 0;
+  const int n     = 0;
 
   REQUIRE(cudaSuccess
           == cub::DeviceRunLengthEncode::NonTrivialRuns(nullptr, bytes, d_in, d_offsets, d_lengths, d_num_runs, n));

--- a/cub/test/catch2_test_device_run_length_encode_env.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env.cu
@@ -67,9 +67,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::Encode works with default environment", "[
           == cub::DeviceRunLengthEncode::Encode(
             d_in.begin(), d_unique_out.begin(), d_counts_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
 
-  c2h::device_vector<int> expected_unique{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_counts{1, 2, 1, 3, 1};
-  c2h::device_vector<int> expected_num_runs{5};
+  const c2h::device_vector<int> expected_unique{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_counts{1, 2, 1, 3, 1};
+  const c2h::device_vector<int> expected_num_runs{5};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_unique_out.resize(d_num_runs_out[0]);
@@ -91,9 +91,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns works with default environm
           == cub::DeviceRunLengthEncode::NonTrivialRuns(
             d_in.begin(), d_offsets_out.begin(), d_lengths_out.begin(), d_num_runs_out.begin(), (int) d_in.size()));
 
-  c2h::device_vector<int> expected_offsets{1, 4};
-  c2h::device_vector<int> expected_lengths{2, 3};
-  c2h::device_vector<int> expected_num_runs{2};
+  const c2h::device_vector<int> expected_offsets{1, 4};
+  const c2h::device_vector<int> expected_lengths{2, 3};
+  const c2h::device_vector<int> expected_num_runs{2};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_offsets_out.resize(d_num_runs_out[0]);
@@ -110,7 +110,7 @@ CUB_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][
   auto d_unique_out   = c2h::device_vector<int>(10);
   auto d_counts_out   = c2h::device_vector<int>(10);
   auto d_num_runs_out = c2h::device_vector<int>(1);
-  int num_items       = static_cast<int>(d_in.size());
+  const int num_items = static_cast<int>(d_in.size());
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -129,9 +129,9 @@ CUB_TEST("DeviceRunLengthEncode::Encode uses environment", "[run_length_encode][
   run_length_encode_env(
     d_in.begin(), d_unique_out.begin(), d_counts_out.begin(), d_num_runs_out.begin(), num_items, env);
 
-  c2h::device_vector<int> expected_unique{1, 2, 3, 4};
-  c2h::device_vector<int> expected_counts{3, 2, 1, 4};
-  c2h::device_vector<int> expected_num_runs{4};
+  const c2h::device_vector<int> expected_unique{1, 2, 3, 4};
+  const c2h::device_vector<int> expected_counts{3, 2, 1, 4};
+  const c2h::device_vector<int> expected_num_runs{4};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_unique_out.resize(d_num_runs_out[0]);
@@ -146,7 +146,7 @@ CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_
   auto d_offsets_out  = c2h::device_vector<int>(10);
   auto d_lengths_out  = c2h::device_vector<int>(10);
   auto d_num_runs_out = c2h::device_vector<int>(1);
-  int num_items       = static_cast<int>(d_in.size());
+  const int num_items = static_cast<int>(d_in.size());
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -165,9 +165,9 @@ CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns uses environment", "[run_length_
   non_trivial_runs_env(
     d_in.begin(), d_offsets_out.begin(), d_lengths_out.begin(), d_num_runs_out.begin(), num_items, env);
 
-  c2h::device_vector<int> expected_offsets{0, 3, 6};
-  c2h::device_vector<int> expected_lengths{3, 2, 4};
-  c2h::device_vector<int> expected_num_runs{3};
+  const c2h::device_vector<int> expected_offsets{0, 3, 6};
+  const c2h::device_vector<int> expected_lengths{3, 2, 4};
+  const c2h::device_vector<int> expected_num_runs{3};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_offsets_out.resize(d_num_runs_out[0]);
@@ -182,9 +182,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_e
   auto d_unique_out   = c2h::device_vector<int>(8);
   auto d_counts_out   = c2h::device_vector<int>(8);
   auto d_num_runs_out = c2h::device_vector<int>(1);
-  int num_items       = static_cast<int>(d_in.size());
+  const int num_items = static_cast<int>(d_in.size());
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -198,7 +198,7 @@ CUB_TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_e
       d_num_runs_out.begin(),
       num_items));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, stream_ref};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
@@ -207,9 +207,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::Encode uses custom stream", "[run_length_e
 
   custom_stream.sync();
 
-  c2h::device_vector<int> expected_unique{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_counts{1, 2, 1, 3, 1};
-  c2h::device_vector<int> expected_num_runs{5};
+  const c2h::device_vector<int> expected_unique{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_counts{1, 2, 1, 3, 1};
+  const c2h::device_vector<int> expected_num_runs{5};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_unique_out.resize(d_num_runs_out[0]);
@@ -224,9 +224,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_
   auto d_offsets_out  = c2h::device_vector<int>(8);
   auto d_lengths_out  = c2h::device_vector<int>(8);
   auto d_num_runs_out = c2h::device_vector<int>(1);
-  int num_items       = static_cast<int>(d_in.size());
+  const int num_items = static_cast<int>(d_in.size());
 
-  cuda::stream custom_stream{cuda::devices[0]};
+  const cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -240,7 +240,7 @@ CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_
       d_num_runs_out.begin(),
       num_items));
 
-  cuda::stream_ref stream_ref{custom_stream};
+  const cuda::stream_ref stream_ref{custom_stream};
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, stream_ref};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
 
@@ -249,9 +249,9 @@ CUB_TEST_CASE("DeviceRunLengthEncode::NonTrivialRuns uses custom stream", "[run_
 
   custom_stream.sync();
 
-  c2h::device_vector<int> expected_offsets{1, 4};
-  c2h::device_vector<int> expected_lengths{2, 3};
-  c2h::device_vector<int> expected_num_runs{2};
+  const c2h::device_vector<int> expected_offsets{1, 4};
+  const c2h::device_vector<int> expected_lengths{2, 3};
+  const c2h::device_vector<int> expected_num_runs{2};
 
   REQUIRE(d_num_runs_out == expected_num_runs);
   d_offsets_out.resize(d_num_runs_out[0]);
@@ -268,7 +268,7 @@ CUB_TEST("DeviceRunLengthEncode::Encode can be tuned", "[run_length_encode][devi
   constexpr int num_items                  = 256;
 
   auto d_block_size = c2h::device_vector<unsigned int>(1, 0);
-  block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto d_unique_out   = c2h::device_vector<int>(1);
   auto d_counts_out   = c2h::device_vector<int>(1);
@@ -290,7 +290,7 @@ CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns can be tuned", "[run_length_enco
   constexpr int num_items                  = 256;
 
   auto d_block_size = c2h::device_vector<unsigned int>(1, 0);
-  block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator d_in(42, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto d_offsets_out  = c2h::device_vector<int>(1);
   auto d_lengths_out  = c2h::device_vector<int>(1);

--- a/cub/test/catch2_test_device_run_length_encode_env_api.cu
+++ b/cub/test/catch2_test_device_run_length_encode_env_api.cu
@@ -23,8 +23,8 @@ CUB_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
   auto counts_out   = thrust::device_vector<int>(8);
   auto num_runs_out = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRunLengthEncode::Encode(
     input.begin(), unique_out.begin(), counts_out.begin(), num_runs_out.begin(), input.size(), stream_ref);
@@ -33,9 +33,9 @@ CUB_TEST("cub::DeviceRunLengthEncode::Encode accepts env with stream", "[run_len
     std::cerr << "cub::DeviceRunLengthEncode::Encode failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_unique{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_counts{1, 2, 1, 3, 1};
-  thrust::device_vector<int> expected_num_runs{5};
+  const thrust::device_vector<int> expected_unique{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_counts{1, 2, 1, 3, 1};
+  const thrust::device_vector<int> expected_num_runs{5};
   // example-end encode-env
   stream.sync();
 
@@ -55,8 +55,8 @@ CUB_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "
   auto lengths_out  = thrust::device_vector<int>(8);
   auto num_runs_out = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceRunLengthEncode::NonTrivialRuns(
     input.begin(), offsets_out.begin(), lengths_out.begin(), num_runs_out.begin(), input.size(), stream_ref);
@@ -65,9 +65,9 @@ CUB_TEST("cub::DeviceRunLengthEncode::NonTrivialRuns accepts env with stream", "
     std::cerr << "cub::DeviceRunLengthEncode::NonTrivialRuns failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_offsets{1, 4};
-  thrust::device_vector<int> expected_lengths{2, 3};
-  thrust::device_vector<int> expected_num_runs{2};
+  const thrust::device_vector<int> expected_offsets{1, 4};
+  const thrust::device_vector<int> expected_lengths{2, 3};
+  const thrust::device_vector<int> expected_num_runs{2};
   // example-end non-trivial-runs-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
+++ b/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
@@ -315,7 +315,7 @@ CUB_TEST("DeviceRunLengthEncode::NonTrivialRuns does not run out of memory",
 
   int expected_non_trivial_runs = 0;
   int value                     = tile_size;
-  int large_group_size          = 3;
+  const int large_group_size    = 3;
   for (int i = 0; i < tile_size; i++)
   {
     int j = 0;
@@ -447,8 +447,8 @@ try
     static_cast<offset_type>(num_items));
 
   // Expected results
-  c2h::device_vector<offset_type> expected_uniques{offset_type{0}, first_run_size};
-  c2h::device_vector<run_length_type> expected_run_lengths{first_run_size, second_run_size};
+  const c2h::device_vector<offset_type> expected_uniques{offset_type{0}, first_run_size};
+  const c2h::device_vector<run_length_type> expected_run_lengths{first_run_size, second_run_size};
 
   // Verify result
   CHECK(out_num_runs[0] == num_uniques);

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -122,7 +122,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     CAPTURE(c2h::type_name<op_t>(), c2h::type_name<accum_t>());
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
     compute_inclusive_scan_reference(host_items.cbegin(), host_items.cend(), expected_result.begin(), op_t{}, accum_t{});
 
@@ -151,7 +151,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     CAPTURE(c2h::type_name<op_t>(), c2h::type_name<accum_t>());
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
     compute_exclusive_scan_reference(host_items.cbegin(), host_items.cend(), expected_result.begin(), accum_t{}, op_t{});
 
@@ -181,7 +181,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     CAPTURE(c2h::type_name<op_t>(), c2h::type_name<accum_t>());
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
     compute_inclusive_scan_reference(
       host_items.cbegin(),
@@ -218,7 +218,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     auto scan_op = unwrap_op(reference_extended_fp(d_in_it), op_t{});
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
 
     // Run test
@@ -254,7 +254,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     auto scan_op = unwrap_op(reference_extended_fp(d_in_it), op_t{});
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
     compute_exclusive_scan_reference(
       host_items.cbegin(), host_items.cend(), expected_result.begin(), accum_t{}, scan_op);
@@ -290,7 +290,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
     // Prepare verification data
     accum_t init_value{};
     init_default_constant(init_value);
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<output_t> expected_result(num_items);
     compute_exclusive_scan_reference(
       host_items.cbegin(), host_items.cend(), expected_result.begin(), init_value, scan_op);

--- a/cub/test/catch2_test_device_scan.cuh
+++ b/cub/test/catch2_test_device_scan.cuh
@@ -113,10 +113,10 @@ void compute_exclusive_scan_by_key_reference(
   EqualityOpT equality_op,
   InitValueT init)
 {
-  c2h::host_vector<ValueT> host_values(d_values);
-  c2h::host_vector<KeyT> host_keys(d_keys);
+  const c2h::host_vector<ValueT> host_values(d_values);
+  const c2h::host_vector<KeyT> host_keys(d_keys);
 
-  std::size_t num_items = host_values.size();
+  const std::size_t num_items = host_values.size();
 
   compute_exclusive_scan_by_key_reference(
     host_values.cbegin(), host_keys.cbegin(), result_out_it, scan_op, equality_op, init, num_items);
@@ -144,9 +144,9 @@ void compute_inclusive_scan_by_key_reference(
 
     for (; i < num_items && equality_op(h_keys_it[i - 1], h_keys_it[i]); ++i)
     {
-      accum_t val      = h_values_it[i];
-      inclusive        = static_cast<accum_t>(scan_op(inclusive, val));
-      result_out_it[i] = static_cast<output_t>(inclusive);
+      const accum_t val = h_values_it[i];
+      inclusive         = static_cast<accum_t>(scan_op(inclusive, val));
+      result_out_it[i]  = static_cast<output_t>(inclusive);
     }
   }
 }
@@ -159,10 +159,10 @@ void compute_inclusive_scan_by_key_reference(
   ScanOpT scan_op,
   EqualityOpT equality_op)
 {
-  c2h::host_vector<ValueT> host_values(d_values);
-  c2h::host_vector<KeyT> host_keys(d_keys);
+  const c2h::host_vector<ValueT> host_values(d_values);
+  const c2h::host_vector<KeyT> host_keys(d_keys);
 
-  std::size_t num_items = host_values.size();
+  const std::size_t num_items = host_values.size();
 
   compute_inclusive_scan_by_key_reference(
     host_values.cbegin(), host_keys.cbegin(), result_out_it, scan_op, equality_op, num_items);

--- a/cub/test/catch2_test_device_scan_alignment.cu
+++ b/cub/test/catch2_test_device_scan_alignment.cu
@@ -49,7 +49,7 @@ CUB_TEST("Device scan works with all device interfaces", "[scan][device]", CUB_S
   auto d_in_it = thrust::raw_pointer_cast(in_items.data());
 
   // Prepare verification data
-  c2h::host_vector<input_t> host_items(in_items);
+  const c2h::host_vector<input_t> host_items(in_items);
   c2h::host_vector<output_t> expected_result(num_items, thrust::no_init);
 
   // Compute verification data

--- a/cub/test/catch2_test_device_scan_api.cu
+++ b/cub/test/catch2_test_device_scan_api.cu
@@ -14,7 +14,7 @@ CUB_TEST("Device inclusive scan works", "[scan][device]", CUB_SMALL)
   thrust::device_vector<int> input{0, -1, 2, -3, 4, -5, 6};
   thrust::device_vector<int> out(input.size());
 
-  int init = 1;
+  const int init = 1;
   size_t temp_storage_bytes{};
 
   cub::DeviceScan::InclusiveScanInit(
@@ -33,7 +33,7 @@ CUB_TEST("Device inclusive scan works", "[scan][device]", CUB_SMALL)
     init,
     static_cast<int>(input.size()));
 
-  thrust::host_vector<int> expected{1, 1, 2, 2, 4, 4, 6};
+  const thrust::host_vector<int> expected{1, 1, 2, 2, 4, 4, 6};
   // example-end device-inclusive-scan
 
   REQUIRE(expected == out);
@@ -171,7 +171,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScanInit args::deferred non-env overload wor
     deferred_init,
     static_cast<int>(input.size()));
 
-  thrust::host_vector<int> expected{1, 1, 2, 2, 4, 4, 6};
+  const thrust::host_vector<int> expected{1, 1, 2, 2, 4, 4, 6};
   // example-end device-inclusive-scan-init-deferred
 
   REQUIRE(expected == out);

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -93,7 +93,7 @@ CUB_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
 
   // Get array of keys from segment offsets
@@ -287,7 +287,7 @@ CUB_TEST("Device scan works when memory for keys and results alias one another",
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
 
   // Get array of keys from segment offsets

--- a/cub/test/catch2_test_device_scan_by_key_env.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env.cu
@@ -43,7 +43,7 @@ CUB_TEST_CASE("Device scan exclusive-sum-by-key works with default environment",
 
   REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
 
-  thrust::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
+  const thrust::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
   REQUIRE(d_out == expected);
 }
 
@@ -65,10 +65,10 @@ CUB_TEST_CASE("Device scan exclusive-scan-by-key works with default environment"
   const auto target_block_size =
     selector_t{}(cuda::compute_capability{device_props.major, device_props.minor}).lookback.threads_per_block;
 
-  num_items_t num_items = 1;
-  auto d_keys           = thrust::device_vector<key_t>{0};
+  const num_items_t num_items = 1;
+  auto d_keys                 = thrust::device_vector<key_t>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
   auto init  = value_t{0};
@@ -90,7 +90,7 @@ CUB_TEST_CASE("Device scan inclusive-sum-by-key works with default environment",
 
   REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveSumByKey(d_keys.begin(), d_in.begin(), d_out.begin(), num_items));
 
-  thrust::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
+  const thrust::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
   REQUIRE(d_out == expected);
 }
 
@@ -112,10 +112,10 @@ CUB_TEST_CASE("Device scan inclusive-scan-by-key works with default environment"
   const auto target_block_size =
     selector_t{}(cuda::compute_capability{device_props.major, device_props.minor}).lookback.threads_per_block;
 
-  num_items_t num_items = 1;
-  auto d_keys           = thrust::device_vector<key_t>{0};
+  const num_items_t num_items = 1;
+  auto d_keys                 = thrust::device_vector<key_t>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = thrust::device_vector<value_t>(1);
 
@@ -164,7 +164,7 @@ CUB_TEST("DeviceScan::ExclusiveSumByKey can be tuned", "[scan][by_key][device]",
 
   device_scan_exclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), 7, equality_op, env);
 
-  c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
+  const c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -183,7 +183,7 @@ CUB_TEST("DeviceScan::ExclusiveScanByKey can be tuned", "[scan][by_key][device]"
   device_scan_exclusive_scan_by_key(
     d_keys.begin(), d_in.begin(), d_out.begin(), scan_op, 0, 7, cuda::std::equal_to<>{}, env);
 
-  c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
+  const c2h::device_vector<int> expected{0, 8, 0, 7, 12, 0, 0};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -201,7 +201,7 @@ CUB_TEST("DeviceScan::InclusiveSumByKey can be tuned", "[scan][by_key][device]",
 
   device_scan_inclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), 7, equality_op, env);
 
-  c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
+  const c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -220,7 +220,7 @@ CUB_TEST("DeviceScan::InclusiveScanByKey can be tuned", "[scan][by_key][device]"
   device_scan_inclusive_scan_by_key(
     d_keys.begin(), d_in.begin(), d_out.begin(), scan_op, 7, cuda::std::equal_to<>{}, env);
 
-  c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
+  const c2h::device_vector<int> expected{8, 14, 7, 12, 15, 0, 9};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -231,10 +231,10 @@ CUB_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][de
 {
   using num_items_t = int;
 
-  num_items_t num_items = 7;
-  auto d_keys           = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
-  auto d_in             = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
-  auto d_out            = thrust::device_vector<float>(num_items);
+  const num_items_t num_items = 7;
+  auto d_keys                 = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
+  auto d_in                   = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
+  auto d_out                  = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -252,7 +252,7 @@ CUB_TEST("Device scan exclusive-sum-by-key uses environment", "[scan][by_key][de
 
   device_scan_exclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), num_items, cuda::std::equal_to<>{}, env);
 
-  thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
+  const thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   REQUIRE(d_out == expected);
 }
 
@@ -261,11 +261,11 @@ CUB_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][d
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 7;
-  auto d_keys           = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
-  auto d_in             = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
-  auto d_out            = thrust::device_vector<float>(num_items);
-  auto init             = 0.0f;
+  const num_items_t num_items = 7;
+  auto d_keys                 = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
+  auto d_in                   = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
+  auto d_out                  = thrust::device_vector<float>(num_items);
+  auto init                   = 0.0f;
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -286,7 +286,7 @@ CUB_TEST("Device scan exclusive-scan-by-key uses environment", "[scan][by_key][d
   device_scan_exclusive_scan_by_key(
     d_keys.begin(), d_in.begin(), d_out.begin(), scan_op_t{}, init, num_items, cuda::std::equal_to<>{}, env);
 
-  thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
+  const thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   REQUIRE(d_out == expected);
 }
 
@@ -294,10 +294,10 @@ CUB_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][de
 {
   using num_items_t = int;
 
-  num_items_t num_items = 7;
-  auto d_keys           = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
-  auto d_in             = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
-  auto d_out            = thrust::device_vector<float>(num_items);
+  const num_items_t num_items = 7;
+  auto d_keys                 = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
+  auto d_in                   = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
+  auto d_out                  = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -315,7 +315,7 @@ CUB_TEST("Device scan inclusive-sum-by-key uses environment", "[scan][by_key][de
 
   device_scan_inclusive_sum_by_key(d_keys.begin(), d_in.begin(), d_out.begin(), num_items, cuda::std::equal_to<>{}, env);
 
-  thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
+  const thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   REQUIRE(d_out == expected);
 }
 
@@ -324,10 +324,10 @@ CUB_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 7;
-  auto d_keys           = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
-  auto d_in             = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
-  auto d_out            = thrust::device_vector<float>(num_items);
+  const num_items_t num_items = 7;
+  auto d_keys                 = thrust::device_vector<int>{0, 0, 1, 1, 1, 2, 2};
+  auto d_in                   = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
+  auto d_out                  = thrust::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -347,7 +347,7 @@ CUB_TEST("Device scan inclusive-scan-by-key uses environment", "[scan][by_key][d
   device_scan_inclusive_scan_by_key(
     d_keys.begin(), d_in.begin(), d_out.begin(), scan_op_t{}, num_items, cuda::std::equal_to<>{}, env);
 
-  thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
+  const thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   REQUIRE(d_out == expected);
 }
 

--- a/cub/test/catch2_test_device_scan_by_key_env_api.cu
+++ b/cub/test/catch2_test_device_scan_by_key_env_api.cu
@@ -21,8 +21,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
   auto input  = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
   auto output = thrust::device_vector<float>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::ExclusiveSumByKey(
     keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, stream_ref);
@@ -31,7 +31,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveSumByKey accepts stream environment", "[scan
     std::cerr << "cub::DeviceScan::ExclusiveSumByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
+  const thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-sum-by-key-env
 
   stream.sync();
@@ -48,8 +48,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
   auto output = thrust::device_vector<float>(7);
   auto init   = 0.0f;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::ExclusiveScanByKey(
     keys.begin(),
@@ -65,7 +65,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScanByKey accepts stream environment", "[sca
     std::cerr << "cub::DeviceScan::ExclusiveScanByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
+  const thrust::device_vector<float> expected{0.0f, 8.0f, 0.0f, 7.0f, 12.0f, 0.0f, 0.0f};
   // example-end exclusive-scan-by-key-env
 
   stream.sync();
@@ -80,8 +80,8 @@ CUB_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
   auto input  = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
   auto output = thrust::device_vector<float>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::InclusiveSumByKey(
     keys.begin(), input.begin(), output.begin(), static_cast<int>(input.size()), cuda::std::equal_to<>{}, stream_ref);
@@ -90,7 +90,7 @@ CUB_TEST("cub::DeviceScan::InclusiveSumByKey accepts stream environment", "[scan
     std::cerr << "cub::DeviceScan::InclusiveSumByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
+  const thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-sum-by-key-env
 
   stream.sync();
@@ -106,8 +106,8 @@ CUB_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
   auto input  = thrust::device_vector<float>{8.0f, 6.0f, 7.0f, 5.0f, 3.0f, 0.0f, 9.0f};
   auto output = thrust::device_vector<float>(7);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::InclusiveScanByKey(
     keys.begin(),
@@ -122,7 +122,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScanByKey accepts stream environment", "[sca
     std::cerr << "cub::DeviceScan::InclusiveScanByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
+  const thrust::device_vector<float> expected{8.0f, 14.0f, 7.0f, 12.0f, 15.0f, 0.0f, 9.0f};
   // example-end inclusive-scan-by-key-env
 
   stream.sync();

--- a/cub/test/catch2_test_device_scan_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_scan_by_key_iterators.cu
@@ -94,14 +94,14 @@ CUB_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", CUB
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", " << std::get<1>(seg_size_range) << "]");
 
   // Generate input segments
-  c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
+  const c2h::device_vector<offset_t> segment_offsets = c2h::gen_uniform_offsets<offset_t>(
     C2H_SEED(1), num_items, std::get<0>(seg_size_range), std::get<1>(seg_size_range));
 
   // Get array of keys from segment offsets
   c2h::device_vector<key_t> segment_keys(num_items);
   c2h::init_key_segments(segment_offsets, segment_keys);
   auto d_keys_it = segment_keys.begin();
-  c2h::host_vector<key_t> h_segment_keys(segment_keys);
+  const c2h::host_vector<key_t> h_segment_keys(segment_keys);
 
   // Prepare input data
   value_t default_constant{};

--- a/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
@@ -30,8 +30,8 @@ struct expected_sum_op
 
   __host__ __device__ __forceinline__ ItemT operator()(const uint64_t index) const
   {
-    uint64_t index_within_segment = index % segment_size;
-    uint64_t full_segments        = index / segment_size;
+    const uint64_t index_within_segment = index % segment_size;
+    const uint64_t full_segments        = index / segment_size;
 
     uint64_t sum_within_partial_segment{};
     if (IsExclusive)
@@ -109,7 +109,7 @@ try
     // Ensure that we created the correct output
     auto expected_out_it = cuda::transform_iterator(
       index_it, expected_sum_op<item_t, is_exclusive>{static_cast<index_t>(segment_size), initial_value});
-    bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+    const bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
     REQUIRE(all_results_correct == true);
   }
   SECTION("InclusiveScanByKey")
@@ -121,7 +121,7 @@ try
     // Ensure that we created the correct output
     auto expected_out_it = cuda::transform_iterator(
       index_it, expected_sum_op<item_t, is_exclusive>{static_cast<index_t>(segment_size), initial_value});
-    bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+    const bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
     REQUIRE(all_results_correct == true);
   }
 }

--- a/cub/test/catch2_test_device_scan_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_scan_custom_policy_hub.cu
@@ -43,7 +43,7 @@ CUB_TEST("DispatchScan::Dispatch: custom policy hub", "[scan][device]", CUB_SMAL
   c2h::gen(C2H_SEED(1), in_items);
 
   c2h::host_vector<value_t> expected(num_items);
-  c2h::host_vector<value_t> host_items(in_items);
+  const c2h::host_vector<value_t> host_items(in_items);
   compute_inclusive_scan_reference(host_items.cbegin(), host_items.cend(), expected.begin(), scan_op_t{}, value_t{});
 
   using policy_hub_t = my_policy_hub<value_t, value_t, accum_t, offset_t, scan_op_t>;

--- a/cub/test/catch2_test_device_scan_deterministic.cu
+++ b/cub/test/catch2_test_device_scan_deterministic.cu
@@ -111,7 +111,7 @@ CUB_TEST("DeviceScan::ExclusiveScan with run_to_run determinism matches host ref
   const auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
   const auto op  = cuda::std::plus<type>{};
 
-  c2h::host_vector<type> h_input(d_input);
+  const c2h::host_vector<type> h_input(d_input);
   c2h::host_vector<type> h_reference(num_items);
   compute_exclusive_scan_reference(h_input.cbegin(), h_input.cend(), h_reference.begin(), type{}, op);
 

--- a/cub/test/catch2_test_device_scan_env.cu
+++ b/cub/test/catch2_test_device_scan_env.cu
@@ -51,9 +51,9 @@ CUB_TEST_CASE("Device scan exclusive scan works with default environment", "[sca
   using value_t     = int;
   using offset_t    = cub::detail::choose_offset_t<num_items_t>;
 
-  num_items_t num_items = 2;
-  auto d_in             = cuda::constant_iterator(value_t{1});
-  auto d_out            = c2h::device_vector<value_t>(num_items);
+  const num_items_t num_items = 2;
+  auto d_in                   = cuda::constant_iterator(value_t{1});
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
 
   using selector_t = cub::detail::scan::
     policy_selector_from_types<decltype(d_in), decltype(d_out.begin()), value_t, offset_t, block_size_check_t>;
@@ -63,7 +63,7 @@ CUB_TEST_CASE("Device scan exclusive scan works with default environment", "[sca
   const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto init = value_t{42};
   REQUIRE(cudaSuccess == cub::DeviceScan::ExclusiveScan(d_in, d_out.begin(), block_size_check, init, num_items));
@@ -78,7 +78,7 @@ CUB_TEST_CASE("Device scan exclusive scan with FutureValue works with default en
 {
   using num_items_t = int;
 
-  num_items_t num_items = 4;
+  const num_items_t num_items = 4;
 
   auto d_in  = c2h::device_vector<int>{1, 1, 1, 1};
   auto d_out = c2h::device_vector<int>(num_items);
@@ -98,7 +98,7 @@ CUB_TEST_CASE("Device scan exclusive sum works with default environment", "[sum]
   using num_items_t = int;
   using value_t     = int;
 
-  num_items_t num_items = 2;
+  const num_items_t num_items = 2;
 
   auto d_in  = cuda::constant_iterator(value_t{1});
   auto d_out = c2h::device_vector<value_t>(num_items);
@@ -113,11 +113,11 @@ CUB_TEST_CASE("Device scan inclusive-scan-init works with default environment", 
   using num_items_t = int;
   using value_t     = int;
 
-  num_items_t num_items = 3;
-  auto d_in             = cuda::constant_iterator(value_t{1});
-  auto d_out            = c2h::device_vector<value_t>(num_items);
+  const num_items_t num_items = 3;
+  auto d_in                   = cuda::constant_iterator(value_t{1});
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
 
-  value_t init{10};
+  const value_t init{10};
 
   REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScanInit(d_in, d_out.begin(), cuda::std::plus{}, init, num_items));
 
@@ -164,7 +164,7 @@ CUB_TEST("Device scan exclusive-scan can be tuned", "[scan][device]", CUB_SMALL,
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto num_items = 3;
   auto d_in      = cuda::constant_iterator(1);
@@ -205,7 +205,7 @@ CUB_TEST_CASE("Device scan inclusive sum works with default environment", "[sum]
   using num_items_t = int;
   using value_t     = int;
 
-  num_items_t num_items = 3;
+  const num_items_t num_items = 3;
 
   auto d_in  = c2h::device_vector<value_t>{1, 1, 1};
   auto d_out = c2h::device_vector<value_t>(num_items);
@@ -222,9 +222,9 @@ CUB_TEST_CASE("Device scan inclusive-scan works with default environment", "[sca
   using value_t     = int;
   using offset_t    = cub::detail::choose_offset_t<num_items_t>;
 
-  num_items_t num_items = 2;
-  auto d_in             = cuda::constant_iterator(value_t{1});
-  auto d_out            = c2h::device_vector<value_t>(num_items);
+  const num_items_t num_items = 2;
+  auto d_in                   = cuda::constant_iterator(value_t{1});
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
 
   using selector_t = cub::detail::scan::
     policy_selector_from_types<decltype(d_in), decltype(d_out.begin()), value_t, offset_t, block_size_check_t>;
@@ -234,7 +234,7 @@ CUB_TEST_CASE("Device scan inclusive-scan works with default environment", "[sca
   const unsigned int target_block_size = selector_t{}(cc).lookback.threads_per_block;
 
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   REQUIRE(cudaSuccess == cub::DeviceScan::InclusiveScan(d_in, d_out.begin(), block_size_check, num_items));
   REQUIRE(d_out[0] == d_in[0]);
@@ -248,7 +248,7 @@ CUB_TEST("Device scan inclusive-scan can be tuned", "[scan][device]", CUB_SMALL,
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto num_items = 3;
   auto d_in      = cuda::constant_iterator(1);
@@ -267,13 +267,13 @@ CUB_TEST("Device scan inclusive-scan-init can be tuned", "[scan][device]", CUB_S
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_check_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto num_items = 3;
   auto d_in      = cuda::constant_iterator(1);
   auto d_out     = c2h::device_vector<int>(num_items);
 
-  int init{10};
+  const int init{10};
 
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(scan_tuning<target_block_size>{}, unrelated_tuning{});
@@ -353,13 +353,13 @@ CUB_TEST("Device scan exclusive-scan uses environment", "[scan][device]", CUB_SM
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = cuda::constant_iterator(1.0f);
-  auto d_out            = c2h::device_vector<float>(num_items);
+  const num_items_t num_items = 10;
+  auto d_in                   = cuda::constant_iterator(1.0f);
+  auto d_out                  = c2h::device_vector<float>(num_items);
 
   using init_value_t = float;
 
-  init_value_t init{42.0f};
+  const init_value_t init{42.0f};
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess
@@ -379,9 +379,9 @@ CUB_TEST("Device scan exclusive-scan with FutureValue uses environment", "[scan]
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = cuda::constant_iterator(1);
-  auto d_out            = c2h::device_vector<int>(num_items);
+  const num_items_t num_items = 10;
+  auto d_in                   = cuda::constant_iterator(1);
+  auto d_out                  = c2h::device_vector<int>(num_items);
 
   auto init_value_vec = c2h::device_vector<int>{42};
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
@@ -404,9 +404,9 @@ CUB_TEST("Device scan exclusive-sum uses environment", "[scan][device]", CUB_SMA
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = cuda::constant_iterator(1.0f);
-  auto d_out            = c2h::device_vector<float>(num_items);
+  const num_items_t num_items = 10;
+  auto d_in                   = cuda::constant_iterator(1.0f);
+  auto d_out                  = c2h::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -424,9 +424,9 @@ CUB_TEST("Device scan inclusive-sum uses environment", "[scan][device]", CUB_SMA
 {
   using num_items_t = int;
 
-  num_items_t num_items = GENERATE(0, 1, 10);
-  auto d_in             = c2h::device_vector<int>(num_items, 3);
-  auto d_out            = c2h::device_vector<int>(num_items);
+  const num_items_t num_items = GENERATE(0, 1, 10);
+  auto d_in                   = c2h::device_vector<int>(num_items, 3);
+  auto d_out                  = c2h::device_vector<int>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess
@@ -442,7 +442,7 @@ CUB_TEST("Device scan inclusive-sum uses environment", "[scan][device]", CUB_SMA
   {
     h_expected[i] = 3 * (i + 1);
   }
-  c2h::device_vector<int> expected = h_expected;
+  const c2h::device_vector<int> expected = h_expected;
   REQUIRE(d_out == expected);
 }
 
@@ -451,9 +451,9 @@ CUB_TEST("Device scan inclusive-scan uses environment", "[scan][device]", CUB_SM
   using scan_op_t   = cuda::std::plus<>;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = cuda::constant_iterator(1.0f);
-  auto d_out            = c2h::device_vector<float>(num_items);
+  const num_items_t num_items = 10;
+  auto d_in                   = cuda::constant_iterator(1.0f);
+  auto d_out                  = c2h::device_vector<float>(num_items);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -471,10 +471,10 @@ CUB_TEST("Device scan inclusive-scan-init uses environment", "[scan][device]", C
 {
   using num_items_t = int;
 
-  num_items_t num_items = 4;
-  auto d_in             = c2h::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
-  auto d_out            = c2h::device_vector<float>(num_items);
-  float init            = 10.0f;
+  const num_items_t num_items = 4;
+  auto d_in                   = c2h::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
+  auto d_out                  = c2h::device_vector<float>(num_items);
+  const float init            = 10.0f;
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess

--- a/cub/test/catch2_test_device_scan_env_api.cu
+++ b/cub/test/catch2_test_device_scan_env_api.cu
@@ -33,7 +33,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan accepts run_to_run determinism requirem
     std::cerr << "cub::DeviceScan::ExclusiveScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 0, 1, 3};
+  const thrust::device_vector<int> expected{0, 0, 1, 3};
   // example-end exclusive-scan-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -48,8 +48,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed deter
   auto output = thrust::device_vector<float>(4);
   auto init   = 1.0f;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto req_env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
   auto env     = cuda::std::execution::env{stream_ref, req_env};
 
@@ -59,7 +59,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan accepts stream and not_guaranteed deter
     std::cerr << "cub::DeviceScan::ExclusiveScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{1.0f, 1.0f, 2.0f, 4.0f};
+  const thrust::device_vector<float> expected{1.0f, 1.0f, 2.0f, 4.0f};
   // example-end exclusive-scan-env-stream
   stream.sync();
 
@@ -81,7 +81,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveSum accepts run_to_run determinism requireme
     std::cerr << "cub::DeviceScan::ExclusiveSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 0, 1, 3};
+  const thrust::device_vector<int> expected{0, 0, 1, 3};
   // example-end exclusive-sum-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -94,8 +94,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determ
   auto input  = thrust::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = thrust::device_vector<float>(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto req_env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
   auto env     = cuda::std::execution::env{stream_ref, req_env};
 
@@ -105,7 +105,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveSum accepts stream and not_guaranteed determ
     std::cerr << "cub::DeviceScan::ExclusiveSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{0.0f, 0.0f, 1.0f, 3.0f};
+  const thrust::device_vector<float> expected{0.0f, 0.0f, 1.0f, 3.0f};
   // example-end exclusive-sum-env-stream
   stream.sync();
 
@@ -127,7 +127,7 @@ CUB_TEST("cub::DeviceScan::InclusiveSum accepts run_to_run determinism requireme
     std::cerr << "cub::DeviceScan::InclusiveSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 10};
+  const thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-sum-env-determinism
 
   REQUIRE(error == cudaSuccess);
@@ -140,8 +140,8 @@ CUB_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determ
   auto input  = thrust::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
   auto output = thrust::device_vector<float>(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto req_env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
   auto env     = cuda::std::execution::env{stream_ref, req_env};
 
@@ -151,7 +151,7 @@ CUB_TEST("cub::DeviceScan::InclusiveSum accepts stream and not_guaranteed determ
     std::cerr << "cub::DeviceScan::InclusiveSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{1.0f, 3.0f, 6.0f, 10.0f};
+  const thrust::device_vector<float> expected{1.0f, 3.0f, 6.0f, 10.0f};
   // example-end inclusive-sum-env-stream
   stream.sync();
 
@@ -177,7 +177,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts environment", 
     std::cerr << "cub::DeviceScan::ExclusiveScan (FutureValue) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{5, 13, 19, 26, 31, 34, 34};
+  const thrust::device_vector<int> expected{5, 13, 19, 26, 31, 34, 34};
   // example-end exclusive-scan-future-env
 
   REQUIRE(error == cudaSuccess);
@@ -193,8 +193,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environ
   auto init_value_vec = thrust::device_vector<int>{10};
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::ExclusiveScan(
     input.begin(), output.begin(), cuda::std::plus{}, future_init, input.size(), stream_ref);
@@ -203,7 +203,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue accepts stream environ
     std::cerr << "cub::DeviceScan::ExclusiveScan (FutureValue) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{10, 11, 13, 16};
+  const thrust::device_vector<int> expected{10, 11, 13, 16};
   // example-end exclusive-scan-future-env-stream
   stream.sync();
 
@@ -224,7 +224,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScan accepts environment", "[scan][env]", CU
     std::cerr << "cub::DeviceScan::InclusiveScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 10};
+  const thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-scan-env
 
   REQUIRE(error == cudaSuccess);
@@ -238,8 +238,8 @@ CUB_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][en
   auto input  = thrust::device_vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
   auto output = thrust::device_vector<float>(4);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::InclusiveScan(input.begin(), output.begin(), op, input.size(), stream_ref);
   if (error != cudaSuccess)
@@ -247,7 +247,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScan accepts stream environment", "[scan][en
     std::cerr << "cub::DeviceScan::InclusiveScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{1.0f, 3.0f, 6.0f, 10.0f};
+  const thrust::device_vector<float> expected{1.0f, 3.0f, 6.0f, 10.0f};
   // example-end inclusive-scan-env-stream
   stream.sync();
 
@@ -269,7 +269,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScanInit accepts environment", "[scan][env]"
     std::cerr << "cub::DeviceScan::InclusiveScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{11, 13, 16, 20};
+  const thrust::device_vector<int> expected{11, 13, 16, 20};
   // example-end inclusive-scan-init-env
 
   REQUIRE(error == cudaSuccess);
@@ -294,7 +294,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScanInit with args::deferred accepts environ
     std::cerr << "cub::DeviceScan::InclusiveScanInit (FutureValue) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{11, 13, 16, 20};
+  const thrust::device_vector<int> expected{11, 13, 16, 20};
   // example-end inclusive-scan-future-init-env
 
   REQUIRE(error == cudaSuccess);
@@ -309,8 +309,8 @@ CUB_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan
   auto output = thrust::device_vector<float>(4);
   auto init   = 10.0f;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::InclusiveScanInit(input.begin(), output.begin(), op, init, input.size(), stream_ref);
   if (error != cudaSuccess)
@@ -318,7 +318,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScanInit accepts stream environment", "[scan
     std::cerr << "cub::DeviceScan::InclusiveScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<float> expected{11.0f, 13.0f, 16.0f, 20.0f};
+  const thrust::device_vector<float> expected{11.0f, 13.0f, 16.0f, 20.0f};
   // example-end inclusive-scan-init-env-stream
   stream.sync();
 
@@ -331,8 +331,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]",
   // example-begin exclusive-sum-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::ExclusiveSum(data.begin(), static_cast<int>(data.size()), stream_ref);
   if (error != cudaSuccess)
@@ -340,7 +340,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveSum in-place accepts stream", "[scan][env]",
     std::cerr << "cub::DeviceScan::ExclusiveSum in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 1, 3, 6};
+  const thrust::device_vector<int> expected{0, 1, 3, 6};
   // example-end exclusive-sum-inplace-env
   stream.sync();
 
@@ -353,8 +353,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]"
   // example-begin exclusive-scan-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error =
     cub::DeviceScan::ExclusiveScan(data.begin(), cuda::std::plus{}, 42, static_cast<int>(data.size()), stream_ref);
@@ -363,7 +363,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan in-place accepts stream", "[scan][env]"
     std::cerr << "cub::DeviceScan::ExclusiveScan in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{42, 43, 45, 48};
+  const thrust::device_vector<int> expected{42, 43, 45, 48};
   // example-end exclusive-scan-inplace-env
   stream.sync();
 
@@ -379,8 +379,8 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts strea
   auto init_value_vec = thrust::device_vector<int>{10};
   auto future_init    = cub::FutureValue<int>(thrust::raw_pointer_cast(init_value_vec.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::ExclusiveScan(
     data.begin(), cuda::std::plus{}, future_init, static_cast<int>(data.size()), stream_ref);
@@ -389,7 +389,7 @@ CUB_TEST("cub::DeviceScan::ExclusiveScan with FutureValue in-place accepts strea
     std::cerr << "cub::DeviceScan::ExclusiveScan (FutureValue) in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{10, 11, 13, 16};
+  const thrust::device_vector<int> expected{10, 11, 13, 16};
   // example-end exclusive-scan-future-inplace-env
   stream.sync();
 
@@ -402,8 +402,8 @@ CUB_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]",
   // example-begin inclusive-sum-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceScan::InclusiveSum(data.begin(), static_cast<int>(data.size()), stream_ref);
   if (error != cudaSuccess)
@@ -411,7 +411,7 @@ CUB_TEST("cub::DeviceScan::InclusiveSum in-place accepts stream", "[scan][env]",
     std::cerr << "cub::DeviceScan::InclusiveSum in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 10};
+  const thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-sum-inplace-env
   stream.sync();
 
@@ -424,8 +424,8 @@ CUB_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]"
   // example-begin inclusive-scan-inplace-env
   auto data = thrust::device_vector<int>{1, 2, 3, 4};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error =
     cub::DeviceScan::InclusiveScan(data.begin(), cuda::std::plus{}, static_cast<int>(data.size()), stream_ref);
@@ -434,7 +434,7 @@ CUB_TEST("cub::DeviceScan::InclusiveScan in-place accepts stream", "[scan][env]"
     std::cerr << "cub::DeviceScan::InclusiveScan in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, 10};
+  const thrust::device_vector<int> expected{1, 3, 6, 10};
   // example-end inclusive-scan-inplace-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -300,7 +300,7 @@ CUB_TEST("Device scan works complex accumulator types", "[scan][device]", CUB_SM
 {
   constexpr int num_items = 2 * 1024 * 1024;
 
-  custom_accumulator_t init{};
+  const custom_accumulator_t init{};
 
   c2h::device_vector<custom_input_t> d_input(static_cast<size_t>(num_items), custom_input_t{1});
   c2h::device_vector<custom_output_t> d_output{static_cast<size_t>(num_items), custom_output_t{nullptr, 0}};

--- a/cub/test/catch2_test_device_scan_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_large_offsets.cu
@@ -28,12 +28,12 @@ struct expected_exclusive_sum_op
 
   __host__ __device__ __forceinline__ ItemT operator()(const uint64_t index) const
   {
-    uint64_t sum_per_full_segment = (segment_size * (segment_size - 1)) / 2;
-    uint64_t full_segments        = index / segment_size;
-    uint64_t index_within_segment = index % segment_size;
+    const uint64_t sum_per_full_segment = (segment_size * (segment_size - 1)) / 2;
+    const uint64_t full_segments        = index / segment_size;
+    const uint64_t index_within_segment = index % segment_size;
 
-    uint64_t sum_within_partial_segment = (index_within_segment * (index_within_segment - 1)) / 2;
-    uint64_t sum_over_full_segments     = full_segments * sum_per_full_segment;
+    const uint64_t sum_within_partial_segment = (index_within_segment * (index_within_segment - 1)) / 2;
+    const uint64_t sum_over_full_segments     = full_segments * sum_per_full_segment;
     return static_cast<ItemT>(sum_within_partial_segment + sum_over_full_segments);
   }
 };
@@ -47,15 +47,15 @@ struct expected_inclusive_sum_op
   {
     // The sum of a completed segment (0 to segment_size-1)
     // Formula: n(n+1)/2 where n is segment_size-1
-    uint64_t sum_per_full_segment = (segment_size * (segment_size - 1)) / 2;
+    const uint64_t sum_per_full_segment = (segment_size * (segment_size - 1)) / 2;
 
-    uint64_t full_segments        = index / segment_size;
-    uint64_t index_within_segment = index % segment_size;
+    const uint64_t full_segments        = index / segment_size;
+    const uint64_t index_within_segment = index % segment_size;
 
     // For inclusive, this includes the current index value in the sum.
-    uint64_t sum_within_partial_segment = (index_within_segment * (index_within_segment + 1)) / 2;
+    const uint64_t sum_within_partial_segment = (index_within_segment * (index_within_segment + 1)) / 2;
 
-    uint64_t sum_over_full_segments = full_segments * sum_per_full_segment;
+    const uint64_t sum_over_full_segments = full_segments * sum_per_full_segment;
 
     return static_cast<ItemT>(sum_within_partial_segment + sum_over_full_segments);
   }
@@ -107,7 +107,7 @@ try
   // Ensure that we created the correct output
   auto expected_out_it =
     cuda::transform_iterator(index_it, expected_exclusive_sum_op<item_t>{static_cast<index_t>(segment_size)});
-  bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+  const bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
   REQUIRE(all_results_correct == true);
 }
 catch (std::bad_alloc&)
@@ -151,7 +151,7 @@ try
   // Ensure that we created the correct output
   auto expected_out_it =
     cuda::transform_iterator(index_it, expected_inclusive_sum_op<item_t>{static_cast<index_t>(segment_size)});
-  bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+  const bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
   REQUIRE(all_results_correct == true);
 }
 catch (std::bad_alloc&)

--- a/cub/test/catch2_test_device_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_scan_noncommutative.cu
@@ -61,7 +61,8 @@ CUB_TEST("Device inclusive scan works with non-commutative operator", "[scan][de
   pair_t* d_output = thrust::raw_pointer_cast(output.data());
 
   size_t tmp_size{};
-  cudaError_t status1 = cub::DeviceScan::InclusiveScan(nullptr, tmp_size, d_input, d_output, op_t{}, input.size());
+  const cudaError_t status1 =
+    cub::DeviceScan::InclusiveScan(nullptr, tmp_size, d_input, d_output, op_t{}, input.size());
   REQUIRE(cudaSuccess == status1);
   REQUIRE(tmp_size > 0);
 
@@ -72,11 +73,11 @@ CUB_TEST("Device inclusive scan works with non-commutative operator", "[scan][de
 
   REQUIRE(d_tmp != nullptr);
 
-  cudaError_t status2 = cub::DeviceScan::InclusiveScan(d_tmp, tmp_size, d_input, d_output, op_t{}, input.size());
+  const cudaError_t status2 = cub::DeviceScan::InclusiveScan(d_tmp, tmp_size, d_input, d_output, op_t{}, input.size());
   REQUIRE(cudaSuccess == status2);
 
   // transfer to host_vector is synchronizing
-  c2h::host_vector<pair_t> h_output(output);
+  const c2h::host_vector<pair_t> h_output(output);
   c2h::host_vector<pair_t> h_input(input);
   c2h::host_vector<pair_t> h_expected(input.size());
 

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -50,8 +50,8 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs works with default environmen
       offsets.begin(),
       offsets.begin() + 1));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -78,8 +78,8 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending works with default 
       offsets.begin(),
       offsets.begin() + 1));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -102,7 +102,7 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys works with default environment
       offsets.begin(),
       offsets.begin() + 1));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -124,7 +124,7 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending works with default e
       offsets.begin(),
       offsets.begin() + 1));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -142,10 +142,10 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with defaul
           == cub::DeviceSegmentedRadixSort::SortKeys(
             d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(result_keys == expected_keys);
 }
 
@@ -163,10 +163,10 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works w
           == cub::DeviceSegmentedRadixSort::SortKeysDescending(
             d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(result_keys == expected_keys);
 }
 
@@ -210,8 +210,8 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairs uses environment", "[segmented_rad
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -254,8 +254,8 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending uses environment", "[seg
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -292,7 +292,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeys uses environment", "[segmented_radi
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -328,7 +328,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending uses environment", "[segm
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
 }
 
@@ -376,8 +376,8 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs uses custom stream", "[segmen
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 
@@ -430,8 +430,8 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending uses custom stream"
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 
@@ -476,7 +476,7 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeys uses custom stream", "[segment
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected_keys);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -522,7 +522,7 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending uses custom stream",
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
 
   REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
@@ -560,10 +560,10 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[s
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(result_keys == expected_keys);
 }
 
@@ -601,10 +601,10 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environ
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(result_keys == expected_keys);
 }
 
@@ -626,13 +626,13 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with defau
           == cub::DeviceSegmentedRadixSort::SortPairs(
             d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  c2h::device_vector<int> result_values(
+  const c2h::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -655,13 +655,13 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works 
           == cub::DeviceSegmentedRadixSort::SortPairsDescending(
             d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  c2h::device_vector<int> result_values(
+  const c2h::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -706,13 +706,13 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment",
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  c2h::device_vector<int> result_values(
+  const c2h::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -757,13 +757,13 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses enviro
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  c2h::device_vector<int> result_values(
+  const c2h::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -814,13 +814,13 @@ CUB_TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stre
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<int> result_keys(
+  const c2h::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  c2h::device_vector<int> result_values(
+  const c2h::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 
@@ -978,7 +978,9 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer can be tuned",
   auto alt_values = c2h::device_vector<int>(10'000);
   c2h::device_vector<unsigned int> d_block_size(1, 0);
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys.data()), thrust::raw_pointer_cast(alt_keys.data()));
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_values(thrust::raw_pointer_cast(values.data()), thrust::raw_pointer_cast(alt_values.data()));
 
   auto d_begin_offsets = block_size_extracting_constant_iterator(0, thrust::raw_pointer_cast(d_block_size.data()));
@@ -1012,7 +1014,9 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer can be tune
   auto alt_values = c2h::device_vector<int>(10'000);
   c2h::device_vector<unsigned int> d_block_size(1, 0);
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys.data()), thrust::raw_pointer_cast(alt_keys.data()));
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_values(thrust::raw_pointer_cast(values.data()), thrust::raw_pointer_cast(alt_values.data()));
 
   auto d_begin_offsets = block_size_extracting_constant_iterator(0, thrust::raw_pointer_cast(d_block_size.data()));
@@ -1044,6 +1048,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer can be tuned",
   auto alt_keys = c2h::device_vector<int>(10'000);
   c2h::device_vector<unsigned int> d_block_size(1, 0);
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys.data()), thrust::raw_pointer_cast(alt_keys.data()));
 
   auto d_begin_offsets = block_size_extracting_constant_iterator(0, thrust::raw_pointer_cast(d_block_size.data()));
@@ -1074,6 +1079,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer can be tuned
   auto alt_keys = c2h::device_vector<int>(10'000);
   c2h::device_vector<unsigned int> d_block_size(1, 0);
 
+  // NOLINTNEXTLINE(misc-const-correctness)
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys.data()), thrust::raw_pointer_cast(alt_keys.data()));
 
   auto d_begin_offsets = block_size_extracting_constant_iterator(0, thrust::raw_pointer_cast(d_block_size.data()));

--- a/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
@@ -24,8 +24,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
   auto values_out = thrust::device_vector<int>(7);
   auto offsets    = thrust::device_vector<int>{0, 3, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairs(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -44,8 +44,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs env with stream", "[segmented
     std::cerr << "cub::DeviceSegmentedRadixSort::SortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end segmented-radix-sort-pairs-env
   stream.sync();
 
@@ -63,8 +63,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
   auto values_out = thrust::device_vector<int>(7);
   auto offsets    = thrust::device_vector<int>{0, 3, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -83,8 +83,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending env with stream", "
     std::cerr << "cub::DeviceSegmentedRadixSort::SortPairsDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end segmented-radix-sort-pairs-descending-env
   stream.sync();
 
@@ -100,8 +100,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -118,7 +118,7 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys env with stream", "[segmented_
     std::cerr << "cub::DeviceSegmentedRadixSort::SortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   // example-end segmented-radix-sort-keys-env
   stream.sync();
 
@@ -133,8 +133,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -151,7 +151,7 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending env with stream", "[
     std::cerr << "cub::DeviceSegmentedRadixSort::SortKeysDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   // example-end segmented-radix-sort-keys-descending-env
   stream.sync();
 
@@ -170,8 +170,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream",
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeys(
     d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1, 0, sizeof(int) * 8, stream_ref);
@@ -180,13 +180,13 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream",
     std::cerr << "cub::DeviceSegmentedRadixSort::SortKeys (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
   // example-end segmented-radix-sort-keys-db-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<int> result_keys(
+  const thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
   REQUIRE(result_keys == expected_keys);
 }
@@ -202,8 +202,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env wit
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortKeysDescending(
     d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1, 0, sizeof(int) * 8, stream_ref);
@@ -213,13 +213,13 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env wit
       << "cub::DeviceSegmentedRadixSort::SortKeysDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
   // example-end segmented-radix-sort-keys-descending-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<int> result_keys(
+  const thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
   REQUIRE(result_keys == expected_keys);
 }
@@ -239,8 +239,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream"
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairs(
     d_keys,
@@ -257,16 +257,16 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream"
     std::cerr << "cub::DeviceSegmentedRadixSort::SortPairs (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end segmented-radix-sort-pairs-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<int> result_keys(
+  const thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  thrust::device_vector<int> result_values(
+  const thrust::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
@@ -287,8 +287,8 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env wi
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
     d_keys,
@@ -306,16 +306,16 @@ CUB_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env wi
       << "cub::DeviceSegmentedRadixSort::SortPairsDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end segmented-radix-sort-pairs-descending-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<int> result_keys(
+  const thrust::device_vector<int> result_keys(
     thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
-  thrust::device_vector<int> result_values(
+  const thrust::device_vector<int> result_values(
     thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);

--- a/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
@@ -408,7 +408,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortKeys: unspecified ranges",
   begin_offsets.pop_back();
 
   {
-    std::size_t num_empty_segments = num_segments / 16;
+    const std::size_t num_empty_segments = num_segments / 16;
     c2h::device_vector<std::size_t> indices(num_empty_segments);
     c2h::gen(C2H_SEED(1), indices, std::size_t{0}, num_segments - 1);
     auto begin = cuda::constant_iterator(key_t{0});
@@ -476,7 +476,7 @@ try
 
   // Generate input keys
   constexpr auto max_histo_size = 250;
-  segmented_verification_helper<key_t> verification_helper{max_histo_size};
+  const segmented_verification_helper<key_t> verification_helper{max_histo_size};
   verification_helper.prepare_input_data(in_keys);
 
   auto offsets = cuda::transform_iterator(

--- a/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
@@ -209,7 +209,7 @@ CUB_TEST("DeviceSegmentedRadixSort::SortPairs: unspecified ranges",
   begin_offsets.pop_back();
 
   {
-    std::size_t num_empty_segments = num_segments / 16;
+    const std::size_t num_empty_segments = num_segments / 16;
     c2h::device_vector<std::size_t> indices(num_empty_segments);
     c2h::gen(C2H_SEED(1), indices, std::size_t{0}, num_segments - 1);
     auto begin = cuda::constant_iterator(key_t{0});
@@ -284,7 +284,7 @@ try
   c2h::device_vector<key_t> in_keys(num_items);
   c2h::device_vector<value_t> in_values(num_items);
   constexpr auto max_histo_size = 250;
-  segmented_verification_helper<key_t> verification_helper{max_histo_size};
+  const segmented_verification_helper<key_t> verification_helper{max_histo_size};
   verification_helper.prepare_input_data(in_keys);
   thrust::copy(in_keys.cbegin(), in_keys.cend(), in_values.begin());
 

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -210,7 +210,7 @@ CUB_TEST(
     using result_t = cub::KeyValuePair<int, output_t>;
 
     // Prepare verification data
-    c2h::host_vector<input_t> host_items(in_items);
+    const c2h::host_vector<input_t> host_items(in_items);
     c2h::host_vector<result_t> expected_result(num_segments);
     compute_segmented_argmin_reference(in_items, segment_offsets, expected_result.begin());
 
@@ -273,8 +273,8 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     c2h::device_vector<output_t> out_result(num_segments);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
 
-    using init_value_t = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
-    init_value_t init  = static_cast<init_value_t>(*unwrap_it(&default_constant));
+    using init_value_t      = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
+    const init_value_t init = static_cast<init_value_t>(*unwrap_it(&default_constant));
     device_segmented_reduce(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size, reduction_op, init);
     // Verify result
     REQUIRE(expected_result == out_result);
@@ -298,7 +298,7 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     auto d_out_it = unwrap_it(thrust::raw_pointer_cast(d_out_result.data()));
     device_segmented_sum(d_in_it, d_out_it, num_segments, segment_size);
 
-    c2h::host_vector<output_t> h_out_result(d_out_result);
+    const c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
     REQUIRE(h_expected_result == h_out_result);
   }
@@ -323,7 +323,7 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     auto d_out_it = thrust::raw_pointer_cast(d_out_result.data());
     device_segmented_min(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
 
-    c2h::host_vector<output_t> h_out_result(d_out_result);
+    const c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
     REQUIRE(h_expected_result == h_out_result);
   }
@@ -340,7 +340,7 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     c2h::device_vector<result_t> d_out_result(num_segments);
     device_segmented_arg_min(d_in_it, thrust::raw_pointer_cast(d_out_result.data()), num_segments, segment_size);
 
-    c2h::host_vector<result_t> h_out_result(d_out_result);
+    const c2h::host_vector<result_t> h_out_result(d_out_result);
     // Verify result
     REQUIRE(h_expected_result == h_out_result);
   }
@@ -364,7 +364,7 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     auto d_out_it = thrust::raw_pointer_cast(d_out_result.data());
     device_segmented_max(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
 
-    c2h::host_vector<output_t> h_out_result(d_out_result);
+    const c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
     REQUIRE(h_expected_result == h_out_result);
   }
@@ -381,7 +381,7 @@ CUB_TEST("Device fixed size segmented reduce works with all device interfaces",
     c2h::device_vector<result_t> d_out_result(num_segments);
     device_segmented_arg_max(d_in_it, thrust::raw_pointer_cast(d_out_result.data()), num_segments, segment_size);
 
-    c2h::host_vector<result_t> h_out_result(d_out_result);
+    const c2h::host_vector<result_t> h_out_result(d_out_result);
     // Verify result
     REQUIRE(h_expected_result == h_out_result);
   }

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -45,13 +45,13 @@ struct is_equal
 CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   c2h::device_vector<int> d_out(3);
-  CustomMin min_op;
-  int initial_value{INT_MAX};
+  const CustomMin min_op;
+  const int initial_value{INT_MAX};
 
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
@@ -82,7 +82,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
     min_op,
     initial_value);
 
-  c2h::device_vector<int> expected{6, INT_MAX, 0};
+  const c2h::device_vector<int> expected{6, INT_MAX, 0};
   // example-end segmented-reduce-reduce
 
   REQUIRE(d_out == expected);
@@ -91,7 +91,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
 CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-sum
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -110,7 +110,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
   cub::DeviceSegmentedReduce::Sum(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
-  c2h::device_vector<int> expected{21, 0, 17};
+  const c2h::device_vector<int> expected{21, 0, 17};
   // example-end segmented-reduce-sum
 
   REQUIRE(d_out == expected);
@@ -119,7 +119,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
 CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-min
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -138,7 +138,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
   cub::DeviceSegmentedReduce::Min(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
-  c2h::device_vector<int> expected{6, INT_MAX, 0};
+  const c2h::device_vector<int> expected{6, INT_MAX, 0};
   // example-end segmented-reduce-min
 
   REQUIRE(d_out == expected);
@@ -147,7 +147,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmin
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -175,7 +175,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[se
 CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-max
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -194,7 +194,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
   cub::DeviceSegmentedReduce::Max(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
-  c2h::device_vector<int> expected{8, INT_MIN, 9};
+  const c2h::device_vector<int> expected{8, INT_MIN, 9};
   // example-end segmented-reduce-max
 
   REQUIRE(d_out == expected);
@@ -203,7 +203,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[segmented_reduce][device]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmax
-  int num_segments                  = 3;
+  const int num_segments            = 3;
   c2h::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                 = thrust::raw_pointer_cast(d_offsets.data());
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -233,12 +233,12 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int d
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-reduce
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
   c2h::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   c2h::device_vector<int> d_out(3);
-  CustomMin min_op;
-  int initial_value{INT_MAX};
+  const CustomMin min_op;
+  const int initial_value{INT_MAX};
 
   // Determine temporary device storage requirements
   void* d_temp_storage      = nullptr;
@@ -253,7 +253,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int d
   cub::DeviceSegmentedReduce::Reduce(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size, min_op, initial_value);
 
-  c2h::device_vector<int> expected{6, 5, 0};
+  const c2h::device_vector<int> expected{6, 5, 0};
   // example-end fixed-size-segmented-reduce-reduce
 
   REQUIRE(d_out == expected);
@@ -264,8 +264,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-sum
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
   c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
   c2h::device_vector<int> d_out(3);
 
@@ -282,7 +282,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Sum(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> d_expected{14, 12, 3};
+  const c2h::device_vector<int> d_expected{14, 12, 3};
   // example-end fixed-size-segmented-reduce-sum
 
   REQUIRE(d_expected == d_out);
@@ -293,8 +293,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-min
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
   c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
   c2h::device_vector<int> d_out(3);
 
@@ -311,7 +311,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Min(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> d_expected{6, 5, 0};
+  const c2h::device_vector<int> d_expected{6, 5, 0};
   // example-end fixed-size-segmented-reduce-min
 
   REQUIRE(d_expected == d_out);
@@ -322,8 +322,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int d
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmin
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
   c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
   c2h::device_vector<cuda::std::pair<int, int>> d_out(3);
 
@@ -340,10 +340,10 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int d
   cub::DeviceSegmentedReduce::ArgMin(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::host_vector<cuda::std::pair<int, int>> h_expected{{0, 6}, {1, 5}, {1, 0}};
+  const c2h::host_vector<cuda::std::pair<int, int>> h_expected{{0, 6}, {1, 5}, {1, 0}};
   // example-end fixed-size-segmented-reduce-argmin
 
-  c2h::host_vector<cuda::std::pair<int, int>> h_out(d_out);
+  const c2h::host_vector<cuda::std::pair<int, int>> h_out(d_out);
 
   REQUIRE(h_expected == h_out);
 }
@@ -353,8 +353,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-max
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
 
   c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
   c2h::device_vector<int> d_out(3);
@@ -372,7 +372,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Max(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> d_expected{8, 7, 3};
+  const c2h::device_vector<int> d_expected{8, 7, 3};
   // example-end fixed-size-segmented-reduce-max
 
   REQUIRE(d_expected == d_out);
@@ -383,8 +383,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int d
          CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmax
-  int num_segments = 3;
-  int segment_size = 2;
+  const int num_segments = 3;
+  const int segment_size = 2;
   c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
   c2h::device_vector<cuda::std::pair<int, int>> d_out(3);
 
@@ -401,10 +401,10 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int d
   cub::DeviceSegmentedReduce::ArgMax(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::host_vector<cuda::std::pair<int, int>> h_expected{{1, 8}, {0, 7}, {0, 3}};
+  const c2h::host_vector<cuda::std::pair<int, int>> h_expected{{1, 8}, {0, 7}, {0, 3}};
   // example-end fixed-size-segmented-reduce-argmax
 
-  c2h::host_vector<cuda::std::pair<int, int>> h_out(d_out);
+  const c2h::host_vector<cuda::std::pair<int, int>> h_out(d_out);
   REQUIRE(h_expected == h_out);
 }
 

--- a/cub/test/catch2_test_device_segmented_reduce_env.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env.cu
@@ -37,7 +37,7 @@ namespace stdexec = cuda::std::execution;
 
 CUB_TEST_CASE("Device segmented reduce works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -47,13 +47,13 @@ CUB_TEST_CASE("Device segmented reduce works with default environment", "[segmen
           == cub::DeviceSegmentedReduce::Reduce(
             d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0));
 
-  thrust::device_vector<int> expected{26, 12, 3};
+  const thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device segmented sum works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -63,13 +63,13 @@ CUB_TEST_CASE("Device segmented sum works with default environment", "[segmented
     cudaSuccess
     == cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
-  thrust::device_vector<int> expected{26, 12, 3};
+  const thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device segmented min works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -79,13 +79,13 @@ CUB_TEST_CASE("Device segmented min works with default environment", "[segmented
     cudaSuccess
     == cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
-  thrust::device_vector<int> expected{5, 0, 1};
+  const thrust::device_vector<int> expected{5, 0, 1};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device segmented max works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -95,13 +95,13 @@ CUB_TEST_CASE("Device segmented max works with default environment", "[segmented
     cudaSuccess
     == cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1));
 
-  thrust::device_vector<int> expected{8, 9, 2};
+  const thrust::device_vector<int> expected{8, 9, 2};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device segmented argmin works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -122,7 +122,7 @@ CUB_TEST_CASE("Device segmented argmin works with default environment", "[segmen
 
 CUB_TEST_CASE("Device segmented argmax works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -145,8 +145,8 @@ CUB_TEST_CASE("Device fixed-size segmented reduce works with default environment
               "[segmented_reduce][device]",
               CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
@@ -154,46 +154,46 @@ CUB_TEST_CASE("Device fixed-size segmented reduce works with default environment
           == cub::DeviceSegmentedReduce::Reduce(
             d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0));
 
-  thrust::device_vector<int> expected{21, 8};
+  const thrust::device_vector<int> expected{21, 8};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device fixed-size segmented sum works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
   REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
-  thrust::device_vector<int> expected{21, 8};
+  const thrust::device_vector<int> expected{21, 8};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device fixed-size segmented min works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
   REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
-  thrust::device_vector<int> expected{6, 0};
+  const thrust::device_vector<int> expected{6, 0};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST_CASE("Device fixed-size segmented max works with default environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
   REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
-  thrust::device_vector<int> expected{8, 5};
+  const thrust::device_vector<int> expected{8, 5};
   REQUIRE(d_out == expected);
 }
 
@@ -201,14 +201,14 @@ CUB_TEST_CASE("Device fixed-size segmented argmin works with default environment
               "[segmented_reduce][device]",
               CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
   REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{1, 6}, {2, 0}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{1, 6}, {2, 0}};
   REQUIRE(d_out == expected);
 }
 
@@ -216,14 +216,14 @@ CUB_TEST_CASE("Device fixed-size segmented argmax works with default environment
               "[segmented_reduce][device]",
               CUB_SMALL)
 {
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
   REQUIRE(cudaSuccess == cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size));
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 8}, {0, 5}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 8}, {0, 5}};
   REQUIRE(d_out == expected);
 }
 
@@ -231,7 +231,7 @@ CUB_TEST_CASE("Device fixed-size segmented argmax works with default environment
 
 CUB_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -256,13 +256,13 @@ CUB_TEST("Device segmented reduce uses environment", "[segmented_reduce][device]
   device_segmented_reduce(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, env);
 
-  thrust::device_vector<int> expected{26, 12, 3};
+  const thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("Device segmented sum uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -278,13 +278,13 @@ CUB_TEST("Device segmented sum uses environment", "[segmented_reduce][device]", 
 
   device_segmented_reduce_sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{26, 12, 3};
+  const thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("Device segmented min uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -300,13 +300,13 @@ CUB_TEST("Device segmented min uses environment", "[segmented_reduce][device]", 
 
   device_segmented_reduce_min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{5, 0, 1};
+  const thrust::device_vector<int> expected{5, 0, 1};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("Device segmented max uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -322,13 +322,13 @@ CUB_TEST("Device segmented max uses environment", "[segmented_reduce][device]", 
 
   device_segmented_reduce_max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{8, 9, 2};
+  const thrust::device_vector<int> expected{8, 9, 2};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -344,13 +344,13 @@ CUB_TEST("Device segmented argmin uses environment", "[segmented_reduce][device]
 
   device_segmented_reduce_argmin(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{3, 5}, {1, 0}, {0, 1}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{{3, 5}, {1, 0}, {0, 1}};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]", CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
@@ -366,7 +366,7 @@ CUB_TEST("Device segmented argmax uses environment", "[segmented_reduce][device]
 
   device_segmented_reduce_argmax(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {2, 9}, {1, 2}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {2, 9}, {1, 2}};
   REQUIRE(d_out == expected);
 }
 
@@ -392,21 +392,21 @@ CUB_TEST("DeviceSegmentedReduce::Reduce can be tuned", "[segmented_reduce][devic
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(3);
   thrust::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   // We are expecting that `unrelated_tuning` is ignored
   auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
 
   device_segmented_reduce(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, reduce_op, 0, env);
 
-  thrust::device_vector<int> expected{26, 12, 3};
+  const thrust::device_vector<int> expected{26, 12, 3};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -415,19 +415,19 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Reduce can be tuned", "[segmented_re
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<::cuda::std::plus<>> reduce_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(segmented_reduce_tuning<target_block_size>{});
 
   device_segmented_reduce(d_in.begin(), d_out.begin(), num_segments, segment_size, reduce_op, 0, env);
 
-  thrust::device_vector<int> expected{21, 8};
+  const thrust::device_vector<int> expected{21, 8};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -436,7 +436,7 @@ CUB_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]"
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_out(3);
@@ -450,7 +450,7 @@ CUB_TEST("DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduce][device]"
 
   device_segmented_reduce_sum(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{4, 3, 2};
+  const thrust::device_vector<int> expected{4, 3, 2};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -459,8 +459,8 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduc
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
@@ -472,7 +472,7 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Sum can be tuned", "[segmented_reduc
 
   device_segmented_reduce_sum(d_in, d_out.begin(), num_segments, segment_size, env);
 
-  thrust::device_vector<int> expected{3, 3};
+  const thrust::device_vector<int> expected{3, 3};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -481,7 +481,7 @@ CUB_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]"
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_out(3);
@@ -492,7 +492,7 @@ CUB_TEST("DeviceSegmentedReduce::Min can be tuned", "[segmented_reduce][device]"
 
   device_segmented_reduce_min(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{1, 1, 1};
+  const thrust::device_vector<int> expected{1, 1, 1};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -501,8 +501,8 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduc
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
@@ -511,7 +511,7 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Min can be tuned", "[segmented_reduc
 
   device_segmented_reduce_min(d_in, d_out.begin(), num_segments, segment_size, env);
 
-  thrust::device_vector<int> expected{1, 1};
+  const thrust::device_vector<int> expected{1, 1};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -520,7 +520,7 @@ CUB_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]"
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_out(3);
@@ -531,7 +531,7 @@ CUB_TEST("DeviceSegmentedReduce::Max can be tuned", "[segmented_reduce][device]"
 
   device_segmented_reduce_max(d_in, d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
 
-  thrust::device_vector<int> expected{1, 1, 1};
+  const thrust::device_vector<int> expected{1, 1, 1};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -540,8 +540,8 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduc
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
@@ -550,7 +550,7 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::Max can be tuned", "[segmented_reduc
 
   device_segmented_reduce_max(d_in, d_out.begin(), num_segments, segment_size, env);
 
-  thrust::device_vector<int> expected{1, 1};
+  const thrust::device_vector<int> expected{1, 1};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -559,7 +559,7 @@ CUB_TEST("DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_reduce][devic
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
@@ -583,8 +583,8 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_re
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
@@ -593,7 +593,7 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMin can be tuned", "[segmented_re
 
   device_segmented_reduce_argmin(d_in, d_out.begin(), num_segments, segment_size, env);
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -602,7 +602,7 @@ CUB_TEST("DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_reduce][devic
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 4, 7, 9};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
@@ -626,8 +626,8 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_re
 {
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
 
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
   thrust::device_vector<unsigned int> d_block_size(1);
 
@@ -636,7 +636,7 @@ CUB_TEST("Fixed-size DeviceSegmentedReduce::ArgMax can be tuned", "[segmented_re
 
   device_segmented_reduce_argmax(d_in, d_out.begin(), num_segments, segment_size, env);
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 1}, {0, 1}};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_segmented_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_env_api.cu
@@ -21,20 +21,20 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinis
          CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
   auto req_env = cuda::execution::require(cuda::execution::determinism::not_guaranteed);
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = ::cuda::std::execution::env{req_env, stream_ref};
 
   auto error =
     cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -50,18 +50,18 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts env with stream and determinis
 CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts stream", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-stream
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Sum(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -79,7 +79,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism require
          CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-determinism
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -89,7 +89,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts run_to_run determinism require
 
   auto error =
     cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -106,7 +106,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism req
          CUB_SMALL)
 {
   // example-begin segmented-reduce-sum-env-non-determinism
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -116,7 +116,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism req
 
   auto error =
     cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -131,18 +131,18 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum accepts not_guaranteed determinism req
 CUB_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, stream_ref);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -158,18 +158,18 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce env-based API", "[segmented_reduce]
 CUB_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-min-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Min(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
-  thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
+  const thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   if (error != cudaSuccess)
   {
@@ -185,18 +185,18 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min env-based API", "[segmented_reduce][en
 CUB_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-max-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Max(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
-  thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
+  const thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   if (error != cudaSuccess)
   {
@@ -212,14 +212,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max env-based API", "[segmented_reduce][en
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmin-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::ArgMin(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
@@ -231,21 +231,22 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin env-based API", "[segmented_reduce]
   // example-end segmented-reduce-argmin-env
   stream.sync();
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin segmented-reduce-argmax-env
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::ArgMax(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, stream_ref);
@@ -257,7 +258,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax env-based API", "[segmented_reduce]
   // example-end segmented-reduce-argmax-env
   stream.sync();
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
   REQUIRE(d_out == expected);
 }
 
@@ -265,7 +267,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism require
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -275,7 +277,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min accepts run_to_run determinism require
 
   auto error =
     cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
+  const thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   REQUIRE(d_out == expected);
   REQUIRE(error == cudaSuccess);
@@ -285,7 +287,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism req
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -295,7 +297,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min accepts not_guaranteed determinism req
 
   auto error =
     cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
+  const thrust::device_vector<int> expected{6, std::numeric_limits<int>::max(), 0};
 
   REQUIRE(d_out == expected);
   REQUIRE(error == cudaSuccess);
@@ -305,7 +307,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism require
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -315,7 +317,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max accepts run_to_run determinism require
 
   auto error =
     cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
+  const thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   REQUIRE(d_out == expected);
   REQUIRE(error == cudaSuccess);
@@ -325,7 +327,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism req
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -335,7 +337,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max accepts not_guaranteed determinism req
 
   auto error =
     cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, env);
-  thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
+  const thrust::device_vector<int> expected{8, std::numeric_limits<int>::lowest(), 9};
 
   REQUIRE(d_out == expected);
   REQUIRE(error == cudaSuccess);
@@ -345,7 +347,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requ
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -358,7 +360,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts run_to_run determinism requ
 
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
   REQUIRE(d_out == expected);
 }
 
@@ -366,7 +369,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism 
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -379,7 +382,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin accepts not_guaranteed determinism 
 
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {1, 6}, {1, std::numeric_limits<int>::max()}, {2, 0}};
   REQUIRE(d_out == expected);
 }
 
@@ -387,7 +391,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requ
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -400,7 +404,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts run_to_run determinism requ
 
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
   REQUIRE(d_out == expected);
 }
 
@@ -408,7 +413,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism 
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -421,7 +426,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax accepts not_guaranteed determinism 
 
   REQUIRE(error == cudaSuccess);
 
-  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
+  const thrust::device_vector<cub::KeyValuePair<int, int>> expected{
+    {0, 8}, {1, std::numeric_limits<int>::lowest()}, {3, 9}};
   REQUIRE(d_out == expected);
 }
 
@@ -430,7 +436,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requ
          CUB_SMALL)
 {
   // example-begin segmented-reduce-reduce-env-determinism
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -440,7 +446,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts run_to_run determinism requ
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -456,7 +462,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism 
          "[segmented_reduce][env]",
          CUB_SMALL)
 {
-  int num_segments                     = 3;
+  const int num_segments               = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
   auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
@@ -466,7 +472,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism 
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
     d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1, ::cuda::std::plus<>{}, 0, env);
-  thrust::device_vector<int> expected{21, 0, 17};
+  const thrust::device_vector<int> expected{21, 0, 17};
 
   if (error != cudaSuccess)
   {
@@ -479,17 +485,17 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce accepts not_guaranteed determinism 
 CUB_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-reduce-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Reduce(
     d_in.begin(), d_out.begin(), num_segments, segment_size, ::cuda::std::plus<>{}, 0, stream_ref);
-  thrust::device_vector<int> expected{21, 8};
+  const thrust::device_vector<int> expected{21, 8};
 
   if (error != cudaSuccess)
   {
@@ -505,16 +511,16 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce fixed-size env-based API", "[segmen
 CUB_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-sum-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Sum(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
-  thrust::device_vector<int> expected{21, 8};
+  const thrust::device_vector<int> expected{21, 8};
 
   if (error != cudaSuccess)
   {
@@ -530,16 +536,16 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum fixed-size env-based API", "[segmented
 CUB_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-min-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Min(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
-  thrust::device_vector<int> expected{6, 0};
+  const thrust::device_vector<int> expected{6, 0};
 
   if (error != cudaSuccess)
   {
@@ -555,16 +561,16 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min fixed-size env-based API", "[segmented
 CUB_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-max-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<int> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::Max(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
-  thrust::device_vector<int> expected{8, 5};
+  const thrust::device_vector<int> expected{8, 5};
 
   if (error != cudaSuccess)
   {
@@ -580,13 +586,13 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max fixed-size env-based API", "[segmented
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmin-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::ArgMin(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
 
@@ -597,20 +603,20 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin fixed-size env-based API", "[segmen
   // example-end fixed-size-segmented-reduce-argmin-env
   stream.sync();
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{1, 6}, {2, 0}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{1, 6}, {2, 0}};
   REQUIRE(d_out == expected);
 }
 
 CUB_TEST("cub::DeviceSegmentedReduce::ArgMax fixed-size env-based API", "[segmented_reduce][env]", CUB_SMALL)
 {
   // example-begin fixed-size-segmented-reduce-argmax-env
-  int num_segments = 2;
-  int segment_size = 3;
+  const int num_segments = 2;
+  const int segment_size = 3;
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0};
   thrust::device_vector<cuda::std::pair<int, int>> d_out(2);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedReduce::ArgMax(d_in.begin(), d_out.begin(), num_segments, segment_size, stream_ref);
 
@@ -621,7 +627,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax fixed-size env-based API", "[segmen
   // example-end fixed-size-segmented-reduce-argmax-env
   stream.sync();
 
-  thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 8}, {0, 5}};
+  const thrust::device_vector<cuda::std::pair<int, int>> expected{{0, 8}, {0, 5}};
   REQUIRE(d_out == expected);
 }
 

--- a/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
@@ -43,7 +43,7 @@ CUB_TEST(
     offset_zero, num_items_in_first_segment, num_items_in_first_segment + num_items_in_second_segment};
 
   // store expected result and initialize device output container
-  c2h::host_vector<offset_t> expected_result = {
+  const c2h::host_vector<offset_t> expected_result = {
     iterator_value * num_items_in_first_segment, iterator_value * num_items_in_second_segment};
   c2h::device_vector<offset_t> device_result(num_segments);
 

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -97,7 +97,7 @@ CUB_TEST("Device reduce works with a very large number of segments", "[reduce][d
   const auto segment_index_it = cuda::counting_iterator(segment_index_t{});
 
   // Segment offsets
-  segment_index_to_offset_op<offset_t, segment_index_t> index_to_offset_op{
+  const segment_index_to_offset_op<offset_t, segment_index_t> index_to_offset_op{
     num_empty_segments, num_segments, segment_size, num_items};
   auto offsets_it = cuda::make_transform_iterator(segment_index_it, index_to_offset_op);
 
@@ -250,7 +250,7 @@ void test_fixed_size_segmented_reduce(
   const auto segment_index_it = cuda::counting_iterator(SegmentIdxT{});
 
   // Segment offsets
-  segment_index_to_offset_op<offset_t, SegmentIdxT> index_to_offset_op{0, num_segments, segment_size, num_items};
+  const segment_index_to_offset_op<offset_t, SegmentIdxT> index_to_offset_op{0, num_segments, segment_size, num_items};
   auto offsets_it = cuda::transform_iterator(segment_index_it, index_to_offset_op);
 
   CAPTURE(c2h::type_name<offset_t>(), c2h::type_name<SegmentIdxT>(), num_segments, segment_size, num_items);

--- a/cub/test/catch2_test_device_segmented_scan.cu
+++ b/cub/test/catch2_test_device_segmented_scan.cu
@@ -84,17 +84,17 @@ bool check_segment(const c2h::host_vector<ValueT>& h_output,
     }
     else if constexpr (cuda::std::is_same_v<ValueT, half_t> || cuda::std::is_same_v<ValueT, bfloat16_t>)
     {
-      float ref_v = h_ref[pos];
-      float act_v = h_output[pos];
+      const float ref_v = h_ref[pos];
+      const float act_v = h_output[pos];
       if (cuda::std::isfinite(ref_v) && cuda::std::isfinite(act_v))
       {
-        float diff   = (ref_v - act_v);
-        float adiff  = (diff > float{0}) ? diff : -diff;
-        float ref_av = (ref_v > float{0}) ? ref_v : -ref_v;
-        float act_av = (act_v > float{0}) ? act_v : -act_v;
+        const float diff   = (ref_v - act_v);
+        const float adiff  = (diff > float{0}) ? diff : -diff;
+        const float ref_av = (ref_v > float{0}) ? ref_v : -ref_v;
+        const float act_av = (act_v > float{0}) ? act_v : -act_v;
 
-        float eps = float{1} / float{128};
-        correct   = correct && (adiff < 3 * eps + 5 * eps * (::cuda::std::max(ref_av, act_av)));
+        const float eps = float{1} / float{128};
+        correct         = correct && (adiff < 3 * eps + 5 * eps * (::cuda::std::max(ref_av, act_av)));
       }
     }
     else
@@ -163,7 +163,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
   auto d_out_it = thrust::raw_pointer_cast(output_vec.data());
 
   c2h::host_vector<offset_t> h_segment_offsets = d_segment_offsets;
-  c2h::host_vector<input_t> h_input            = in_items;
+  const c2h::host_vector<input_t> h_input      = in_items;
   c2h::host_vector<output_t> h_output(num_items);
   c2h::host_vector<output_t> h_ref(num_items);
 
@@ -186,7 +186,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
         output_t{},
         op_t{});
 
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -198,7 +198,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
 
     for (offset_t i = 0; i < num_segments; ++i)
     {
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -227,7 +227,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
         scan_op,
         h_accum_t{});
 
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -244,7 +244,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
 
       for (offset_t i = 0; i < num_segments; ++i)
       {
-        bool correct = check_segment(
+        const bool correct = check_segment(
           h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
         REQUIRE(correct);
       }
@@ -289,7 +289,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
         scan_op,
         h_accum_t{init_value});
       // Verify result
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -303,7 +303,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
     for (offset_t i = 0; i < num_segments; ++i)
     {
       // Verify result
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -328,7 +328,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
         output_t{},
         cuda::std::plus<>{});
 
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -340,7 +340,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
 
     for (offset_t i = 0; i < num_segments; ++i)
     {
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -364,7 +364,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
         cuda::std::plus<>{},
         output_t{});
 
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }
@@ -376,7 +376,7 @@ CUB_TEST("Device segmented_scan works with all device interfaces",
 
     for (offset_t i = 0; i < num_segments; ++i)
     {
-      bool correct = check_segment(
+      const bool correct = check_segment(
         h_output, h_ref, h_segment_offsets[i], h_segment_offsets[i + 1]); // NOLINT(bugprone-misplaced-widening-cast)
       REQUIRE(correct);
     }

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -74,7 +74,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with two offsets w
     static_cast<::cuda::std::int64_t>(num_segments));
   check_execution_status(status, algo_name);
 
-  thrust::device_vector<int> expected{0, 1, 3, 0, 4, 0, 6, 13};
+  const thrust::device_vector<int> expected{0, 1, 3, 0, 4, 0, 6, 13};
   // example-end exclusive-segmented-sum-two-offsets
 
   REQUIRE(status == cudaSuccess);
@@ -92,11 +92,11 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets
   auto input = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
   // offsets to starts of each of 4 rows
-  size_t row_size       = 4;
+  const size_t row_size = 4;
   auto in_begin_offsets = thrust::device_vector<size_t>{0, row_size, 2 * row_size};
   auto num_segments     = in_begin_offsets.size();
   // Perform row-wise sum for 3-by-3 principal sub-matrix
-  size_t segment_size = 3;
+  const size_t segment_size = 3;
 
   auto in_end_offsets = thrust::device_vector<size_t>{
     0 * row_size + segment_size, 1 * row_size + segment_size, 2 * row_size + segment_size};
@@ -141,7 +141,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum API with three offsets
     static_cast<::cuda::std::int64_t>(num_segments));
   check_execution_status(status, algo_name);
 
-  thrust::device_vector<int> expected{0, 1, 3, 0, 5, 11, 0, 9, 19};
+  const thrust::device_vector<int> expected{0, 1, 3, 0, 5, 11, 0, 9, 19};
   // example-end exclusive-segmented-sum-three-offsets
 
   REQUIRE(status == cudaSuccess);
@@ -191,7 +191,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with two offsets w
     static_cast<::cuda::std::int64_t>(num_segments));
   check_execution_status(status, algo_name);
 
-  thrust::device_vector<int> expected{2, 3, 4, 2, 3, 2, 3, 4};
+  const thrust::device_vector<int> expected{2, 3, 4, 2, 3, 2, 3, 4};
   // example-end inclusive-segmented-sum-two-offsets
 
   REQUIRE(status == cudaSuccess);
@@ -209,14 +209,14 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets
   auto input = thrust::device_vector<int>{1, 1, 1, 1, -1, -1, -1, -1, 2, 2, 2, 2, -2, -2, -2, -2};
 
   // begin offsets for each of 4 rows
-  size_t m          = 4;
+  const size_t m    = 4;
   auto row_offsets  = thrust::device_vector<size_t>{0, m, 2 * m, 3 * m, 4 * m};
   auto num_segments = row_offsets.size() - 1;
 
   // Allocate m rows of m + 1 filled with zero-initialized values
   auto output = thrust::device_vector<int>((m + 1) * m, 0);
   // begin offsets to second element of each row
-  size_t lda             = m + 1;
+  const size_t lda       = m + 1;
   auto out_begin_offsets = thrust::device_vector<size_t>{1, lda + 1, 2 * lda + 1, 3 * lda + 1};
 
   cuda::std::uint8_t* d_temp_storage = nullptr;
@@ -258,7 +258,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum API with three offsets
 
   std::vector<int> h_expected{};
   h_expected.reserve(output.size());
-  std::vector<std::vector<int>> expected_rows{
+  const std::vector<std::vector<int>> expected_rows{
     {0, 1, 2, 3, 4}, {0, -1, -2, -3, -4}, {0, 2, 4, 6, 8}, {0, -2, -4, -6, -8}};
   for (const auto& row : expected_rows)
   {
@@ -278,13 +278,13 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit[2 offsets]";
   // example-begin inclusive-segmented-scan-init-two-offsets
-  unsigned prime = 7;
-  auto input     = thrust::device_vector<unsigned>{
+  const unsigned prime = 7;
+  auto input           = thrust::device_vector<unsigned>{
     2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6};
 
   auto row_size    = static_cast<size_t>(prime);
   auto row_offsets = thrust::device_vector<size_t>{0, row_size, 2 * row_size, 3 * row_size, 4 * row_size, 5 * row_size};
-  size_t num_segments = row_offsets.size() - 1;
+  const size_t num_segments = row_offsets.size() - 1;
 
   thrust::device_vector<unsigned> output(input.size(), thrust::no_init);
 
@@ -295,7 +295,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
     const auto proj_v2 = (v2 % m_p);
     return (proj_v1 * proj_v2) % m_p;
   };
-  unsigned init_value = 1;
+  const unsigned init_value = 1;
 
   auto d_in  = input.begin();
   auto d_out = output.begin();
@@ -337,7 +337,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
 
   std::vector<unsigned> h_expected{};
   h_expected.reserve(output.size());
-  std::vector<std::vector<unsigned>> expected_rows{
+  const std::vector<std::vector<unsigned>> expected_rows{
     {2, 4, 1, 2, 4, 1, 2}, {3, 2, 6, 4, 5, 1, 3}, {4, 2, 1, 4, 2, 1, 4}, {5, 4, 6, 2, 3, 1, 5}, {6, 1, 6, 1, 6, 1, 6}};
   for (const auto& row : expected_rows)
   {
@@ -382,7 +382,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets 
   auto scan_op = [] __host__ __device__(unsigned v1, unsigned v2) -> unsigned {
     return v1 ^ v2;
   };
-  unsigned init_value = 0u;
+  const unsigned init_value = 0u;
 
   // 128 input elements
   // auto input = thrust::device_vector<unsigned>{0x64b40b1b, 0x7bf23c0c, 0xaa982e07, ... };
@@ -394,11 +394,11 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan API with two offsets 
   cuda::std::uint8_t* d_temp_storage = nullptr;
   size_t temp_storage_bytes          = 0;
 
-  auto d_in           = input.begin();
-  auto d_out          = output.begin();
-  auto begin_offsets  = offsets.begin();
-  auto end_offsets    = offsets.begin() + 1;
-  size_t num_segments = offsets.size() - 1;
+  auto d_in                 = input.begin();
+  auto d_out                = output.begin();
+  auto begin_offsets        = offsets.begin();
+  auto end_offsets          = offsets.begin() + 1;
+  const size_t num_segments = offsets.size() - 1;
 
   // inquire size of needed temporary storage and allocate
   auto status = cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
@@ -440,7 +440,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
   */
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedScan[3-offsets]";
   // example-begin inclusive-segmented-scan-three-offsets
-  size_t n = 8;
+  const size_t n = 8;
   thrust::device_vector<float> input{0.21f, 0.33f, 0.17f, 0.56f, 0.31f, 0.25f, 1.0f, 0.72f};
 
   constexpr unsigned _zero{0};
@@ -478,7 +478,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan API with three offset
     d_temp_storage, temp_storage_bytes, d_in, d_out, in_begin_offsets, in_end_offsets, out_begin_offsets, n, scan_op);
   check_execution_status(status, algo_name);
 
-  thrust::device_vector<float> expected{
+  const thrust::device_vector<float> expected{
     0.21f, 0.33f, 0.33f, 0.56f, 0.56f, 0.56f, 1.00f, 1.00f, // row 0
     0.00f, 0.33f, 0.33f, 0.56f, 0.56f, 0.56f, 1.00f, 1.00f, // row 1
     0.00f, 0.00f, 0.17f, 0.56f, 0.56f, 0.56f, 1.00f, 1.00f, // row 2

--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -278,12 +278,13 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit[2 offsets]";
   // example-begin inclusive-segmented-scan-init-two-offsets
-  const unsigned prime = 7;
-  auto input           = thrust::device_vector<unsigned>{
+  constexpr unsigned prime = 7;
+  const auto input         = thrust::device_vector<unsigned>{
     2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6};
 
-  auto row_size    = static_cast<size_t>(prime);
-  auto row_offsets = thrust::device_vector<size_t>{0, row_size, 2 * row_size, 3 * row_size, 4 * row_size, 5 * row_size};
+  constexpr auto row_size = size_t{prime};
+  const auto row_offsets =
+    thrust::device_vector<size_t>{0, row_size, 2 * row_size, 3 * row_size, 4 * row_size, 5 * row_size};
   const size_t num_segments = row_offsets.size() - 1;
 
   thrust::device_vector<unsigned> output(input.size(), thrust::no_init);
@@ -344,7 +345,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
     h_expected.insert(h_expected.end(), row.begin(), row.end());
   }
 
-  auto expected = thrust::device_vector<unsigned>{h_expected};
+  const auto expected = thrust::device_vector<unsigned>{h_expected};
   // example-end inclusive-segmented-scan-init-two-offsets
 
   REQUIRE(status == cudaSuccess);

--- a/cub/test/catch2_test_device_segmented_scan_env.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env.cu
@@ -50,7 +50,7 @@ CUB_TEST_CASE("Device segmented exclusive sum works with default environment", "
           == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
-  thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
+  const thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
   REQUIRE(d_out == expected);
 }
 
@@ -66,7 +66,7 @@ CUB_TEST_CASE("Device segmented exclusive scan works with default environment", 
           == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
+  const thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
   REQUIRE(d_out == expected);
 }
 
@@ -82,7 +82,7 @@ CUB_TEST_CASE("Device segmented inclusive sum works with default environment", "
           == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments));
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
 }
 
@@ -98,7 +98,7 @@ CUB_TEST_CASE("Device segmented inclusive scan works with default environment", 
           == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}));
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
 }
 
@@ -116,7 +116,7 @@ CUB_TEST_CASE("Device segmented inclusive scan init works with default environme
           == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
             d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  const thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
   REQUIRE(d_out == expected);
 }
 
@@ -137,7 +137,7 @@ CUB_TEST_CASE("Device segmented exclusive sum with separate offsets works with d
           == cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
-  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
+  const thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   REQUIRE(d_out == expected);
 }
 
@@ -159,7 +159,7 @@ CUB_TEST_CASE("Device segmented exclusive scan with separate offsets works with 
     == cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  const thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
@@ -180,7 +180,7 @@ CUB_TEST_CASE("Device segmented inclusive sum with separate offsets works with d
           == cub::DeviceSegmentedScan::InclusiveSegmentedSum(
             d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments));
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  const thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
@@ -202,7 +202,7 @@ CUB_TEST_CASE("Device segmented inclusive scan with separate offsets works with 
     == cub::DeviceSegmentedScan::InclusiveSegmentedScan(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}));
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  const thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
@@ -224,7 +224,7 @@ CUB_TEST_CASE("Device segmented inclusive scan init with separate offsets works 
     == cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
       d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, 100));
 
-  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  const thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
 
@@ -248,7 +248,7 @@ CUB_TEST("Device segmented exclusive sum uses environment", "[segmented_scan][de
 
   device_segmented_exclusive_sum(d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, env);
 
-  thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
+  const thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
   REQUIRE(d_out == expected);
 }
 
@@ -279,7 +279,7 @@ CUB_TEST("Device segmented exclusive scan uses environment", "[segmented_scan][d
   device_segmented_exclusive_scan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100, env);
 
-  thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
+  const thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
   REQUIRE(d_out == expected);
 }
 
@@ -301,7 +301,7 @@ CUB_TEST("Device segmented inclusive sum uses environment", "[segmented_scan][de
 
   device_segmented_inclusive_sum(d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, env);
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
 }
 
@@ -331,7 +331,7 @@ CUB_TEST("Device segmented inclusive scan uses environment", "[segmented_scan][d
   device_segmented_inclusive_scan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, env);
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
 }
 
@@ -362,7 +362,7 @@ CUB_TEST("Device segmented inclusive scan init uses environment", "[segmented_sc
   device_segmented_inclusive_scan_init(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, ::cuda::std::plus<>{}, 100, env);
 
-  thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  const thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
   REQUIRE(d_out == expected);
 }
 
@@ -395,7 +395,7 @@ CUB_TEST("Device segmented exclusive sum with separate offsets uses environment"
   device_segmented_exclusive_sum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
 
-  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
+  const thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   REQUIRE(d_out == expected);
 }
 
@@ -438,7 +438,7 @@ CUB_TEST("Device segmented exclusive scan with separate offsets uses environment
     100,
     env);
 
-  thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
+  const thrust::device_vector<int> expected{100, 101, 103, sentinel, 100, 104, sentinel, 100, 106, 113};
   REQUIRE(d_out == expected);
 }
 
@@ -471,7 +471,7 @@ CUB_TEST("Device segmented inclusive sum with separate offsets uses environment"
   device_segmented_inclusive_sum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, env);
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  const thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
@@ -505,7 +505,7 @@ CUB_TEST("Device segmented inclusive scan with separate offsets uses environment
   device_segmented_inclusive_scan(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, ::cuda::std::plus<>{}, env);
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  const thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   REQUIRE(d_out == expected);
 }
 
@@ -550,7 +550,7 @@ CUB_TEST("Device segmented inclusive scan init with separate offsets uses enviro
     100,
     env);
 
-  thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
+  const thrust::device_vector<int> expected{101, 103, 106, sentinel, 104, 109, sentinel, 106, 113, 121};
   REQUIRE(d_out == expected);
 }
 
@@ -620,13 +620,13 @@ CUB_TEST("Device segmented exclusive scan can be tuned", "[segmented_scan][devic
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
 
   device_segmented_exclusive_scan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, 100, env);
 
-  thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
+  const thrust::device_vector<int> expected{100, 108, 114, 121, 100, 103, 103, 100, 101};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -640,13 +640,13 @@ CUB_TEST("Device segmented inclusive scan can be tuned", "[segmented_scan][devic
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
 
   device_segmented_inclusive_scan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, env);
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -660,13 +660,13 @@ CUB_TEST("Device segmented inclusive scan init can be tuned", "[segmented_scan][
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
   c2h::device_vector<unsigned int> d_block_size(1);
-  block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<::cuda::std::plus<>> scan_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto env = cuda::execution::tune(segmented_scan_tuning<target_block_size>{});
 
   device_segmented_inclusive_scan_init(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, scan_op, 100, env);
 
-  thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
+  const thrust::device_vector<int> expected{108, 114, 121, 126, 103, 103, 112, 101, 103};
   REQUIRE(d_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_segmented_scan_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_env_api.cu
@@ -25,8 +25,8 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[seg
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, stream_ref);
@@ -35,7 +35,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum accepts stream", "[seg
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
+  const thrust::device_vector<int> expected{0, 8, 14, 21, 0, 3, 3, 0, 1};
   // example-end exclusive-segmented-sum-env
   stream.sync();
 
@@ -52,8 +52,8 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, 4, stream_ref);
@@ -62,7 +62,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan accepts stream", "[se
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{4, 8, 8, 8, 4, 4, 4, 4, 4};
+  const thrust::device_vector<int> expected{4, 8, 8, 8, 4, 4, 4, 4, 4};
   // example-end exclusive-segmented-scan-env
   stream.sync();
 
@@ -79,8 +79,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[seg
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedSum(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, stream_ref);
@@ -89,7 +89,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum accepts stream", "[seg
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
+  const thrust::device_vector<int> expected{8, 14, 21, 26, 3, 3, 12, 1, 3};
   // example-end inclusive-segmented-sum-env
   stream.sync();
 
@@ -106,8 +106,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[se
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, stream_ref);
@@ -116,7 +116,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan accepts stream", "[se
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 8, 8, 8, 3, 3, 9, 1, 2};
+  const thrust::device_vector<int> expected{8, 8, 8, 8, 3, 3, 9, 1, 2};
   // example-end inclusive-segmented-scan-env
   stream.sync();
 
@@ -133,8 +133,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9, 1, 2};
   thrust::device_vector<int> d_out(d_in.size());
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
     d_in.begin(), d_out.begin(), d_offsets_it, d_offsets_it + 1, num_segments, cuda::maximum<>{}, 4, stream_ref);
@@ -143,7 +143,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit accepts stream", 
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 8, 8, 8, 4, 4, 9, 4, 4};
+  const thrust::device_vector<int> expected{8, 8, 8, 8, 4, 4, 9, 4, 4};
   // example-end inclusive-segmented-scan-init-env
   stream.sync();
 
@@ -165,8 +165,8 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedSum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, stream_ref);
@@ -175,7 +175,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedSum (separate offsets) acc
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
+  const thrust::device_vector<int> expected{0, 1, 3, sentinel, 0, 4, sentinel, 0, 6, 13};
   // example-end exclusive-segmented-sum-separate-env
   stream.sync();
 
@@ -197,8 +197,8 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
   thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::ExclusiveSegmentedScan(
     d_in.begin(),
@@ -215,7 +215,7 @@ CUB_TEST("cub::DeviceSegmentedScan::ExclusiveSegmentedScan (separate offsets) ac
     std::cerr << "cub::DeviceSegmentedScan::ExclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{2, 3, 3, sentinel, 2, 2, sentinel, 2, 9, 9};
+  const thrust::device_vector<int> expected{2, 3, 3, sentinel, 2, 2, sentinel, 2, 9, 9};
   // example-end exclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -237,8 +237,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
   thrust::device_vector<int> d_in{1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedSum(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, stream_ref);
@@ -247,7 +247,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedSum (separate offsets) acc
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedSum failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
+  const thrust::device_vector<int> expected{1, 3, 6, sentinel, 4, 9, sentinel, 6, 13, 21};
   // example-end inclusive-segmented-sum-separate-env
   stream.sync();
 
@@ -269,8 +269,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
   thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     d_in.begin(), d_out.begin(), d_in_off_it, d_in_off_it + 1, d_out_off_it, num_segments, cuda::maximum<>{}, stream_ref);
@@ -279,7 +279,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScan (separate offsets) ac
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScan failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{3, 3, 4, sentinel, 1, 5, sentinel, 9, 9, 9};
+  const thrust::device_vector<int> expected{3, 3, 4, sentinel, 1, 5, sentinel, 9, 9, 9};
   // example-end inclusive-segmented-scan-separate-env
   stream.sync();
 
@@ -301,8 +301,8 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
   thrust::device_vector<int> d_in{3, 1, 4, 1, 5, 9, 2, 6};
   thrust::device_vector<int> d_out(10, sentinel);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedScan::InclusiveSegmentedScanInit(
     d_in.begin(),
@@ -319,7 +319,7 @@ CUB_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit (separate offsets
     std::cerr << "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{7, 7, 7, sentinel, 7, 7, sentinel, 9, 9, 9};
+  const thrust::device_vector<int> expected{7, 7, 7, sentinel, 7, 7, sentinel, 9, 9, 9};
   // example-end inclusive-segmented-scan-init-separate-env
   stream.sync();
 

--- a/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
+++ b/cub/test/catch2_test_device_segmented_scan_multi_segment.cu
@@ -205,8 +205,8 @@ struct numeric_op
   {
     using Up = typename cuda::std::make_unsigned<value_t>::type;
     const Up m{63};
-    Up r_a = static_cast<Up>(a) % m;
-    Up r_b = static_cast<Up>(b) % m;
+    const Up r_a = static_cast<Up>(a) % m;
+    const Up r_b = static_cast<Up>(b) % m;
     return (r_a + r_b) % m;
   }
 };
@@ -240,9 +240,9 @@ CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative
 
   using policy_t = policy_selector_t<block_size, items_per_thread, max_segments_per_block>;
 
-  unsigned num_items = block_size * items_per_thread * 101 + 1;
-  c2h::device_vector<offset_t> offsets{0, num_items / 4, num_items / 2, num_items - (num_items / 4), num_items};
-  size_t num_segments = offsets.size() - 1;
+  const unsigned num_items = block_size * items_per_thread * 101 + 1;
+  const c2h::device_vector<offset_t> offsets{0, num_items / 4, num_items / 2, num_items - (num_items / 4), num_items};
+  const size_t num_segments = offsets.size() - 1;
 
   c2h::device_vector<pair_t> input(num_items, thrust::default_init);
   thrust::tabulate(input.begin(), input.end(), impl::populate_bicyclic_monoid_input<unsigned int>{});
@@ -267,7 +267,7 @@ CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative
   c2h::host_vector<pair_t> h_expected(input.size(), thrust::default_init);
   c2h::host_vector<offset_t> h_offsets(offsets);
 
-  op_t op{};
+  const op_t op{};
   pair_t h_init{0, 0};
 
   for (offset_t segment_id = 0; segment_id < num_segments; ++segment_id)
@@ -282,7 +282,7 @@ CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative
 
   const int one_segment_per_worker = 1;
 
-  cub::NullType d_no_init{};
+  const cub::NullType d_no_init{};
 
   SECTION("worker-block, one segment per worker")
   {
@@ -296,7 +296,7 @@ CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative
       d_no_init,
       one_segment_per_worker);
 
-    c2h::host_vector<pair_t> h_output(output);
+    const c2h::host_vector<pair_t> h_output(output);
 
     REQUIRE(h_expected == h_output);
   }
@@ -315,7 +315,7 @@ CUB_TEST("segmented inclusive scan works correctly for pairs with noncommutative
       d_no_init,
       two_segments_per_worker);
 
-    c2h::host_vector<pair_t> h_output(output);
+    const c2h::host_vector<pair_t> h_output(output);
 
     REQUIRE(h_expected == h_output);
   }
@@ -343,7 +343,7 @@ CUB_TEST(
     h_offsets[i] = i * items_per_segment;
   }
 
-  c2h::device_vector<offset_t> offsets = h_offsets;
+  const c2h::device_vector<offset_t> offsets = h_offsets;
   c2h::device_vector<value_t> input(num_items);
   thrust::tabulate(input.begin(), input.end(), init_op<value_t>{});
   c2h::device_vector<value_t> output(input.size(), thrust::no_init);
@@ -374,8 +374,8 @@ CUB_TEST(
   c2h::host_vector<value_t> h_input(input);
   c2h::host_vector<value_t> h_expected(input.size(), thrust::default_init);
 
-  op_t op{};
-  value_t h_init{3};
+  const op_t op{};
+  const value_t h_init{3};
 
   for (unsigned segment_id = 0; segment_id < num_segments; ++segment_id)
   {
@@ -389,7 +389,7 @@ CUB_TEST(
 
   const int segments_per_worker = 2;
 
-  d_init_t d_init_v{h_init};
+  const d_init_t d_init_v{h_init};
 
   SECTION("worker block")
   {
@@ -403,7 +403,7 @@ CUB_TEST(
       d_init_v,
       segments_per_worker);
 
-    c2h::host_vector<value_t> h_output(output);
+    const c2h::host_vector<value_t> h_output(output);
     REQUIRE(h_expected == h_output);
   }
 }
@@ -425,8 +425,8 @@ CUB_TEST("Segmented inclusive scan works correctly for integer types",
   using policy_t = policy_selector_t<block_size, items_per_thread, max_segments_per_block>;
 
   const unsigned num_items = block_size * items_per_thread * 132;
-  c2h::device_vector<offset_t> offsets{0, num_items / 4, num_items / 2, num_items - (num_items / 4), num_items};
-  size_t num_segments = offsets.size() - 1;
+  const c2h::device_vector<offset_t> offsets{0, num_items / 4, num_items / 2, num_items - (num_items / 4), num_items};
+  const size_t num_segments = offsets.size() - 1;
 
   c2h::device_vector<value_t> input(num_items, thrust::default_init);
   thrust::tabulate(input.begin(), input.end(), init_op<value_t>{});
@@ -451,8 +451,8 @@ CUB_TEST("Segmented inclusive scan works correctly for integer types",
   c2h::host_vector<value_t> h_expected(input.size(), thrust::default_init);
   c2h::host_vector<offset_t> h_offsets(offsets);
 
-  op_t op{};
-  value_t h_init{0};
+  const op_t op{};
+  const value_t h_init{0};
 
   for (unsigned segment_id = 0; segment_id < num_segments; ++segment_id)
   {
@@ -466,7 +466,7 @@ CUB_TEST("Segmented inclusive scan works correctly for integer types",
 
   const int segments_per_worker = 4;
 
-  cub::NullType d_no_init{};
+  const cub::NullType d_no_init{};
 
   SECTION("worker-block")
   {
@@ -480,7 +480,7 @@ CUB_TEST("Segmented inclusive scan works correctly for integer types",
       d_no_init,
       segments_per_worker);
 
-    c2h::host_vector<value_t> h_output(output);
+    const c2h::host_vector<value_t> h_output(output);
     REQUIRE(h_expected == h_output);
   }
 }
@@ -508,7 +508,7 @@ CUB_TEST("Segmented inclusive scan with init works for integer types",
 
   CAPTURE(num_segments, num_items, items_per_segment, cuda::std::is_signed_v<value_t>);
 
-  c2h::device_vector<offset_t> offsets = h_offsets;
+  const c2h::device_vector<offset_t> offsets = h_offsets;
   c2h::device_vector<value_t> input(num_items, thrust::default_init);
   thrust::tabulate(input.begin(), input.end(), init_op<value_t>{});
   c2h::device_vector<value_t> output(input.size(), thrust::default_init);
@@ -539,8 +539,8 @@ CUB_TEST("Segmented inclusive scan with init works for integer types",
   c2h::host_vector<value_t> h_input(input);
   c2h::host_vector<value_t> h_expected(input.size(), thrust::default_init);
 
-  op_t op{};
-  value_t h_init{3};
+  const op_t op{};
+  const value_t h_init{3};
 
   for (unsigned segment_id = 0; segment_id < num_segments; ++segment_id)
   {
@@ -552,7 +552,7 @@ CUB_TEST("Segmented inclusive scan with init works for integer types",
       h_init);
   }
 
-  d_init_t d_init_v{h_init};
+  const d_init_t d_init_v{h_init};
   const int segments_per_worker = 2;
 
   // pre-condition to ensure that incomplete tail tile case is tested
@@ -570,7 +570,7 @@ CUB_TEST("Segmented inclusive scan with init works for integer types",
       d_init_v,
       segments_per_worker);
 
-    c2h::host_vector<value_t> h_output(output);
+    const c2h::host_vector<value_t> h_output(output);
     REQUIRE(h_expected == h_output);
   }
 }
@@ -585,14 +585,14 @@ make_in_out_offsets(const std::vector<OffsetT>& sizes, OffsetT gap)
 {
   std::vector<OffsetT> offsets;
 
-  std::size_t segment_count = sizes.size();
+  const std::size_t segment_count = sizes.size();
 
   static constexpr OffsetT zero{0};
 
   offsets.resize(segment_count + 1);
   offsets[0] = zero;
 
-  cuda::std::plus<> plus_t{};
+  const cuda::std::plus<> plus_t{};
 
   compute_inclusive_scan_reference(sizes.begin(), sizes.end(), offsets.begin() + 1, plus_t, zero);
 
@@ -632,8 +632,8 @@ CUB_TEST("Segmented inclusive scan skips empty segments", "[multi_segment][segme
 
   const auto [in_offsets_v, out_offsets_v] = make_in_out_offsets(segment_sizes, gap);
 
-  c2h::device_vector<offset_t> offsets{in_offsets_v.begin(), in_offsets_v.end()};
-  c2h::device_vector<offset_t> out_offsets{out_offsets_v.begin(), out_offsets_v.end()};
+  const c2h::device_vector<offset_t> offsets{in_offsets_v.begin(), in_offsets_v.end()};
+  const c2h::device_vector<offset_t> out_offsets{out_offsets_v.begin(), out_offsets_v.end()};
 
   const auto num_segments = static_cast<cuda::std::size_t>(segment_sizes.size());
   const auto num_items    = static_cast<cuda::std::size_t>(in_offsets_v.back());
@@ -647,9 +647,9 @@ CUB_TEST("Segmented inclusive scan skips empty segments", "[multi_segment][segme
 
   constexpr int segments_per_worker = 2;
 
-  op_t op{};
-  value_t h_init_v{0};
-  cub::NullType d_no_init{};
+  const op_t op{};
+  const value_t h_init_v{0};
+  const cub::NullType d_no_init{};
 
   c2h::host_vector<value_t> h_input(input);
   c2h::host_vector<offset_t> h_offsets(offsets);
@@ -738,8 +738,8 @@ CUB_TEST("Segmented inclusive scan handles end_offset < begin_offset", "[multi_s
     REQUIRE(offset >= offset_t{0});
   }
 
-  c2h::device_vector<offset_t> offsets{in_offsets_v.begin(), in_offsets_v.end()};
-  c2h::device_vector<offset_t> out_offsets{out_offsets_v.begin(), out_offsets_v.end()};
+  const c2h::device_vector<offset_t> offsets{in_offsets_v.begin(), in_offsets_v.end()};
+  const c2h::device_vector<offset_t> out_offsets{out_offsets_v.begin(), out_offsets_v.end()};
 
   const auto num_segments = segment_sizes.size();
   const auto num_items    = static_cast<cuda::std::size_t>(in_offsets_v.back());
@@ -753,9 +753,9 @@ CUB_TEST("Segmented inclusive scan handles end_offset < begin_offset", "[multi_s
 
   constexpr int segments_per_worker = 2;
 
-  op_t op{};
-  value_t h_init_v{0};
-  cub::NullType d_no_init{};
+  const op_t op{};
+  const value_t h_init_v{0};
+  const cub::NullType d_no_init{};
 
   c2h::host_vector<value_t> h_input(input);
   c2h::host_vector<offset_t> h_offsets(offsets);
@@ -877,7 +877,7 @@ CUB_TEST("segmented inclusive scan works correctly with fancy iterators", "[mult
 
   CAPTURE(num_segments, num_items, items_per_segment, cuda::std::is_signed_v<value_t>);
 
-  c2h::device_vector<offset_t> offsets = h_offsets;
+  const c2h::device_vector<offset_t> offsets = h_offsets;
 
   const auto input_it = cuda::make_transform_iterator(cuda::counting_iterator<value_t>(0), init_op<value_t>{});
 
@@ -906,8 +906,8 @@ CUB_TEST("segmented inclusive scan works correctly with fancy iterators", "[mult
   c2h::host_vector<value_t> h_input(input_it, input_it + num_items);
   c2h::host_vector<value_t> h_expected(num_items, thrust::default_init);
 
-  op_t op{};
-  value_t h_init{3};
+  const op_t op{};
+  const value_t h_init{3};
 
   for (unsigned segment_id = 0; segment_id < num_segments; ++segment_id)
   {
@@ -926,7 +926,7 @@ CUB_TEST("segmented inclusive scan works correctly with fancy iterators", "[mult
     }
   }
 
-  d_init_t d_init_v{h_init};
+  const d_init_t d_init_v{h_init};
   const int segments_per_worker = 2;
 
   SECTION("worker block")
@@ -941,7 +941,7 @@ CUB_TEST("segmented inclusive scan works correctly with fancy iterators", "[mult
       d_init_v,
       segments_per_worker);
 
-    c2h::host_vector<value_t> h_output(output);
+    const c2h::host_vector<value_t> h_output(output);
     REQUIRE(h_expected == h_output);
   }
 }

--- a/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
+++ b/cub/test/catch2_test_device_segmented_scan_noncommutative.cu
@@ -78,9 +78,9 @@ CUB_TEST("Device inclusive segmented scan works with non-commutative operator", 
   using op_t   = impl::bicyclic_monoid_op<unsigned>;
   using pair_t = typename op_t::pair_t;
 
-  unsigned num_items = 1'234'567;
+  const unsigned num_items = 1'234'567;
   c2h::device_vector<unsigned> offsets{0, num_items / 4, num_items / 2, num_items - (num_items / 4), num_items};
-  size_t num_segments = offsets.size() - 1;
+  const size_t num_segments = offsets.size() - 1;
 
   c2h::device_vector<pair_t> input(num_items);
   thrust::tabulate(input.begin(), input.end(), impl::populate_input<unsigned>{});
@@ -91,7 +91,7 @@ CUB_TEST("Device inclusive segmented scan works with non-commutative operator", 
   unsigned* d_offsets = thrust::raw_pointer_cast(offsets.data());
 
   size_t tmp_size{};
-  cudaError_t status1 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+  const cudaError_t status1 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     nullptr,
     tmp_size,
     d_input,
@@ -110,7 +110,7 @@ CUB_TEST("Device inclusive segmented scan works with non-commutative operator", 
 
   REQUIRE(d_tmp != nullptr);
 
-  cudaError_t status2 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
+  const cudaError_t status2 = cub::DeviceSegmentedScan::InclusiveSegmentedScan(
     d_tmp,
     tmp_size,
     d_input,
@@ -122,7 +122,7 @@ CUB_TEST("Device inclusive segmented scan works with non-commutative operator", 
   REQUIRE(cudaSuccess == status2);
 
   // transfer to host_vector is synchronizing
-  c2h::host_vector<pair_t> h_output(output);
+  const c2h::host_vector<pair_t> h_output(output);
   c2h::host_vector<pair_t> h_input(input);
   c2h::host_vector<pair_t> h_expected(input.size());
   c2h::host_vector<unsigned> h_offsets(offsets);

--- a/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_segmented_sort_custom_policy_hub.cu
@@ -60,7 +60,7 @@ CUB_TEST("DispatchSegmentedSort::Dispatch: custom policy hub", "[segmented][sort
   using offset_t                 = int;
   constexpr bool is_overwrite_ok = false;
 
-  c2h::host_vector<key_t> h_keys_in{7, 2, 5, 1, 4, 3, 9, 8, 6, 0};
+  const c2h::host_vector<key_t> h_keys_in{7, 2, 5, 1, 4, 3, 9, 8, 6, 0};
   c2h::host_vector<offset_t> h_offsets{0, 4, 7, 10};
 
   c2h::device_vector<key_t> d_keys_in = h_keys_in;

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -50,7 +50,7 @@ CUB_TEST("DeviceSegmentedSortKeys: No segments", "[keys][segmented][sort][device
   const bool sort_descending = GENERATE(ascending, descending);
   const bool sort_buffer     = GENERATE(pointers, double_buffer);
 
-  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr);
+  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr); // NOLINT(misc-const-correctness)
   cub::DoubleBuffer<cub::NullType> values_buffer(nullptr, nullptr);
   values_buffer.selector = 1;
 
@@ -87,7 +87,7 @@ CUB_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][dev
   c2h::device_vector<int> offsets(num_segments + 1, int{});
   const int* d_offsets = thrust::raw_pointer_cast(offsets.data());
 
-  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr);
+  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr); // NOLINT(misc-const-correctness)
   cub::DoubleBuffer<cub::NullType> values_buffer(nullptr, nullptr);
   values_buffer.selector = 1;
 
@@ -206,7 +206,7 @@ try
 
   // Generate input keys
   constexpr auto max_histo_size = 250;
-  segmented_verification_helper<key_t> verification_helper{max_histo_size};
+  const segmented_verification_helper<key_t> verification_helper{max_histo_size};
   verification_helper.prepare_input_data(in_keys);
 
   auto offsets = cuda::transform_iterator(

--- a/cub/test/catch2_test_device_segmented_sort_keys_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env.cu
@@ -48,7 +48,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortKeys works with default environment",
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
 }
 
@@ -70,7 +70,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortKeysDescending works with default enviro
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
 }
 
@@ -92,7 +92,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeys works with default environmen
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
 }
 
@@ -114,7 +114,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending works with default 
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
 }
 
@@ -136,8 +136,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortKeys DoubleBuffer works with default env
             thrust::raw_pointer_cast(offsets.data()),
             thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -159,8 +159,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortKeysDescending DoubleBuffer works with d
             thrust::raw_pointer_cast(offsets.data()),
             thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -182,8 +182,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeys DoubleBuffer works with defau
             thrust::raw_pointer_cast(offsets.data()),
             thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -205,8 +205,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer works 
             thrust::raw_pointer_cast(offsets.data()),
             thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -241,7 +241,7 @@ CUB_TEST("DeviceSegmentedSort::SortKeys uses environment", "[segmented_sort][key
             thrust::raw_pointer_cast(offsets.data()) + 1,
             env);
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
 }
 
@@ -275,7 +275,7 @@ CUB_TEST("DeviceSegmentedSort::SortKeysDescending uses environment", "[segmented
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
 }
 
@@ -309,7 +309,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeys uses environment", "[segmented_sor
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   REQUIRE(keys_out == expected);
 }
 
@@ -343,7 +343,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending uses environment", "[seg
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   REQUIRE(keys_out == expected);
 }
 
@@ -376,8 +376,8 @@ CUB_TEST("DeviceSegmentedSort::SortKeys DoubleBuffer uses environment", "[segmen
             thrust::raw_pointer_cast(offsets.data()) + 1,
             env);
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -413,8 +413,8 @@ CUB_TEST("DeviceSegmentedSort::SortKeysDescending DoubleBuffer uses environment"
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -450,8 +450,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeys DoubleBuffer uses environment",
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -487,8 +487,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer uses enviro
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -521,7 +521,7 @@ CUB_TEST("DeviceSegmentedSort::SortKeys can be tuned", "[segmented_sort][keys][d
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -533,7 +533,7 @@ CUB_TEST("DeviceSegmentedSort::SortKeys can be tuned", "[segmented_sort][keys][d
             end_offsets,
             env);
 
-  c2h::device_vector<int> expected{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(keys_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -547,7 +547,7 @@ CUB_TEST(
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -560,7 +560,7 @@ CUB_TEST(
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected{9, 8, 7, 6, 5, 3, 0};
   REQUIRE(keys_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -573,7 +573,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeys can be tuned", "[segmented_sort][k
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -586,7 +586,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeys can be tuned", "[segmented_sort][k
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(keys_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }
@@ -602,7 +602,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned",
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -615,7 +615,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortKeysDescending can be tuned",
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected{9, 8, 7, 6, 5, 3, 0};
   REQUIRE(keys_out == expected);
   REQUIRE(d_block_size[0] == target_block_size);
 }

--- a/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys_env_api.cu
@@ -22,8 +22,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -38,7 +38,7 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeys env-based API", "[segmented_sort][k
     std::cerr << "cub::DeviceSegmentedSort::SortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end sort-keys-env
 
   stream.sync();
@@ -53,8 +53,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -69,7 +69,7 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending env-based API", "[segment
     std::cerr << "cub::DeviceSegmentedSort::SortKeysDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end sort-keys-descending-env
 
   stream.sync();
@@ -86,8 +86,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortKeys(
     d_keys,
@@ -101,12 +101,12 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeys DoubleBuffer env-based API", "[segm
     std::cerr << "cub::DeviceSegmentedSort::SortKeys (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end sort-keys-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -121,8 +121,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortKeysDescending(
     d_keys,
@@ -136,12 +136,12 @@ CUB_TEST("cub::DeviceSegmentedSort::SortKeysDescending DoubleBuffer env-based AP
     std::cerr << "cub::DeviceSegmentedSort::SortKeysDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end sort-keys-descending-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -152,8 +152,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeys(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -168,7 +168,7 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys env-based API", "[segmented_s
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeys failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end stable-sort-keys-env
 
   stream.sync();
@@ -183,8 +183,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
   auto keys_out = thrust::device_vector<int>(7);
   auto offsets  = thrust::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeysDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -199,7 +199,7 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending env-based API", "[s
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeysDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end stable-sort-keys-descending-env
 
   stream.sync();
@@ -216,8 +216,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeys(
     d_keys,
@@ -231,12 +231,12 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeys DoubleBuffer env-based API", 
     std::cerr << "cub::DeviceSegmentedSort::StableSortKeys (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected{6, 7, 8, 0, 3, 5, 9};
   // example-end stable-sort-keys-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 
@@ -251,8 +251,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
 
   cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf0.data()), thrust::raw_pointer_cast(keys_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortKeysDescending(
     d_keys,
@@ -267,12 +267,12 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortKeysDescending DoubleBuffer env-ba
       << "cub::DeviceSegmentedSort::StableSortKeysDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected{8, 7, 6, 9, 5, 3, 0};
   // example-end stable-sort-keys-descending-db-env
 
   stream.sync();
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result(d_keys.Current(), d_keys.Current() + 7);
   REQUIRE(result == expected);
 }
 

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -45,7 +45,7 @@ CUB_TEST("DeviceSegmentedSortPairs: No segments", "[pairs][segmented][sort][devi
   const bool sort_descending = GENERATE(ascending, descending);
   const bool sort_buffer     = GENERATE(pointers, double_buffer);
 
-  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr);
+  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr); // NOLINT(misc-const-correctness)
   cub::DoubleBuffer<ValueT> values_buffer(nullptr, nullptr);
   values_buffer.selector = 1;
 
@@ -83,7 +83,7 @@ CUB_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][d
   c2h::device_vector<int> offsets(num_segments + 1, int{});
   const int* d_offsets = thrust::raw_pointer_cast(offsets.data());
 
-  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr);
+  cub::DoubleBuffer<KeyT> keys_buffer(nullptr, nullptr); // NOLINT(misc-const-correctness)
   cub::DoubleBuffer<ValueT> values_buffer(nullptr, nullptr);
   values_buffer.selector = 1;
 
@@ -218,7 +218,7 @@ try
   c2h::device_vector<key_t> in_keys(num_items);
   c2h::device_vector<value_t> in_values(num_items);
   constexpr auto max_histo_size = 250;
-  segmented_verification_helper<key_t> verification_helper{max_histo_size};
+  segmented_verification_helper<key_t> verification_helper{max_histo_size}; // NOLINT(misc-const-correctness)
   verification_helper.prepare_input_data(in_keys);
   thrust::copy(in_keys.cbegin(), in_keys.cend(), in_values.begin());
 

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env.cu
@@ -53,8 +53,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortPairs works with default environme
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -81,8 +81,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::StableSortPairsDescending works with default
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -109,8 +109,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable works with default envir
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -137,8 +137,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable works with def
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -167,10 +167,10 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer works with 
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -199,10 +199,10 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer w
       thrust::raw_pointer_cast(offsets.data()),
       thrust::raw_pointer_cast(offsets.data()) + 1));
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -219,7 +219,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream",
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -252,8 +252,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable uses custom stream",
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -268,7 +268,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom st
   auto values_out = c2h::device_vector<int>(7);
   auto offsets    = c2h::device_vector<int>{0, 3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -301,8 +301,8 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable uses custom st
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -321,7 +321,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -349,10 +349,10 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses custom
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -371,7 +371,7 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer u
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -400,10 +400,10 @@ CUB_TEST_CASE("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer u
 
   stream.sync();
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -444,8 +444,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairs uses environment", "[segmented_so
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -486,8 +486,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending uses environment", "[se
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -530,10 +530,10 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairs DoubleBuffer uses environment",
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -576,10 +576,10 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer uses envir
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -620,8 +620,8 @@ CUB_TEST("DeviceSegmentedSort::SortPairs nonstable uses environment", "[segmente
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -664,8 +664,8 @@ CUB_TEST("DeviceSegmentedSort::SortPairsDescending nonstable uses environment",
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
 }
@@ -707,10 +707,10 @@ CUB_TEST("DeviceSegmentedSort::SortPairs nonstable DoubleBuffer uses environment
              thrust::raw_pointer_cast(offsets.data()) + 1,
              env);
 
-  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -753,10 +753,10 @@ CUB_TEST("DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer uses e
     thrust::raw_pointer_cast(offsets.data()) + 1,
     env);
 
-  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
-  c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const c2h::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const c2h::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -792,7 +792,7 @@ CUB_TEST("DeviceSegmentedSort::SortPairs can be tuned", "[segmented_sort][pairs]
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -807,8 +807,8 @@ CUB_TEST("DeviceSegmentedSort::SortPairs can be tuned", "[segmented_sort][pairs]
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(d_block_size[0] == target_block_size);
@@ -825,7 +825,7 @@ CUB_TEST(
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -840,8 +840,8 @@ CUB_TEST(
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(d_block_size[0] == target_block_size);
@@ -857,7 +857,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairs can be tuned", "[segmented_sort][
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -872,8 +872,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairs can be tuned", "[segmented_sort][
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
-  c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
+  const c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
+  const c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(d_block_size[0] == target_block_size);
@@ -892,7 +892,7 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending can be tuned",
   auto begin_offsets                       = c2h::device_vector<int>{0};
   c2h::device_vector<unsigned int> d_block_size(1);
 
-  block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator end_offsets(7, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(segmented_sort_tuning<target_block_size>{});
 
@@ -907,8 +907,8 @@ CUB_TEST("DeviceSegmentedSort::StableSortPairsDescending can be tuned",
     end_offsets,
     env);
 
-  c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
-  c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
+  const c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
+  const c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
   REQUIRE(d_block_size[0] == target_block_size);

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
@@ -24,8 +24,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_
   auto offsets_begin = thrust::device_vector<int>{0, 3};
   auto offsets_end   = thrust::device_vector<int>{3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortPairs(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -42,8 +42,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs env-based API", "[segmented_
     std::cerr << "cub::DeviceSegmentedSort::StableSortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end stable-sort-pairs-env
   stream.sync();
 
@@ -62,8 +62,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[
   auto offsets_begin = thrust::device_vector<int>{0, 3};
   auto offsets_end   = thrust::device_vector<int>{3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortPairsDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -80,8 +80,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending env-based API", "[
     std::cerr << "cub::DeviceSegmentedSort::StableSortPairsDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end stable-sort-pairs-descending-env
   stream.sync();
 
@@ -106,8 +106,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API",
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortPairs(
     d_keys,
@@ -122,14 +122,14 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairs DoubleBuffer env-based API",
     std::cerr << "cub::DeviceSegmentedSort::StableSortPairs (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end stable-sort-pairs-db-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -150,8 +150,8 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-b
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::StableSortPairsDescending(
     d_keys,
@@ -167,14 +167,14 @@ CUB_TEST("cub::DeviceSegmentedSort::StableSortPairsDescending DoubleBuffer env-b
       << "cub::DeviceSegmentedSort::StableSortPairsDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end stable-sort-pairs-descending-db-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -189,8 +189,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmen
   auto offsets_begin = thrust::device_vector<int>{0, 3};
   auto offsets_end   = thrust::device_vector<int>{3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortPairs(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -207,8 +207,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmen
     std::cerr << "cub::DeviceSegmentedSort::SortPairs failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end sort-pairs-env
   stream.sync();
 
@@ -229,8 +229,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API"
   auto offsets_begin = thrust::device_vector<int>{0, 3};
   auto offsets_end   = thrust::device_vector<int>{3, 7};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortPairsDescending(
     thrust::raw_pointer_cast(keys_in.data()),
@@ -247,8 +247,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API"
     std::cerr << "cub::DeviceSegmentedSort::SortPairsDescending failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end sort-pairs-descending-env
   stream.sync();
 
@@ -273,8 +273,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based A
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortPairs(
     d_keys,
@@ -289,14 +289,14 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based A
     std::cerr << "cub::DeviceSegmentedSort::SortPairs (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
-  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  const thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  const thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
   // example-end sort-pairs-db-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }
@@ -317,8 +317,8 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer e
   cub::DoubleBuffer<int> d_values(
     thrust::raw_pointer_cast(values_buf0.data()), thrust::raw_pointer_cast(values_buf1.data()));
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSegmentedSort::SortPairsDescending(
     d_keys,
@@ -333,14 +333,14 @@ CUB_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer e
     std::cerr << "cub::DeviceSegmentedSort::SortPairsDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
-  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  const thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  const thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
   // example-end sort-pairs-descending-db-env
   stream.sync();
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
-  thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
+  const thrust::device_vector<int> result_keys(d_keys.Current(), d_keys.Current() + 7);
+  const thrust::device_vector<int> result_values(d_values.Current(), d_values.Current() + 7);
   REQUIRE(result_keys == expected_keys);
   REQUIRE(result_values == expected_values);
 }

--- a/cub/test/catch2_test_device_segmented_topk_keys.cu
+++ b/cub/test/catch2_test_device_segmented_topk_keys.cu
@@ -1118,7 +1118,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with large variable-size unalign
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   c2h::device_vector<key_t> keys_in_buffer(pad + num_items, thrust::no_init);
   c2h::device_vector<key_t> keys_out_buffer(total_output_size, thrust::no_init);
@@ -1271,7 +1271,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with small variable-size segment
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare keys input & output
   c2h::device_vector<key_t> keys_in_buffer(num_items, thrust::no_init);
@@ -1356,7 +1356,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys leave surplus cluster CTAs idle on sm
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   c2h::device_vector<key_t> keys_in_buffer(pad + num_items, thrust::no_init);
   c2h::device_vector<key_t> keys_out_buffer(total_output_size, thrust::no_init);
@@ -1455,7 +1455,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with fixed-size segments and per
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare input & output. Input segments are fixed-size (strided); output segments are compacted (variable).
   c2h::device_vector<key_t> keys_in_buffer(num_segments * segment_size, thrust::no_init);
@@ -1553,7 +1553,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Keys work with variable-size segments and 
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare keys input & output
   c2h::device_vector<key_t> keys_in_buffer(num_items, thrust::no_init);

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -241,7 +241,7 @@ bool verify_unique_indices(c2h::device_vector<ValueT>& values_out, cuda::std::in
   auto num_items   = sorted_values.size();
   auto counting_it = cuda::make_counting_iterator(cuda::std::int64_t{0});
   auto seg_ids     = cuda::make_transform_iterator(counting_it, fixed_stride_segment_id_op{k});
-  flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), seg_ids};
+  flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), seg_ids}; // NOLINT(misc-const-correctness)
   auto num_duplicates = thrust::count_if(counting_it, counting_it + (num_items - 1), flag_op);
 
   return num_duplicates == 0;
@@ -272,7 +272,7 @@ bool verify_unique_indices(const c2h::device_vector<ValueT>& values_compacted,
                   segment_ids.begin());
   thrust::inclusive_scan(segment_ids.begin(), segment_ids.end(), segment_ids.begin());
 
-  flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), segment_ids.cbegin()};
+  flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), segment_ids.cbegin()}; // NOLINT(misc-const-correctness)
 
   auto num_duplicates = thrust::count_if(
     cuda::make_counting_iterator(cuda::std::size_t{0}), cuda::make_counting_iterator(num_items - 1), flag_op);
@@ -1023,12 +1023,12 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs deterministic tie-break returns the 
     d_keys_in, d_keys_out, d_values_in, d_values_out, seg_arg, k_arg, ns_arg);
 
   // Values still belong to their keys, and no source index is selected twice.
-  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+  const c2h::device_vector<key_t> expected_keys(keys_in_buffer);
   REQUIRE(verify_pairs_consistency(expected_keys, keys_out_buffer, values_out_buffer) == true);
   REQUIRE(verify_unique_indices(values_out_buffer, num_segments, k) == true);
 
   // The deterministic path must return *exactly* the index-ordered top-k. Compare per-segment selected index sets.
-  c2h::host_vector<key_t> h_keys = keys_in_buffer;
+  const c2h::host_vector<key_t> h_keys = keys_in_buffer;
   const c2h::host_vector<val_t> ref =
     reference_deterministic_topk_indices<key_t, val_t>(h_keys, num_segments, segment_size, k, direction, prefer_larger);
 
@@ -1111,12 +1111,12 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs run a tiny multi-CTA segment through
     d_keys_in, d_keys_out, d_values_in, d_values_out, seg_sizes, k_param, cuda::args::immediate{num_segments}, env);
 
   // Values still belong to their keys, and no source index is selected twice.
-  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+  const c2h::device_vector<key_t> expected_keys(keys_in_buffer);
   REQUIRE(verify_pairs_consistency(expected_keys, keys_out_buffer, values_out_buffer) == true);
   REQUIRE(verify_unique_indices(values_out_buffer, num_segments, k) == true);
 
   // The deterministic path must return *exactly* the index-ordered top-k. Compare per-segment selected index sets.
-  c2h::host_vector<key_t> h_keys = keys_in_buffer;
+  const c2h::host_vector<key_t> h_keys = keys_in_buffer;
   const c2h::host_vector<val_t> ref =
     reference_deterministic_topk_indices<key_t, val_t>(h_keys, num_segments, segment_size, k, direction, prefer_larger);
 
@@ -1204,12 +1204,12 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs deterministic tie-break streams the 
     d_keys_in, d_keys_out, d_values_in, d_values_out, seg_arg, k_arg, ns_arg);
 
   // Values still belong to their keys, and no source index is selected twice.
-  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+  const c2h::device_vector<key_t> expected_keys(keys_in_buffer);
   REQUIRE(verify_pairs_consistency(expected_keys, keys_out_buffer, values_out_buffer) == true);
   REQUIRE(verify_unique_indices(values_out_buffer, num_segments, k) == true);
 
   // The deterministic path must return *exactly* the index-ordered top-k. Compare per-segment selected index sets.
-  c2h::host_vector<key_t> h_keys = keys_in_buffer;
+  const c2h::host_vector<key_t> h_keys = keys_in_buffer;
   const c2h::host_vector<val_t> ref =
     reference_deterministic_topk_indices<key_t, val_t>(h_keys, num_segments, segment_size, k, direction, prefer_larger);
 
@@ -1309,7 +1309,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs deterministic tie-break streams the 
 
   // Materialize the (non-contiguous) key input for verification: same heavy-tie function of the global index.
   c2h::host_vector<key_t> h_keys(static_cast<cuda::std::size_t>(num_items));
-  heavy_tie_key_op<key_t> key_op{};
+  const heavy_tie_key_op<key_t> key_op{};
   for (segment_size_t idx = 0; idx < num_items; ++idx)
   {
     h_keys[static_cast<cuda::std::size_t>(idx)] = key_op(idx);
@@ -1447,7 +1447,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs deterministic unspecified tie-break 
   }
 
   // Sanity: values still belong to their keys and no source index repeats within a segment.
-  c2h::device_vector<key_t> expected_keys(keys_in_buffer);
+  const c2h::device_vector<key_t> expected_keys(keys_in_buffer);
   REQUIRE(verify_pairs_consistency(expected_keys, keys_out_a, values_out_a) == true);
   REQUIRE(verify_unique_indices(values_out_a, num_segments, k) == true);
   // The second run uses config B (the streaming path under gpu_to_gpu); validate its pairing/uniqueness too so a
@@ -2011,7 +2011,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with small variable-size segmen
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare keys input & output
   c2h::device_vector<key_t> keys_in_buffer(num_items, thrust::no_init);
@@ -2130,7 +2130,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with fixed-size segments and pe
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare keys input & output. Input segments are fixed-size (strided); output segments are compacted (variable).
   c2h::device_vector<key_t> keys_in_buffer(num_segments * segment_size, thrust::no_init);
@@ -2248,7 +2248,7 @@ CUB_TEST("DeviceBatchedTopK::{Min,Max}Pairs work with variable-size segments and
   c2h::device_vector<segment_size_t> compacted_offsets(num_segments + 1, thrust::no_init);
   thrust::exclusive_scan(
     compacted_output_sizes_it, compacted_output_sizes_it + num_segments + 1, compacted_offsets.begin());
-  segment_size_t total_output_size = compacted_offsets.back();
+  const segment_size_t total_output_size = compacted_offsets.back();
 
   // Prepare keys input & output
   c2h::device_vector<key_t> keys_in_buffer(num_items, thrust::no_init);

--- a/cub/test/catch2_test_device_segmented_topk_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_topk_pairs.cu
@@ -238,10 +238,10 @@ bool verify_unique_indices(c2h::device_vector<ValueT>& values_out, cuda::std::in
   c2h::device_vector<ValueT> sorted_values{values_out};
   fixed_size_segmented_sort_keys(sorted_values, num_segments, k, cub::detail::topk::select::min);
 
-  auto num_items   = sorted_values.size();
-  auto counting_it = cuda::make_counting_iterator(cuda::std::int64_t{0});
-  auto seg_ids     = cuda::make_transform_iterator(counting_it, fixed_stride_segment_id_op{k});
-  flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), seg_ids}; // NOLINT(misc-const-correctness)
+  const auto num_items = sorted_values.size();
+  auto counting_it     = cuda::make_counting_iterator(cuda::std::int64_t{0});
+  const auto seg_ids   = cuda::make_transform_iterator(counting_it, fixed_stride_segment_id_op{k});
+  const flag_intra_segment_duplicates flag_op{sorted_values.cbegin(), seg_ids};
   auto num_duplicates = thrust::count_if(counting_it, counting_it + (num_items - 1), flag_op);
 
   return num_duplicates == 0;

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -31,7 +31,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_out(num_items);
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  const is_even_t is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;
@@ -59,7 +59,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
     num_items,
     is_even);
 
-  c2h::device_vector<int> expected{0, 1, 5};
+  const c2h::device_vector<int> expected{0, 1, 5};
   // example-end segmented-select-flaggedif
 
   REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
@@ -74,7 +74,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
   c2h::device_vector<int> d_data  = {0, 1, 2, 3, 4, 5, 6, 7};
   c2h::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   c2h::device_vector<int> d_num_selected_out(num_items);
-  is_even_t is_even{};
+  const is_even_t is_even{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;
@@ -94,7 +94,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf in-place works with int data elements", "
     num_items,
     is_even);
 
-  c2h::device_vector<int> expected{0, 1, 5};
+  const c2h::device_vector<int> expected{0, 1, 5};
   // example-end segmented-select-flaggedif-inplace
 
   REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
@@ -127,7 +127,7 @@ CUB_TEST("cub::DeviceSelect::Unique in-place works with int data elements", "[se
   // Resize input to new length
   d_data.resize(d_num_selected_out[0]);
 
-  thrust::device_vector<int> expected{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected{0, 2, 9, 5, 8};
   // example-end select-unique-inplace
 
   REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
@@ -152,7 +152,7 @@ CUB_TEST("cub::DeviceSelect::Unique in-place with equality_op works with int dat
   constexpr int num_items                       = 8;
   thrust::device_vector<int> d_data             = {0, 2, 2, 9, 5, 5, 5, 8};
   thrust::device_vector<int> d_num_selected_out = {0};
-  my_equality_op equality_op{};
+  const my_equality_op equality_op{};
 
   // Determine temporary device storage requirements
   size_t temp_storage_bytes = 0;
@@ -174,7 +174,7 @@ CUB_TEST("cub::DeviceSelect::Unique in-place with equality_op works with int dat
   // Resize input to new length
   d_data.resize(d_num_selected_out[0]);
 
-  thrust::device_vector<int> expected{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected{0, 2, 9, 5, 8};
   // example-end select-unique-inplace-eqop
 
   REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
@@ -299,7 +299,7 @@ CUB_TEST("DeviceSelect::UniqueByKey legacy size-query is unambiguous", "[select]
   int* d_keys_out           = nullptr;
   int* d_values_out         = nullptr;
   int* d_num_selected       = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess
           == cub::DeviceSelect::UniqueByKey(

--- a/cub/test/catch2_test_device_select_env.cu
+++ b/cub/test/catch2_test_device_select_env.cu
@@ -45,19 +45,19 @@ CUB_TEST_CASE("Device select works with default environment", "[select][device]"
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  less_than_t<value_t> select_op{5};
+  const less_than_t<value_t> select_op{5};
 
   // launch wrapper always assumes the last argument is the environment
   REQUIRE(
     cudaSuccess == cub::DeviceSelect::If(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -69,19 +69,19 @@ CUB_TEST_CASE("Device select flagged works with default environment", "[select][
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   // launch wrapper always assumes the last argument is the environment
   REQUIRE(
     cudaSuccess
     == cub::DeviceSelect::Flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -93,20 +93,20 @@ CUB_TEST_CASE("Device select flagged_if works with default environment", "[selec
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
   REQUIRE(cudaSuccess
           == cub::DeviceSelect::FlaggedIf(
             d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -118,16 +118,16 @@ CUB_TEST_CASE("Device select flagged in-place works with default environment", "
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   REQUIRE(
     cudaSuccess == cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -139,16 +139,16 @@ CUB_TEST_CASE("Device select if in-place works with default environment", "[sele
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  less_than_t<value_t> select_op{5};
+  const less_than_t<value_t> select_op{5};
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -160,19 +160,19 @@ CUB_TEST_CASE("Device select flagged_if in-place works with default environment"
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
   REQUIRE(
     cudaSuccess
     == cub::DeviceSelect::FlaggedIf(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -184,15 +184,15 @@ CUB_TEST_CASE("Device select unique works with default environment", "[select][d
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items));
 
-  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -206,18 +206,18 @@ CUB_TEST_CASE("Device select unique with custom equality_op works with default e
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  eq_mod3_t<value_t> eq_mod3{};
+  const eq_mod3_t<value_t> eq_mod3{};
 
   REQUIRE(
     cudaSuccess == cub::DeviceSelect::Unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
-  c2h::device_vector<value_t> expected_output{0, 1, 2};
-  c2h::device_vector<int> expected_num_selected{3};
+  const c2h::device_vector<value_t> expected_output{0, 1, 2};
+  const c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -229,14 +229,14 @@ CUB_TEST_CASE("Device select unique in-place works with default environment", "[
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items));
 
-  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -250,16 +250,16 @@ CUB_TEST_CASE("Device select unique in-place with custom equality_op works with 
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  eq_mod3_t<value_t> eq_mod3{};
+  const eq_mod3_t<value_t> eq_mod3{};
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3));
 
-  c2h::device_vector<value_t> expected_output{0, 1, 2};
-  c2h::device_vector<int> expected_num_selected{3};
+  const c2h::device_vector<value_t> expected_output{0, 1, 2};
+  const c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -271,12 +271,12 @@ CUB_TEST_CASE("Device select unique_by_key works with default environment", "[se
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_keys_in        = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_values_in      = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
-  auto d_values_out     = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_keys_in              = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_values_in            = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_keys_out             = c2h::device_vector<value_t>(num_items);
+  auto d_values_out           = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   REQUIRE(
     cudaSuccess
@@ -288,9 +288,9 @@ CUB_TEST_CASE("Device select unique_by_key works with default environment", "[se
       d_num_selected.begin(),
       num_items));
 
-  c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_keys_out.resize(d_num_selected[0]);
@@ -306,12 +306,12 @@ CUB_TEST_CASE("Device select unique_by_key works with default environment and ex
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_keys_in        = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_values_in      = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
-  auto d_values_out     = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 8;
+  auto d_keys_in              = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_values_in            = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_keys_out             = c2h::device_vector<value_t>(num_items);
+  auto d_values_out           = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
   auto env = stdexec::env{};
 
@@ -326,9 +326,9 @@ CUB_TEST_CASE("Device select unique_by_key works with default environment and ex
       num_items,
       env));
 
-  c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_keys_out.resize(d_num_selected[0]);
@@ -353,13 +353,13 @@ CUB_TEST_CASE("Device select unique_by_key default tuning chooses target block s
 
   const auto target_block_size = selector_t{}(cc).threads_per_block;
 
-  num_items_t num_items = 1;
-  auto d_keys_in        = c2h::device_vector<key_t>{0};
-  auto d_keys_out       = c2h::device_vector<key_t>(1);
-  auto d_values_out     = c2h::device_vector<value_t>(1);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
-  auto d_block_size     = c2h::device_vector<unsigned int>(1);
-  block_size_check_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const num_items_t num_items = 1;
+  auto d_keys_in              = c2h::device_vector<key_t>{0};
+  auto d_keys_out             = c2h::device_vector<key_t>(1);
+  auto d_values_out           = c2h::device_vector<value_t>(1);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
+  auto d_block_size           = c2h::device_vector<unsigned int>(1);
+  const block_size_check_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
   auto d_values_in = cuda::constant_iterator(value_t{1});
 
   REQUIRE(
@@ -386,12 +386,12 @@ CUB_TEST("Device select uses environment", "[select][device]", CUB_SMALL)
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  less_than_t<value_t> select_op{6};
+  const less_than_t<value_t> select_op{6};
 
   size_t expected_bytes_allocated{};
   // calculate expected_bytes_allocated - call CUB API directly, not through wrapper
@@ -404,8 +404,8 @@ CUB_TEST("Device select uses environment", "[select][device]", CUB_SMALL)
 
   device_select_if(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -417,11 +417,11 @@ CUB_TEST("Device select flagged uses environment", "[select][device]", CUB_SMALL
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -439,8 +439,8 @@ CUB_TEST("Device select flagged uses environment", "[select][device]", CUB_SMALL
 
   device_select_flagged(d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, env);
 
-  c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -452,13 +452,13 @@ CUB_TEST("Device select flagged_if uses environment", "[select][device]", CUB_SM
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_flags          = c2h::device_vector<int>{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_flags                = c2h::device_vector<int>{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -478,8 +478,8 @@ CUB_TEST("Device select flagged_if uses environment", "[select][device]", CUB_SM
   device_select_flagged_if(
     d_in.begin(), d_flags.begin(), d_out.begin(), d_num_selected.begin(), num_items, select_op, env);
 
-  c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -491,10 +491,10 @@ CUB_TEST("Device select flagged in-place uses environment", "[select][device]", 
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -513,8 +513,8 @@ CUB_TEST("Device select flagged in-place uses environment", "[select][device]", 
   REQUIRE(
     cudaSuccess == cub::DeviceSelect::Flagged(d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, env));
 
-  c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -526,11 +526,11 @@ CUB_TEST("Device select if in-place uses environment", "[select][device]", CUB_S
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  less_than_t<value_t> select_op{6};
+  const less_than_t<value_t> select_op{6};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -542,8 +542,8 @@ CUB_TEST("Device select if in-place uses environment", "[select][device]", CUB_S
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::If(d_data.begin(), d_num_selected.begin(), num_items, select_op, env));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -555,12 +555,12 @@ CUB_TEST("Device select flagged_if in-place uses environment", "[select][device]
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_data           = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto d_flags          = c2h::device_vector<int>{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_data                 = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto d_flags                = c2h::device_vector<int>{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -581,8 +581,8 @@ CUB_TEST("Device select flagged_if in-place uses environment", "[select][device]
           == cub::DeviceSelect::FlaggedIf(
             d_data.begin(), d_flags.begin(), d_num_selected.begin(), num_items, select_op, env));
 
-  c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 3, 5, 7, 9};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -594,10 +594,10 @@ CUB_TEST("Device select unique uses environment", "[select][device]", CUB_SMALL)
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_in             = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_in                   = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess
@@ -608,8 +608,8 @@ CUB_TEST("Device select unique uses environment", "[select][device]", CUB_SMALL)
 
   device_select_unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, env);
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -621,12 +621,12 @@ CUB_TEST("Device select unique with custom equality_op uses environment", "[sele
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  eq_mod3_t<value_t> eq_mod3{};
+  const eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -638,8 +638,8 @@ CUB_TEST("Device select unique with custom equality_op uses environment", "[sele
 
   device_select_unique(d_in.begin(), d_out.begin(), d_num_selected.begin(), num_items, eq_mod3, env);
 
-  c2h::device_vector<value_t> expected_output{0, 1, 2};
-  c2h::device_vector<int> expected_num_selected{3};
+  const c2h::device_vector<value_t> expected_output{0, 1, 2};
+  const c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -651,9 +651,9 @@ CUB_TEST("Device select unique in-place uses environment", "[select][device]", C
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_data           = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_data                 = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -664,8 +664,8 @@ CUB_TEST("Device select unique in-place uses environment", "[select][device]", C
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, env));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4, 5};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -677,11 +677,11 @@ CUB_TEST("Device select unique in-place with custom equality_op uses environment
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  eq_mod3_t<value_t> eq_mod3{};
+  const eq_mod3_t<value_t> eq_mod3{};
 
   size_t expected_bytes_allocated{};
   REQUIRE(cudaSuccess
@@ -692,8 +692,8 @@ CUB_TEST("Device select unique in-place with custom equality_op uses environment
 
   REQUIRE(cudaSuccess == cub::DeviceSelect::Unique(d_data.begin(), d_num_selected.begin(), num_items, eq_mod3, env));
 
-  c2h::device_vector<value_t> expected_output{0, 1, 2};
-  c2h::device_vector<int> expected_num_selected{3};
+  const c2h::device_vector<value_t> expected_output{0, 1, 2};
+  const c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -705,12 +705,12 @@ CUB_TEST("Device select unique_by_key uses environment", "[select][device]", CUB
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_keys_in        = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
-  auto d_values_in      = c2h::device_vector<value_t>{10, 11, 20, 21, 30, 31, 40, 41, 50, 51};
-  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
-  auto d_values_out     = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 10;
+  auto d_keys_in              = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_values_in            = c2h::device_vector<value_t>{10, 11, 20, 21, 30, 31, 40, 41, 50, 51};
+  auto d_keys_out             = c2h::device_vector<value_t>(num_items);
+  auto d_values_out           = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -737,9 +737,9 @@ CUB_TEST("Device select unique_by_key uses environment", "[select][device]", CUB
     ::cuda::std::equal_to<>{},
     env);
 
-  c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};
-  c2h::device_vector<value_t> expected_values{10, 20, 30, 40, 50};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};
+  const c2h::device_vector<value_t> expected_values{10, 20, 30, 40, 50};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_keys_out.resize(d_num_selected[0]);
@@ -753,12 +753,12 @@ CUB_TEST("Device select unique_by_key uses environment without equality_op", "[s
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 10;
-  auto d_keys_in        = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
-  auto d_values_in      = c2h::device_vector<value_t>{10, 11, 20, 21, 30, 31, 40, 41, 50, 51};
-  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
-  auto d_values_out     = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<int>(1);
+  const num_items_t num_items = 10;
+  auto d_keys_in              = c2h::device_vector<value_t>{1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto d_values_in            = c2h::device_vector<value_t>{10, 11, 20, 21, 30, 31, 40, 41, 50, 51};
+  auto d_keys_out             = c2h::device_vector<value_t>(num_items);
+  auto d_values_out           = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<int>(1);
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -784,9 +784,9 @@ CUB_TEST("Device select unique_by_key uses environment without equality_op", "[s
     num_items,
     env);
 
-  c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};
-  c2h::device_vector<value_t> expected_values{10, 20, 30, 40, 50};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_keys{1, 2, 3, 4, 5};
+  const c2h::device_vector<value_t> expected_values{10, 20, 30, 40, 50};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_keys_out.resize(d_num_selected[0]);
@@ -800,12 +800,12 @@ CUB_TEST_CASE("Device select uses custom stream", "[select][device]", CUB_SMALL)
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  less_than_t<value_t> select_op{5};
+  const less_than_t<value_t> select_op{5};
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -823,8 +823,8 @@ CUB_TEST_CASE("Device select uses custom stream", "[select][device]", CUB_SMALL)
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 2, 3, 4};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -838,11 +838,11 @@ CUB_TEST_CASE("Device select flagged uses custom stream", "[select][device]", CU
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -866,8 +866,8 @@ CUB_TEST_CASE("Device select flagged uses custom stream", "[select][device]", CU
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -881,13 +881,13 @@ CUB_TEST_CASE("Device select flagged_if uses custom stream", "[select][device]",
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_flags          = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_flags                = c2h::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -913,8 +913,8 @@ CUB_TEST_CASE("Device select flagged_if uses custom stream", "[select][device]",
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
-  c2h::device_vector<int> expected_num_selected{4};
+  const c2h::device_vector<value_t> expected_output{1, 4, 6, 7};
+  const c2h::device_vector<int> expected_num_selected{4};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -928,10 +928,10 @@ CUB_TEST_CASE("Device select unique uses custom stream", "[select][device]", CUB
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_in             = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_out            = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_in                   = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_out                  = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -948,8 +948,8 @@ CUB_TEST_CASE("Device select unique uses custom stream", "[select][device]", CUB
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_out.resize(d_num_selected[0]);
@@ -963,9 +963,9 @@ CUB_TEST_CASE("Device select unique in-place uses custom stream", "[select][devi
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -982,8 +982,8 @@ CUB_TEST_CASE("Device select unique in-place uses custom stream", "[select][devi
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_output{0, 2, 9, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -997,11 +997,11 @@ CUB_TEST_CASE("Device select unique in-place with custom equality_op uses custom
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_data           = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_data                 = c2h::device_vector<value_t>{0, 3, 6, 1, 4, 7, 2, 5};
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
-  eq_mod3_t<value_t> eq_mod3{};
+  const eq_mod3_t<value_t> eq_mod3{};
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -1018,8 +1018,8 @@ CUB_TEST_CASE("Device select unique in-place with custom equality_op uses custom
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_output{0, 1, 2};
-  c2h::device_vector<int> expected_num_selected{3};
+  const c2h::device_vector<value_t> expected_output{0, 1, 2};
+  const c2h::device_vector<int> expected_num_selected{3};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_data.resize(d_num_selected[0]);
@@ -1033,12 +1033,12 @@ CUB_TEST_CASE("Device select unique_by_key uses custom stream", "[select][device
   using value_t     = int;
   using num_items_t = int;
 
-  num_items_t num_items = 8;
-  auto d_keys_in        = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
-  auto d_values_in      = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto d_keys_out       = c2h::device_vector<value_t>(num_items);
-  auto d_values_out     = c2h::device_vector<value_t>(num_items);
-  auto d_num_selected   = c2h::device_vector<unsigned int>(1);
+  const num_items_t num_items = 8;
+  auto d_keys_in              = c2h::device_vector<value_t>{0, 2, 2, 9, 5, 5, 5, 8};
+  auto d_values_in            = c2h::device_vector<value_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto d_keys_out             = c2h::device_vector<value_t>(num_items);
+  auto d_values_out           = c2h::device_vector<value_t>(num_items);
+  auto d_num_selected         = c2h::device_vector<unsigned int>(1);
 
   cudaStream_t custom_stream;
   REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
@@ -1071,9 +1071,9 @@ CUB_TEST_CASE("Device select unique_by_key uses custom stream", "[select][device
 
   REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
 
-  c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
-  c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
-  c2h::device_vector<int> expected_num_selected{5};
+  const c2h::device_vector<value_t> expected_keys{0, 2, 9, 5, 8};
+  const c2h::device_vector<value_t> expected_values{1, 2, 4, 5, 8};
+  const c2h::device_vector<int> expected_num_selected{5};
 
   REQUIRE(d_num_selected == expected_num_selected);
   d_keys_out.resize(d_num_selected[0]);
@@ -1142,7 +1142,7 @@ CUB_TEST("DeviceSelect::If can be tuned", "[select][device]", CUB_SMALL, block_s
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1158,7 +1158,7 @@ CUB_TEST("DeviceSelect::If in-place can be tuned", "[select][device]", CUB_SMALL
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<less_than_5_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1175,7 +1175,7 @@ CUB_TEST("DeviceSelect::Flagged can be tuned", "[select][device]", CUB_SMALL, bl
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1191,7 +1191,7 @@ CUB_TEST("DeviceSelect::Flagged in-place can be tuned", "[select][device]", CUB_
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator flags_begin(1, thrust::raw_pointer_cast(d_block_size.data()));
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1209,7 +1209,7 @@ CUB_TEST("DeviceSelect::FlaggedIf can be tuned", "[select][device]", CUB_SMALL, 
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<even_flag_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<even_flag_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1226,7 +1226,7 @@ CUB_TEST("DeviceSelect::FlaggedIf in-place can be tuned", "[select][device]", CU
   auto d_num_selected                      = c2h::device_vector<unsigned int>(1);
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
-  block_size_extracting_op<even_flag_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const block_size_extracting_op<even_flag_t> select_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1245,7 +1245,7 @@ CUB_TEST("DeviceSelect::Unique can be tuned", "[select][device]", CUB_SMALL, blo
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
   using eq_op_t = block_size_extracting_op<cuda::std::equal_to<>>;
-  eq_op_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const eq_op_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(select_tuning<target_block_size>{});
 
@@ -1265,7 +1265,7 @@ CUB_TEST("DeviceSelect::UniqueByKey can be tuned", "[select][device]", CUB_SMALL
   auto d_block_size                        = c2h::device_vector<unsigned int>(1);
 
   using eq_op_t = block_size_extracting_op<cuda::std::equal_to<>>;
-  eq_op_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
+  const eq_op_t equality_op{thrust::raw_pointer_cast(d_block_size.data())};
 
   auto env = cuda::execution::tune(unique_by_key_tuning<target_block_size>{});
 

--- a/cub/test/catch2_test_device_select_env_api.cu
+++ b/cub/test/catch2_test_device_select_env_api.cu
@@ -22,10 +22,10 @@ CUB_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]", CUB_S
   auto input        = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
   auto output       = thrust::device_vector<int>(4);
   auto num_selected = thrust::device_vector<int>(1);
-  less_than_t<int> le{5};
+  const less_than_t<int> le{5};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::If(
     input.begin(),
@@ -39,8 +39,8 @@ CUB_TEST("cub::DeviceSelect::If accepts env with stream", "[select][env]", CUB_S
     std::cerr << "cub::DeviceSelect::If failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 2, 3, 4};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 2, 3, 4};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-if-env
 
   stream.sync();
@@ -57,8 +57,8 @@ CUB_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]", 
   auto output       = thrust::device_vector<int>(4);
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Flagged(
     input.begin(),
@@ -72,8 +72,8 @@ CUB_TEST("cub::DeviceSelect::Flagged accepts env with stream", "[select][env]", 
     std::cerr << "cub::DeviceSelect::Flagged failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 4, 6, 7};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 4, 6, 7};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flagged-env
 
   stream.sync();
@@ -89,10 +89,10 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]"
   auto flags        = thrust::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
   auto output       = thrust::device_vector<int>(4);
   auto num_selected = thrust::device_vector<int>(1);
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::FlaggedIf(
     input.begin(),
@@ -107,8 +107,8 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf accepts env with stream", "[select][env]"
     std::cerr << "cub::DeviceSelect::FlaggedIf failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 4, 6, 7};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 4, 6, 7};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flaggedif-env
 
   stream.sync();
@@ -124,8 +124,8 @@ CUB_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select
   auto flags        = thrust::device_vector<char>{1, 0, 0, 1, 0, 1, 1, 0};
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Flagged(
     data.begin(), flags.begin(), num_selected.begin(), static_cast<::cuda::std::int64_t>(data.size()), stream_ref);
@@ -134,8 +134,8 @@ CUB_TEST("cub::DeviceSelect::Flagged in-place accepts env with stream", "[select
     std::cerr << "cub::DeviceSelect::Flagged in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 4, 6, 7};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 4, 6, 7};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flagged-inplace-env
 
   stream.sync();
@@ -150,10 +150,10 @@ CUB_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env
   // example-begin select-if-inplace-env
   auto data         = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
   auto num_selected = thrust::device_vector<int>(1);
-  less_than_t<int> le{5};
+  const less_than_t<int> le{5};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::If(
     data.begin(), num_selected.begin(), static_cast<::cuda::std::int64_t>(data.size()), le, stream_ref);
@@ -162,8 +162,8 @@ CUB_TEST("cub::DeviceSelect::If in-place accepts env with stream", "[select][env
     std::cerr << "cub::DeviceSelect::If in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 2, 3, 4};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 2, 3, 4};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-if-inplace-env
 
   stream.sync();
@@ -179,10 +179,10 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[sele
   auto data         = thrust::device_vector<int>{1, 2, 3, 4, 5, 6, 7, 8};
   auto flags        = thrust::device_vector<int>{2, 1, 1, 4, 1, 6, 6, 1};
   auto num_selected = thrust::device_vector<int>(1);
-  mod_n<int> select_op{2};
+  const mod_n<int> select_op{2};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::FlaggedIf(
     data.begin(),
@@ -196,8 +196,8 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf in-place accepts env with stream", "[sele
     std::cerr << "cub::DeviceSelect::FlaggedIf in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{1, 4, 6, 7};
-  thrust::device_vector<int> expected_num_selected{4};
+  const thrust::device_vector<int> expected_output{1, 4, 6, 7};
+  const thrust::device_vector<int> expected_num_selected{4};
   // example-end select-flaggedif-inplace-env
 
   stream.sync();
@@ -214,8 +214,8 @@ CUB_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]", C
   auto output       = thrust::device_vector<int>(5);
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Unique(
     input.begin(), output.begin(), num_selected.begin(), static_cast<::cuda::std::int64_t>(input.size()), stream_ref);
@@ -224,8 +224,8 @@ CUB_TEST("cub::DeviceSelect::Unique accepts env with stream", "[select][env]", C
     std::cerr << "cub::DeviceSelect::Unique failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_num_selected{5};
+  const thrust::device_vector<int> expected_output{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_num_selected{5};
   // example-end select-unique-env
 
   stream.sync();
@@ -242,10 +242,10 @@ CUB_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
   auto output       = thrust::device_vector<int>(8);
   auto num_selected = thrust::device_vector<int>(1);
 
-  eq_mod3_t<int> eq_mod3{};
+  const eq_mod3_t<int> eq_mod3{};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Unique(
     input.begin(),
@@ -261,8 +261,8 @@ CUB_TEST("cub::DeviceSelect::Unique with custom equality_op accepts env with str
 
   // 0,3,6 all == mod 3 (consecutive), keep first (0); 1,4,7 all == mod 3 (consecutive), keep first (1);
   // 2,5 == mod 3 (consecutive), keep first (2)
-  thrust::device_vector<int> expected_output{0, 1, 2};
-  thrust::device_vector<int> expected_num_selected{3};
+  const thrust::device_vector<int> expected_output{0, 1, 2};
+  const thrust::device_vector<int> expected_num_selected{3};
   // example-end select-unique-eqop-env
   stream.sync();
 
@@ -278,8 +278,8 @@ CUB_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select]
   auto data         = thrust::device_vector<int>{0, 2, 2, 9, 5, 5, 5, 8};
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Unique(
     data.begin(), num_selected.begin(), static_cast<::cuda::std::int64_t>(data.size()), stream_ref);
@@ -288,8 +288,8 @@ CUB_TEST("cub::DeviceSelect::Unique in-place accepts env with stream", "[select]
     std::cerr << "cub::DeviceSelect::Unique in-place failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_output{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_num_selected{5};
+  const thrust::device_vector<int> expected_output{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_num_selected{5};
   // example-end select-unique-inplace-env
   stream.sync();
 
@@ -308,10 +308,10 @@ CUB_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env
   auto data         = thrust::device_vector<int>{0, 3, 6, 1, 4, 7, 2, 5};
   auto num_selected = thrust::device_vector<int>(1);
 
-  eq_mod3_t<int> eq_mod3{};
+  const eq_mod3_t<int> eq_mod3{};
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::Unique(
     data.begin(), num_selected.begin(), static_cast<::cuda::std::int64_t>(data.size()), eq_mod3, stream_ref);
@@ -322,8 +322,8 @@ CUB_TEST("cub::DeviceSelect::Unique in-place with custom equality_op accepts env
 
   // 0,3,6 all == mod 3 (consecutive), keep first (0); 1,4,7 all == mod 3 (consecutive), keep first (1);
   // 2,5 == mod 3 (consecutive), keep first (2)
-  thrust::device_vector<int> expected_output{0, 1, 2};
-  thrust::device_vector<int> expected_num_selected{3};
+  const thrust::device_vector<int> expected_output{0, 1, 2};
+  const thrust::device_vector<int> expected_num_selected{3};
   // example-end select-unique-inplace-eqop-env
   stream.sync();
 
@@ -342,8 +342,8 @@ CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env
   auto values_out   = thrust::device_vector<int>(5);
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::UniqueByKey(
     keys_in.begin(),
@@ -359,9 +359,9 @@ CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream", "[select][env
     std::cerr << "cub::DeviceSelect::UniqueByKey failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
-  thrust::device_vector<int> expected_num_selected{5};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
+  const thrust::device_vector<int> expected_num_selected{5};
   // example-end select-uniquebykey-env
 
   stream.sync();
@@ -381,8 +381,8 @@ CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equalit
   auto values_out   = thrust::device_vector<int>(5);
   auto num_selected = thrust::device_vector<int>(1);
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
 
   auto error = cub::DeviceSelect::UniqueByKey(
     keys_in.begin(),
@@ -398,9 +398,9 @@ CUB_TEST("cub::DeviceSelect::UniqueByKey accepts env with stream without equalit
     std::cerr << "cub::DeviceSelect::UniqueByKey without equality_op failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
-  thrust::device_vector<int> expected_num_selected{5};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
+  const thrust::device_vector<int> expected_num_selected{5};
   // example-end select-uniquebykey-default-eq-env
 
   stream.sync();
@@ -427,9 +427,9 @@ CUB_TEST("cub::DeviceSelect::UniqueByKey accepts default env without equality_op
     std::cerr << "cub::DeviceSelect::UniqueByKey with default env failed with status: " << error << '\n';
   }
 
-  thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
-  thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
-  thrust::device_vector<int> expected_num_selected{5};
+  const thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
+  const thrust::device_vector<int> expected_values{1, 2, 4, 5, 8};
+  const thrust::device_vector<int> expected_num_selected{5};
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(keys_out == expected_keys);

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -162,7 +162,7 @@ CUB_TEST("DeviceSelect::Flagged does not change input", "[device][select_flagged
   int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
 
   select_flagged(in.begin(), flags.begin(), out.begin(), d_num_selected_out, num_items);
 
@@ -262,26 +262,26 @@ CUB_TEST("DeviceSelect::Flagged works with user provided memory and environment"
 
   SECTION("DeviceSelect::Flagged works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged(stream.get());
   }
 
   SECTION("DeviceSelect::Flagged works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged(stream);
   }
 
   SECTION("DeviceSelect::Flagged works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_flagged(stream_ref);
   }
 
   SECTION("DeviceSelect::Flagged works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_flagged(env);
   }
 
@@ -293,7 +293,7 @@ CUB_TEST("DeviceSelect::Flagged works with user provided memory and environment"
 
   SECTION("DeviceSelect::Flagged works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_flagged(policy);
   }
@@ -600,7 +600,7 @@ try
   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
   constexpr auto max_partition_size = static_cast<offset_t>(cuda::std::numeric_limits<std::int32_t>::max());
 
-  offset_t num_items = GENERATE_COPY(
+  const offset_t num_items = GENERATE_COPY(
     values({
       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
       offset_t{2} * max_partition_size, // 2 partitions
@@ -620,14 +620,14 @@ try
   offset_t* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // Run test
-  offset_t expected_num_copied = (num_items + match_every_nth - offset_t{1}) / match_every_nth;
+  const offset_t expected_num_copied = (num_items + match_every_nth - offset_t{1}) / match_every_nth;
   c2h::device_vector<type> out(expected_num_copied);
   select_flagged(in, flags_in, out.begin(), d_first_num_selected_out, num_items);
 
   // Ensure that we created the correct output
   REQUIRE(num_selected_out[0] == expected_num_copied);
-  auto expected_out_it     = cuda::transform_iterator(in, multiply_n<offset_t>{static_cast<offset_t>(match_every_nth)});
-  bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), expected_out_it);
+  auto expected_out_it = cuda::transform_iterator(in, multiply_n<offset_t>{static_cast<offset_t>(match_every_nth)});
+  const bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), expected_out_it);
   REQUIRE(all_results_correct == true);
 }
 catch (std::bad_alloc&)

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -36,8 +36,8 @@ template <class T, class FlagT, class Pred>
 static c2h::host_vector<T>
 get_reference(c2h::device_vector<T> const& in, c2h::device_vector<FlagT> const& flags, Pred if_predicate)
 {
-  c2h::host_vector<T> reference   = in;
-  c2h::host_vector<FlagT> h_flags = flags;
+  c2h::host_vector<T> reference         = in;
+  const c2h::host_vector<FlagT> h_flags = flags;
   // Zips flags and items
   auto zipped_in_it = thrust::make_zip_iterator(h_flags.cbegin(), reference.cbegin());
 
@@ -179,7 +179,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  const is_even_t<flag_type> is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -191,7 +191,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<input_type> reference_in = in;
+  const c2h::device_vector<input_type> reference_in = in;
 
   select_flagged_if(in.begin(), flags.begin(), out.begin(), d_num_selected_out, num_items, is_even);
 
@@ -283,26 +283,26 @@ CUB_TEST("DeviceSelect::FlaggedIf works with user provided memory and environmen
 
   SECTION("DeviceSelect::FlaggedIf works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged_if(stream.get());
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged_if(stream);
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_flagged_if(stream_ref);
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_flagged_if(env);
   }
 
@@ -314,7 +314,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with user provided memory and environmen
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_flagged_if(policy);
   }
@@ -393,26 +393,26 @@ CUB_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and e
 
   SECTION("DeviceSelect::FlaggedIf works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged_if(stream.get());
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_flagged_if(stream);
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_flagged_if(stream_ref);
   }
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_flagged_if(env);
   }
 
@@ -424,7 +424,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works in place with user provided memory and e
 
   SECTION("DeviceSelect::FlaggedIf works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_flagged_if(policy);
   }
@@ -511,7 +511,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  const is_even_t<flag_type> is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);
@@ -539,7 +539,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged
   c2h::device_vector<input_type> out(num_items);
   c2h::gen(C2H_SEED(2), in);
 
-  is_even_t<flag_type> is_even{};
+  const is_even_t<flag_type> is_even{};
 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(C2H_SEED(1), flags);

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -124,14 +124,14 @@ CUB_TEST("DeviceSelect::If does not change input", "[device][select_if]", CUB_SM
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
 
   select_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, le);
 
@@ -148,7 +148,7 @@ CUB_TEST("DeviceSelect::If is stable", "[device][select_if]", CUB_SMALL)
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -228,26 +228,26 @@ CUB_TEST("DeviceSelect::If works with user provided memory and environment", "[d
 
   SECTION("DeviceSelect::If works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_select_if(stream.get());
   }
 
   SECTION("DeviceSelect::If works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_select_if(stream);
   }
 
   SECTION("DeviceSelect::If works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_select_if(stream_ref);
   }
 
   SECTION("DeviceSelect::If works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_select_if(env);
   }
 
@@ -259,7 +259,7 @@ CUB_TEST("DeviceSelect::If works with user provided memory and environment", "[d
 
   SECTION("DeviceSelect::If works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_select_if(policy);
   }
@@ -317,26 +317,26 @@ CUB_TEST("DeviceSelect::If works in place with user provided memory and environm
 
   SECTION("DeviceSelect::If works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_select_if(stream.get());
   }
 
   SECTION("DeviceSelect::If works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_select_if(stream);
   }
 
   SECTION("DeviceSelect::If works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_select_if(stream_ref);
   }
 
   SECTION("DeviceSelect::If works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_select_if(env);
   }
 
@@ -348,7 +348,7 @@ CUB_TEST("DeviceSelect::If works in place with user provided memory and environm
 
   SECTION("DeviceSelect::If works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_select_if(policy);
   }
@@ -365,7 +365,7 @@ CUB_TEST("DeviceSelect::If works with iterators", "[device][select_if]", CUB_SMA
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -388,7 +388,7 @@ CUB_TEST("DeviceSelect::If works with pointers", "[device][select_if]", CUB_SMAL
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -411,7 +411,7 @@ CUB_TEST("DeviceSelect::If works in place", "[device][select_if]", CUB_SMALL, ty
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -458,7 +458,7 @@ CUB_TEST("DeviceSelect::If works with a different output type", "[device][select
   c2h::gen(C2H_SEED(2), in);
 
   // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -482,7 +482,7 @@ try
   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
   constexpr auto max_partition_size = static_cast<offset_t>(cuda::std::numeric_limits<std::int32_t>::max());
 
-  offset_t num_items = GENERATE_COPY(
+  const offset_t num_items = GENERATE_COPY(
     values({
       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
       offset_t{2} * max_partition_size, // 2 partitions
@@ -501,15 +501,15 @@ try
 
   // Run test
   constexpr offset_t match_every_nth = 1000000;
-  offset_t expected_num_copied       = (num_items + match_every_nth - offset_t{1}) / match_every_nth;
+  const offset_t expected_num_copied = (num_items + match_every_nth - offset_t{1}) / match_every_nth;
   c2h::device_vector<type> out(expected_num_copied);
   select_if(
     in, out.begin(), d_first_num_selected_out, num_items, mod_n<offset_t>{static_cast<offset_t>(match_every_nth)});
 
   // Ensure that we created the correct output
   REQUIRE(num_selected_out[0] == expected_num_copied);
-  auto expected_out_it     = cuda::transform_iterator(in, multiply_n<offset_t>{static_cast<offset_t>(match_every_nth)});
-  bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), expected_out_it);
+  auto expected_out_it = cuda::transform_iterator(in, multiply_n<offset_t>{static_cast<offset_t>(match_every_nth)});
+  const bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), expected_out_it);
   REQUIRE(all_results_correct == true);
 }
 catch (std::bad_alloc&)
@@ -529,7 +529,7 @@ try
   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
   constexpr auto max_partition_size = static_cast<offset_t>(cuda::std::numeric_limits<std::int32_t>::max());
 
-  offset_t num_items = GENERATE_COPY(
+  const offset_t num_items = GENERATE_COPY(
     values({
       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
       offset_t{2} * max_partition_size, // 2 partitions
@@ -559,7 +559,7 @@ try
 
   // Ensure that we created the correct output
   REQUIRE(num_selected_out[0] == num_items);
-  bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), in);
+  const bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), in);
   REQUIRE(all_results_correct == true);
 }
 catch (std::bad_alloc&)

--- a/cub/test/catch2_test_device_select_if_vsmem.cu
+++ b/cub/test/catch2_test_device_select_if_vsmem.cu
@@ -46,7 +46,7 @@ CUB_TEST("DeviceSelect::If works for large types", "[select_if][vsmem][device]",
   c2h::gen(C2H_SEED(2), in);
 
   // Just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
+  const less_than_t<type> le{in[num_items / 2]};
 
   // Run test
   c2h::device_vector<int> num_selected_out(1, 0);

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -182,7 +182,7 @@ CUB_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]"
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
   // copy input first
-  c2h::device_vector<type> reference = in;
+  const c2h::device_vector<type> reference = in;
 
   // test overload without predicate
   select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
@@ -280,26 +280,26 @@ CUB_TEST(
 
   SECTION("DeviceSelect::Unique works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique(stream.get());
   }
 
   SECTION("DeviceSelect::Unique works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique(stream);
   }
 
   SECTION("DeviceSelect::Unique works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_unique(stream_ref);
   }
 
   SECTION("DeviceSelect::Unique works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_unique(env);
   }
 
@@ -311,7 +311,7 @@ CUB_TEST(
 
   SECTION("DeviceSelect::Unique works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique(policy);
   }
@@ -521,7 +521,7 @@ try
   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
   constexpr auto max_partition_size = static_cast<offset_t>(cuda::std::numeric_limits<std::int32_t>::max());
 
-  offset_t num_items = GENERATE_COPY(
+  const offset_t num_items = GENERATE_COPY(
     values({
       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
       offset_t{2} * max_partition_size, // 2 partitions

--- a/cub/test/catch2_test_device_select_unique_by_key.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key.cu
@@ -197,8 +197,8 @@ CUB_TEST("DeviceSelect::UniqueByKey does not change input", "[device][select_uni
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  c2h::device_vector<type> reference_keys     = keys_in;
-  c2h::device_vector<val_type> reference_vals = vals_in;
+  const c2h::device_vector<type> reference_keys     = keys_in;
+  const c2h::device_vector<val_type> reference_vals = vals_in;
 
   select_unique_by_key(
     keys_in.begin(),
@@ -422,8 +422,8 @@ CUB_TEST("DeviceSelect::UniqueByKey works for very large input that need 64-bit 
   using index_type = std::int64_t;
 
   const std::size_t num_items = 4400000000ULL;
-  c2h::host_vector<type> reference_keys{static_cast<type>(0), static_cast<type>(1), static_cast<type>(0)};
-  c2h::host_vector<index_type> reference_values{0, 4300000000ULL, 4300000001ULL};
+  const c2h::host_vector<type> reference_keys{static_cast<type>(0), static_cast<type>(1), static_cast<type>(0)};
+  const c2h::host_vector<index_type> reference_values{0, 4300000000ULL, 4300000001ULL};
 
   auto keys_in   = cuda::transform_iterator(cuda::counting_iterator(0ULL), index_to_value_t<type>{});
   auto values_in = cuda::counting_iterator(0ULL);

--- a/cub/test/catch2_test_device_select_unique_by_key_env.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key_env.cu
@@ -169,26 +169,26 @@ CUB_TEST("DeviceSelect::UniqueByKey works with user provided memory and environm
 
   SECTION("DeviceSelect::UniqueByKey works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique_by_key(stream.get());
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique_by_key(stream);
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_unique_by_key(stream_ref);
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_unique_by_key(env);
   }
 
@@ -200,7 +200,7 @@ CUB_TEST("DeviceSelect::UniqueByKey works with user provided memory and environm
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique_by_key(policy);
   }
@@ -301,26 +301,26 @@ CUB_TEST("DeviceSelect::UniqueByKey works with user provided operator, memory an
 
   SECTION("DeviceSelect::UniqueByKey works with cudaStream_t")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique_by_key(stream.get());
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     test_unique_by_key(stream);
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::stream_ref")
   {
-    cuda::stream stream{cuda::devices[current_device]};
-    cuda::stream_ref stream_ref{stream};
+    const cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream_ref stream_ref{stream};
     test_unique_by_key(stream_ref);
   }
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::std::execution::env")
   {
-    cuda::std::execution::env env{};
+    const cuda::std::execution::env env{};
     test_unique_by_key(env);
   }
 
@@ -332,7 +332,7 @@ CUB_TEST("DeviceSelect::UniqueByKey works with user provided operator, memory an
 
   SECTION("DeviceSelect::UniqueByKey works with cuda::execution::gpu with stream")
   {
-    cuda::stream stream{cuda::devices[current_device]};
+    const cuda::stream stream{cuda::devices[current_device]};
     const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
     test_unique_by_key(policy);
   }

--- a/cub/test/catch2_test_device_three_way_partition.cu
+++ b/cub/test/catch2_test_device_three_way_partition.cu
@@ -91,8 +91,8 @@ CUB_TEST("Device three-way partition can handle empty problems", "[partition][de
   c2h::device_vector<type> num_selected_out{42, 42};
   type* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  less_than_t<type> le(type{0});
-  greater_or_equal_t<type> ge(type{1});
+  const less_than_t<type> le(type{0});
+  const greater_or_equal_t<type> ge(type{1});
 
   partition(in, d_first_part_out, d_second_part_out, d_unselected_out, d_num_selected_out, num_items, le, ge);
   REQUIRE(num_selected_out[0] == 0);
@@ -215,8 +215,8 @@ CUB_TEST("Device three-way partition is stable", "[partition][device]", CUB_SMAL
 
   pair_type first_val_of_second_part = cuda::std::make_pair(static_cast<type>(2 * num_items / 3), std::uint32_t{});
 
-  less_than_t<pair_type> le(first_unselected_val);
-  greater_or_equal_t<pair_type> ge(first_val_of_second_part);
+  const less_than_t<pair_type> le(first_unselected_val);
+  const greater_or_equal_t<pair_type> ge(first_val_of_second_part);
 
   auto cub_result    = cub_partition(le, ge, in);
   auto thrust_result = thrust_partition(le, ge, in);
@@ -232,11 +232,11 @@ CUB_TEST("Device three-way partition handles empty first part", "[partition][dev
   c2h::device_vector<type> in(num_items);
   thrust::sequence(c2h::device_policy, in.begin(), in.end());
 
-  type first_unselected_val     = type{0};
-  type first_val_of_second_part = static_cast<type>(num_items / 2);
+  const type first_unselected_val     = type{0};
+  const type first_val_of_second_part = static_cast<type>(num_items / 2);
 
-  less_than_t<type> le(first_unselected_val);
-  greater_or_equal_t<type> ge(first_val_of_second_part);
+  const less_than_t<type> le(first_unselected_val);
+  const greater_or_equal_t<type> ge(first_val_of_second_part);
 
   auto cub_result    = cub_partition(le, ge, in);
   auto thrust_result = thrust_partition(le, ge, in);
@@ -253,11 +253,11 @@ CUB_TEST("Device three-way partition handles empty second part", "[partition][de
   c2h::device_vector<type> in(num_items);
   thrust::sequence(c2h::device_policy, in.begin(), in.end());
 
-  type first_unselected_val     = static_cast<type>(num_items / 2);
-  type first_val_of_second_part = type{0}; // empty set for unsigned types
+  const type first_unselected_val     = static_cast<type>(num_items / 2);
+  const type first_val_of_second_part = type{0}; // empty set for unsigned types
 
-  less_than_t<type> le(first_unselected_val);
-  greater_or_equal_t<type> ge(first_val_of_second_part);
+  const less_than_t<type> le(first_unselected_val);
+  const greater_or_equal_t<type> ge(first_val_of_second_part);
 
   auto cub_result    = cub_partition(ge, le, in);
   auto thrust_result = thrust_partition(ge, le, in);
@@ -274,10 +274,10 @@ CUB_TEST("Device three-way partition handles empty unselected part", "[partition
   c2h::device_vector<type> in(num_items);
   thrust::sequence(c2h::device_policy, in.begin(), in.end());
 
-  type first_unselected_val = static_cast<type>(num_items / 2);
+  const type first_unselected_val = static_cast<type>(num_items / 2);
 
-  less_than_t<type> le(first_unselected_val);
-  greater_or_equal_t<type> ge(first_unselected_val);
+  const less_than_t<type> le(first_unselected_val);
+  const greater_or_equal_t<type> ge(first_unselected_val);
 
   auto cub_result    = cub_partition(le, ge, in);
   auto thrust_result = thrust_partition(le, ge, in);
@@ -294,9 +294,9 @@ CUB_TEST("Device three-way partition handles only unselected items", "[partition
   c2h::device_vector<type> in(num_items);
   thrust::sequence(c2h::device_policy, in.begin(), in.end());
 
-  type first_unselected_val = type{0};
+  const type first_unselected_val = type{0};
 
-  less_than_t<type> le(first_unselected_val);
+  const less_than_t<type> le(first_unselected_val);
 
   auto cub_result    = cub_partition(le, le, in);
   auto thrust_result = thrust_partition(le, le, in);
@@ -315,9 +315,9 @@ CUB_TEST("Device three-way partition handles reverse iterator", "[partition][dev
   const int num_items_in_first_part = num_items / 3;
   const int num_unselected_items    = 2 * num_items / 3;
 
-  type first_part_val{0};
-  type second_part_val{1};
-  type unselected_part_val{2};
+  const type first_part_val{0};
+  const type second_part_val{1};
+  const type unselected_part_val{2};
 
   c2h::device_vector<type> in(num_items, second_part_val);
   thrust::fill_n(c2h::device_policy, in.begin(), num_items_in_first_part, first_part_val);
@@ -327,8 +327,8 @@ CUB_TEST("Device three-way partition handles reverse iterator", "[partition][dev
 
   c2h::device_vector<type> first_and_unselected_part(num_items);
 
-  cuda::equal_to_value<type> first_selector{first_part_val};
-  cuda::equal_to_value<type> second_selector{second_part_val};
+  const cuda::equal_to_value<type> first_selector{first_part_val};
+  const cuda::equal_to_value<type> second_selector{second_part_val};
 
   c2h::device_vector<int> num_selected_out(2);
 
@@ -367,14 +367,14 @@ CUB_TEST("Device three-way partition handles single output", "[partition][device
 {
   using type = typename c2h::get<0, TestType>;
 
-  const int num_items          = GENERATE_COPY(take(10, random(1, 1000000)));
-  int num_items_in_first_part  = num_items / 3;
-  int num_unselected_items     = 2 * num_items / 3;
-  int num_items_in_second_part = num_items - num_items_in_first_part - num_unselected_items;
+  const int num_items                = GENERATE_COPY(take(10, random(1, 1000000)));
+  const int num_items_in_first_part  = num_items / 3;
+  const int num_unselected_items     = 2 * num_items / 3;
+  const int num_items_in_second_part = num_items - num_items_in_first_part - num_unselected_items;
 
-  type first_part_val{0};
-  type second_part_val{1};
-  type unselected_part_val{2};
+  const type first_part_val{0};
+  const type second_part_val{1};
+  const type unselected_part_val{2};
 
   c2h::device_vector<type> in(num_items, second_part_val);
   thrust::fill_n(c2h::device_policy, in.begin(), num_items_in_first_part, first_part_val);
@@ -384,8 +384,8 @@ CUB_TEST("Device three-way partition handles single output", "[partition][device
 
   c2h::device_vector<type> output(num_items);
 
-  cuda::equal_to_value<type> first_selector{first_part_val};
-  cuda::equal_to_value<type> second_selector{second_part_val};
+  const cuda::equal_to_value<type> first_selector{first_part_val};
+  const cuda::equal_to_value<type> second_selector{second_part_val};
 
   c2h::device_vector<int> num_selected_out(2);
 
@@ -440,9 +440,9 @@ try
   auto first_selector  = mod_equal_to<offset_t>{3, 0};
   auto second_selector = mod_equal_to<offset_t>{3, 1};
 
-  offset_t expected_first  = num_items / offset_t{3} + (num_items % offset_t{3} >= 1);
-  offset_t expected_second = num_items / offset_t{3} + (num_items % offset_t{3} >= 2);
-  offset_t expected_third  = num_items / offset_t{3};
+  const offset_t expected_first  = num_items / offset_t{3} + (num_items % offset_t{3} >= 1);
+  const offset_t expected_second = num_items / offset_t{3} + (num_items % offset_t{3} >= 2);
+  const offset_t expected_third  = num_items / offset_t{3};
 
   auto expected_first_it  = cuda::transform_iterator(in, multiply_and_add<offset_t>{3, 0});
   auto expected_second_it = cuda::transform_iterator(in, multiply_and_add<offset_t>{3, 1});

--- a/cub/test/catch2_test_device_topk_api.cu
+++ b/cub/test/catch2_test_device_topk_api.cu
@@ -32,7 +32,7 @@ CUB_TEST("DeviceTopK::MinKeys API example for non-deterministic, unsorted result
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   cudaStreamCreate(&stream);
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};
@@ -55,7 +55,7 @@ CUB_TEST("DeviceTopK::MinKeys API example for non-deterministic, unsorted result
 
   // Get the top-k results into sorted order for easy comparison
   thrust::sort(output.begin(), output.end());
-  thrust::host_vector<int> expected{-3, 1, 2, 4};
+  const thrust::host_vector<int> expected{-3, 1, 2, 4};
   // example-end topk-min-keys-non-deterministic-unsorted
 
   REQUIRE(output == expected);
@@ -77,7 +77,7 @@ CUB_TEST("DeviceTopK::MaxKeys API example for non-deterministic, unsorted result
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   cudaStreamCreate(&stream);
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};
@@ -100,7 +100,7 @@ CUB_TEST("DeviceTopK::MaxKeys API example for non-deterministic, unsorted result
 
   // Get the top-k results into sorted order for easy comparison
   thrust::sort(output.begin(), output.end(), cuda::std::greater{});
-  thrust::host_vector<int> expected{8, 7, 6, 5};
+  const thrust::host_vector<int> expected{8, 7, 6, 5};
   // example-end topk-max-keys-non-deterministic-unsorted
 
   REQUIRE(output == expected);
@@ -124,7 +124,7 @@ CUB_TEST("DeviceTopK::MinPairs API example for non-deterministic, unsorted resul
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   cudaStreamCreate(&stream);
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};
@@ -150,8 +150,8 @@ CUB_TEST("DeviceTopK::MinPairs API example for non-deterministic, unsorted resul
 
   // Get the top-k results into sorted order for easy comparison
   thrust::sort_by_key(keys_out.begin(), keys_out.end(), values_out.begin());
-  thrust::host_vector<int> expected_keys{-3, 1, 2, 4};
-  thrust::host_vector<int> expected_values{1, 2, 5, 6};
+  const thrust::host_vector<int> expected_keys{-3, 1, 2, 4};
+  const thrust::host_vector<int> expected_values{1, 2, 5, 6};
   // example-end topk-min-pairs-non-deterministic-unsorted
 
   REQUIRE(keys_out == expected_keys);
@@ -176,7 +176,7 @@ CUB_TEST("DeviceTopK::MaxPairs API example for non-deterministic, unsorted resul
   // Prepare CUDA stream
   cudaStream_t stream = nullptr;
   cudaStreamCreate(&stream);
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream_ref stream_ref{stream};
 
   // Create the environment with the stream and requirements
   auto env = cuda::std::execution::env{stream_ref, requirements};
@@ -202,8 +202,8 @@ CUB_TEST("DeviceTopK::MaxPairs API example for non-deterministic, unsorted resul
 
   // Get the top-k results into sorted order for easy comparison
   thrust::sort_by_key(keys_out.begin(), keys_out.end(), values_out.begin(), cuda::std::greater<>{});
-  thrust::host_vector<int> expected_keys{8, 7, 6, 5};
-  thrust::host_vector<int> expected_values{4, 3, 7, 0};
+  const thrust::host_vector<int> expected_keys{8, 7, 6, 5};
+  const thrust::host_vector<int> expected_values{4, 3, 7, 0};
   // example-end topk-max-pairs-non-deterministic-unsorted
 
   REQUIRE(keys_out == expected_keys);
@@ -296,7 +296,7 @@ CUB_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]", 
 
     // Sort output for comparison (output order is not guaranteed)
     thrust::sort(out.begin(), out.end(), cuda::std::greater<>{});
-    thrust::device_vector<custom_t> expected = {
+    const thrust::device_vector<custom_t> expected = {
       {+3.7f, 5}, //
       {+2.5f, 4}, //
       {+1.1f, 3} //
@@ -343,7 +343,7 @@ CUB_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]", 
 
     // Sort output for comparison (output order is not guaranteed)
     thrust::sort(out.begin(), out.end());
-    thrust::device_vector<custom_t> expected = {
+    const thrust::device_vector<custom_t> expected = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2} //
@@ -415,13 +415,13 @@ CUB_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]", 
     // Sort by key for comparison (output order is not guaranteed)
     thrust::sort_by_key(keys_out.begin(), keys_out.end(), vals_out.begin(), cuda::std::greater<>{});
 
-    thrust::device_vector<custom_t> expected_keys = {
+    const thrust::device_vector<custom_t> expected_keys = {
       {+3.7f, 5}, //
       {+2.5f, 4}, //
       {+1.1f, 3} //
     };
 
-    thrust::device_vector<int> expected_vals = {5, 0, 2};
+    const thrust::device_vector<int> expected_vals = {5, 0, 2};
     // example-end topk-max-pairs-custom-type
 
     REQUIRE(expected_keys == keys_out);
@@ -490,13 +490,13 @@ CUB_TEST("DeviceTopK works with custom types and decomposer", "[device][topk]", 
     // Sort by key for comparison (output order is not guaranteed)
     thrust::sort_by_key(keys_out.begin(), keys_out.end(), vals_out.begin());
 
-    thrust::device_vector<custom_t> expected_keys = {
+    const thrust::device_vector<custom_t> expected_keys = {
       {-2.5f, 0}, //
       {+0.0f, 1}, //
       {-0.0f, 2} //
     };
 
-    thrust::device_vector<int> expected_vals = {1, 3, 4};
+    const thrust::device_vector<int> expected_vals = {1, 3, 4};
     // example-end topk-min-pairs-custom-type
 
     REQUIRE(expected_keys == keys_out);

--- a/cub/test/catch2_test_device_topk_env.cu
+++ b/cub/test/catch2_test_device_topk_env.cu
@@ -60,7 +60,7 @@ CUB_TEST("DeviceTopK::MaxKeys can be tuned", "[topk][device]", CUB_SMALL, block_
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
 
-  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   c2h::device_vector<int> d_keys_out(3);
 
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
@@ -89,7 +89,7 @@ CUB_TEST("DeviceTopK::MinKeys can be tuned", "[topk][device]", CUB_SMALL, block_
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
 
-  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   c2h::device_vector<int> d_keys_out(3);
 
   auto env = stdexec::env{topk_requirements(), cuda::execution::tune(topk_tuning<target_block_size>{})};
@@ -118,7 +118,7 @@ CUB_TEST("DeviceTopK::MaxPairs can be tuned", "[topk][device]", CUB_SMALL, block
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
 
-  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   auto values_in = cuda::make_counting_iterator<int>(0);
   c2h::device_vector<int> d_keys_out(3);
   c2h::device_vector<int> d_values_out(3);
@@ -151,7 +151,7 @@ CUB_TEST("DeviceTopK::MinPairs can be tuned", "[topk][device]", CUB_SMALL, block
   constexpr unsigned int target_block_size = c2h::get<0, TestType>::value;
   c2h::device_vector<unsigned int> d_block_size{0};
 
-  block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
+  const block_size_extracting_constant_iterator input(42, thrust::raw_pointer_cast(d_block_size.data()));
   auto values_in = cuda::make_counting_iterator<int>(0);
   c2h::device_vector<int> d_keys_out(3);
   c2h::device_vector<int> d_values_out(3);
@@ -211,8 +211,8 @@ CUB_TEST("DeviceTopK::MaxKeys env-alloc returns correct top K", "[topk][env]", C
   const int num_items = 256;
   c2h::device_vector<int> d_in(num_items);
   c2h::gen(C2H_SEED(1), d_in);
-  c2h::host_vector<int> h_in      = d_in;
-  c2h::device_vector<int> d_out_k = c2h::device_vector<int>(8);
+  const c2h::host_vector<int> h_in = d_in;
+  c2h::device_vector<int> d_out_k  = c2h::device_vector<int>(8);
 
   auto env = topk_requirements();
   REQUIRE(cudaSuccess == cub::DeviceTopK::MaxKeys(d_in.begin(), d_out_k.begin(), num_items, 8, env));
@@ -229,8 +229,8 @@ CUB_TEST("DeviceTopK::MinKeys env-alloc returns correct bottom K", "[topk][env]"
   const int num_items = 256;
   c2h::device_vector<int> d_in(num_items);
   c2h::gen(C2H_SEED(1), d_in);
-  c2h::host_vector<int> h_in      = d_in;
-  c2h::device_vector<int> d_out_k = c2h::device_vector<int>(8);
+  const c2h::host_vector<int> h_in = d_in;
+  c2h::device_vector<int> d_out_k  = c2h::device_vector<int>(8);
 
   auto env = topk_requirements();
   REQUIRE(cudaSuccess == cub::DeviceTopK::MinKeys(d_in.begin(), d_out_k.begin(), num_items, 8, env));
@@ -322,7 +322,7 @@ CUB_TEST("DeviceTopK::MaxKeys env-alloc handles K equal to num_items", "[topk][e
 
   c2h::host_vector<int> h_out = d_out;
   std::sort(h_out.begin(), h_out.end(), cuda::std::greater<int>{});
-  c2h::host_vector<int> expected{9, 7, 5, 2, 1};
+  const c2h::host_vector<int> expected{9, 7, 5, 2, 1};
   REQUIRE(h_out == expected);
 }
 

--- a/cub/test/catch2_test_device_topk_env_api.cu
+++ b/cub/test/catch2_test_device_topk_env_api.cu
@@ -45,12 +45,12 @@ struct topk_custom_decomposer_t
 CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-keys-env
-  auto d_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
-  auto d_out = thrust::device_vector<int>(3);
-  int k      = 3;
+  auto d_in   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
+  auto d_out  = thrust::device_vector<int>(3);
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -61,7 +61,7 @@ CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]",
   {
     std::cerr << "cub::DeviceTopK::MaxKeys failed with status: " << error << '\n';
   }
-  thrust::device_vector<int> expected{9, 8, 7}; // possibly in different order
+  const thrust::device_vector<int> expected{9, 8, 7}; // possibly in different order
   // example-end topk-max-keys-env
 
   stream.sync();
@@ -75,12 +75,12 @@ CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]",
 CUB_TEST("cub::DeviceTopK::MinKeys env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-keys-env
-  auto d_in  = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
-  auto d_out = thrust::device_vector<int>(3);
-  int k      = 3;
+  auto d_in   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
+  auto d_out  = thrust::device_vector<int>(3);
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -91,7 +91,7 @@ CUB_TEST("cub::DeviceTopK::MinKeys env-alloc accepts stream_ref", "[topk][env]",
   {
     std::cerr << "cub::DeviceTopK::MinKeys failed with status: " << error << '\n';
   }
-  thrust::device_vector<int> expected{0, 1, 2}; // possibly in different order
+  const thrust::device_vector<int> expected{0, 1, 2}; // possibly in different order
   // example-end topk-min-keys-env
 
   stream.sync();
@@ -108,10 +108,10 @@ CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc accepts stream_ref", "[topk][env]"
   auto d_values_in  = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto d_keys_out   = thrust::device_vector<int>(3);
   auto d_values_out = thrust::device_vector<int>(3);
-  int k             = 3;
+  const int k       = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -129,7 +129,7 @@ CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc accepts stream_ref", "[topk][env]"
   {
     std::cerr << "cub::DeviceTopK::MaxPairs failed with status: " << error << '\n';
   }
-  thrust::device_vector<int> expected_keys{9, 8, 7}; // possibly in different order
+  const thrust::device_vector<int> expected_keys{9, 8, 7}; // possibly in different order
   // example-end topk-max-pairs-env
 
   stream.sync();
@@ -146,10 +146,10 @@ CUB_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]"
   auto d_values_in  = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto d_keys_out   = thrust::device_vector<int>(3);
   auto d_values_out = thrust::device_vector<int>(3);
-  int k             = 3;
+  const int k       = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -167,7 +167,7 @@ CUB_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]"
   {
     std::cerr << "cub::DeviceTopK::MinPairs failed with status: " << error << '\n';
   }
-  thrust::device_vector<int> expected_keys{0, 1, 2}; // possibly in different order
+  const thrust::device_vector<int> expected_keys{0, 1, 2}; // possibly in different order
   // example-end topk-min-pairs-env
 
   stream.sync();
@@ -180,14 +180,14 @@ CUB_TEST("cub::DeviceTopK::MinPairs env-alloc accepts stream_ref", "[topk][env]"
 CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-keys-decomposer-env
-  thrust::host_vector<topk_custom_t> h_in{
+  const thrust::host_vector<topk_custom_t> h_in{
     {8, 0}, {6, 1}, {7, 2}, {5, 3}, {3, 4}, {0, 5}, {9, 6}, {1, 7}, {4, 8}, {2, 9}};
   thrust::device_vector<topk_custom_t> d_in = h_in;
   thrust::device_vector<topk_custom_t> d_out(3);
-  int k = 3;
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -199,7 +199,7 @@ CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref"
   {
     std::cerr << "cub::DeviceTopK::MaxKeys failed with status: " << error << '\n';
   }
-  thrust::host_vector<int> expected_ranks{9, 8, 7}; // possibly in different order
+  const thrust::host_vector<int> expected_ranks{9, 8, 7}; // possibly in different order
   // example-end topk-max-keys-decomposer-env
 
   stream.sync();
@@ -209,21 +209,21 @@ CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc with decomposer accepts stream_ref"
   std::sort(h_out.begin(), h_out.end(), [](const topk_custom_t& a, const topk_custom_t& b) {
     return a.rank > b.rank;
   });
-  thrust::host_vector<int> actual_ranks{h_out[0].rank, h_out[1].rank, h_out[2].rank};
+  const thrust::host_vector<int> actual_ranks{h_out[0].rank, h_out[1].rank, h_out[2].rank};
   REQUIRE(actual_ranks == expected_ranks);
 }
 
 CUB_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-keys-decomposer-env
-  thrust::host_vector<topk_custom_t> h_in{
+  const thrust::host_vector<topk_custom_t> h_in{
     {8, 0}, {6, 1}, {7, 2}, {5, 3}, {3, 4}, {0, 5}, {9, 6}, {1, 7}, {4, 8}, {2, 9}};
   thrust::device_vector<topk_custom_t> d_in = h_in;
   thrust::device_vector<topk_custom_t> d_out(3);
-  int k = 3;
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -235,7 +235,7 @@ CUB_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref"
   {
     std::cerr << "cub::DeviceTopK::MinKeys failed with status: " << error << '\n';
   }
-  thrust::host_vector<int> expected_ranks{0, 1, 2}; // possibly in different order
+  const thrust::host_vector<int> expected_ranks{0, 1, 2}; // possibly in different order
   // example-end topk-min-keys-decomposer-env
 
   stream.sync();
@@ -245,23 +245,23 @@ CUB_TEST("cub::DeviceTopK::MinKeys env-alloc with decomposer accepts stream_ref"
   std::sort(h_out.begin(), h_out.end(), [](const topk_custom_t& a, const topk_custom_t& b) {
     return a.rank < b.rank;
   });
-  thrust::host_vector<int> actual_ranks{h_out[0].rank, h_out[1].rank, h_out[2].rank};
+  const thrust::host_vector<int> actual_ranks{h_out[0].rank, h_out[1].rank, h_out[2].rank};
   REQUIRE(actual_ranks == expected_ranks);
 }
 
 CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-pairs-decomposer-env
-  thrust::host_vector<topk_custom_t> h_keys_in{
+  const thrust::host_vector<topk_custom_t> h_keys_in{
     {8, 0}, {6, 1}, {7, 2}, {5, 3}, {3, 4}, {0, 5}, {9, 6}, {1, 7}, {4, 8}, {2, 9}};
   thrust::device_vector<topk_custom_t> d_keys_in = h_keys_in;
   thrust::device_vector<int> d_values_in{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   thrust::device_vector<topk_custom_t> d_keys_out(3);
   thrust::device_vector<int> d_values_out(3);
-  int k = 3;
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -280,7 +280,7 @@ CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref
   {
     std::cerr << "cub::DeviceTopK::MaxPairs failed with status: " << error << '\n';
   }
-  thrust::host_vector<int> expected_ranks{9, 8, 7}; // possibly in different order
+  const thrust::host_vector<int> expected_ranks{9, 8, 7}; // possibly in different order
   // example-end topk-max-pairs-decomposer-env
 
   stream.sync();
@@ -290,23 +290,23 @@ CUB_TEST("cub::DeviceTopK::MaxPairs env-alloc with decomposer accepts stream_ref
   std::sort(h_keys_out.begin(), h_keys_out.end(), [](const topk_custom_t& a, const topk_custom_t& b) {
     return a.rank > b.rank;
   });
-  thrust::host_vector<int> actual_ranks{h_keys_out[0].rank, h_keys_out[1].rank, h_keys_out[2].rank};
+  const thrust::host_vector<int> actual_ranks{h_keys_out[0].rank, h_keys_out[1].rank, h_keys_out[2].rank};
   REQUIRE(actual_ranks == expected_ranks);
 }
 
 CUB_TEST("cub::DeviceTopK::MinPairs env-alloc with decomposer accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-min-pairs-decomposer-env
-  thrust::host_vector<topk_custom_t> h_keys_in{
+  const thrust::host_vector<topk_custom_t> h_keys_in{
     {8, 0}, {6, 1}, {7, 2}, {5, 3}, {3, 4}, {0, 5}, {9, 6}, {1, 7}, {4, 8}, {2, 9}};
   thrust::device_vector<topk_custom_t> d_keys_in = h_keys_in;
   thrust::device_vector<int> d_values_in{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   thrust::device_vector<topk_custom_t> d_keys_out(3);
   thrust::device_vector<int> d_values_out(3);
-  int k = 3;
+  const int k = 3;
 
-  cuda::stream stream{cuda::devices[0]};
-  cuda::stream_ref stream_ref{stream};
+  const cuda::stream stream{cuda::devices[0]};
+  const cuda::stream_ref stream_ref{stream};
   auto env = cuda::std::execution::env{
     cuda::execution::require(cuda::execution::determinism::not_guaranteed, //
                              cuda::execution::output_ordering::unsorted),
@@ -325,7 +325,7 @@ CUB_TEST("cub::DeviceTopK::MinPairs env-alloc with decomposer accepts stream_ref
   {
     std::cerr << "cub::DeviceTopK::MinPairs failed with status: " << error << '\n';
   }
-  thrust::host_vector<int> expected_ranks{0, 1, 2}; // possibly in different order
+  const thrust::host_vector<int> expected_ranks{0, 1, 2}; // possibly in different order
   // example-end topk-min-pairs-decomposer-env
 
   stream.sync();
@@ -335,6 +335,6 @@ CUB_TEST("cub::DeviceTopK::MinPairs env-alloc with decomposer accepts stream_ref
   std::sort(h_keys_out.begin(), h_keys_out.end(), [](const topk_custom_t& a, const topk_custom_t& b) {
     return a.rank < b.rank;
   });
-  thrust::host_vector<int> actual_ranks{h_keys_out[0].rank, h_keys_out[1].rank, h_keys_out[2].rank};
+  const thrust::host_vector<int> actual_ranks{h_keys_out[0].rank, h_keys_out[1].rank, h_keys_out[2].rank};
   REQUIRE(actual_ranks == expected_ranks);
 }

--- a/cub/test/catch2_test_device_topk_env_api.cu
+++ b/cub/test/catch2_test_device_topk_env_api.cu
@@ -32,11 +32,11 @@ struct topk_custom_t
 
 struct topk_custom_decomposer_t
 {
-  __host__ __device__ ::cuda::std::tuple<int&> operator()(topk_custom_t& key) const
+  __host__ __device__::cuda::std::tuple<int&> operator()(topk_custom_t& key) const
   {
     return {key.rank};
   }
-  __host__ __device__ ::cuda::std::tuple<const int&> operator()(const topk_custom_t& key) const
+  __host__ __device__::cuda::std::tuple<const int&> operator()(const topk_custom_t& key) const
   {
     return {key.rank};
   }
@@ -45,9 +45,9 @@ struct topk_custom_decomposer_t
 CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]", CUB_SMALL)
 {
   // example-begin topk-max-keys-env
-  auto d_in   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
-  auto d_out  = thrust::device_vector<int>(3);
-  const int k = 3;
+  const auto d_in = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9, 1, 4, 2};
+  auto d_out      = thrust::device_vector<int>(3);
+  const int k     = 3;
 
   const cuda::stream stream{cuda::devices[0]};
   const cuda::stream_ref stream_ref{stream};
@@ -56,7 +56,7 @@ CUB_TEST("cub::DeviceTopK::MaxKeys env-alloc accepts stream_ref", "[topk][env]",
                              cuda::execution::output_ordering::unsorted),
     stream_ref};
 
-  auto error = cub::DeviceTopK::MaxKeys(d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), k, env);
+  const auto error = cub::DeviceTopK::MaxKeys(d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), k, env);
   if (error != cudaSuccess)
   {
     std::cerr << "cub::DeviceTopK::MaxKeys failed with status: " << error << '\n';

--- a/cub/test/catch2_test_device_topk_pairs.cu
+++ b/cub/test/catch2_test_device_topk_pairs.cu
@@ -257,7 +257,7 @@ CUB_TEST("DeviceTopK::MaxPairs: Test for large num_items", "[pairs][topk][device
   // Verify results
   auto keys_expected_it   = cuda::std::make_reverse_iterator(keys_in + num_items);
   auto values_expected_it = cuda::std::make_reverse_iterator(values_in + num_items);
-  bool res                = check_results(
+  const bool res          = check_results(
     keys_expected_it, values_expected_it, keys_out, values_out, num_items, static_cast<num_items_t>(k), comparator_t{});
   REQUIRE(res == true);
 }

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -282,7 +282,7 @@ CUB_TEST("DeviceTransform::Transform non-default constructible types", "[device]
 
   transform_many(cuda::std::make_tuple(input.begin()), result.begin(), num_items, cuda::std::identity{});
 
-  c2h::host_vector<type> reference_h(num_items, non_default_constructible{42});
+  const c2h::host_vector<type> reference_h(num_items, non_default_constructible{42});
   REQUIRE(c2h::host_vector<type>(result) == reference_h);
 }
 
@@ -383,7 +383,7 @@ CUB_TEST("DeviceTransform::Generate", "[device][transform]", CUB_SMALL)
   generate(result.begin(), num_items, give_me_five{});
 
   // compute reference and verify
-  c2h::device_vector<int> reference(num_items, 5);
+  const c2h::device_vector<int> reference(num_items, 5);
   REQUIRE(reference == result);
 }
 
@@ -394,7 +394,7 @@ CUB_TEST("DeviceTransform::Fill", "[device][transform]", CUB_SMALL)
   fill(result.begin(), num_items, 5);
 
   // compute reference and verify
-  c2h::device_vector<int> reference(num_items, 5);
+  const c2h::device_vector<int> reference(num_items, 5);
   REQUIRE(reference == result);
 }
 
@@ -402,8 +402,8 @@ CUB_TEST("DeviceTransform::Transform fancy input iterator types", "[device][tran
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
-  cuda::counting_iterator<type> a{0};
-  cuda::counting_iterator<type> b{10};
+  const cuda::counting_iterator<type> a{0};
+  const cuda::counting_iterator<type> b{10};
 
   c2h::device_vector<type> result(num_items, thrust::no_init);
   transform_many(cuda::std::make_tuple(a, b), result.begin(), num_items, cuda::std::plus<type>{});
@@ -456,7 +456,7 @@ CUB_TEST("DeviceTransform::Transform mixed iterator types 2 -> 3", "[device][tra
 {
   using type          = unsigned; // overflow is defined
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
-  cuda::counting_iterator<type> a{0};
+  const cuda::counting_iterator<type> a{0};
   c2h::device_vector<type> b(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(1), b);
 
@@ -654,7 +654,7 @@ CUB_TEST("DeviceTransform::Transform vectorized output bug", "[device][transform
 {
   using thrust::placeholders::_1;
 
-  int num_items = std::numeric_limits<std::uint16_t>::max() - 1;
+  const int num_items = std::numeric_limits<std::uint16_t>::max() - 1;
   c2h::device_vector<std::uint16_t> input(num_items);
   c2h::device_vector<std::uint16_t> output(num_items);
   thrust::sequence(input.begin(), input.end());
@@ -722,7 +722,7 @@ CUB_TEST("DeviceTransform::Transform function/output_iter return type not conver
   auto out_it = cuda::transform_output_iterator(output.begin(), BtoC{});
   transform_many(input.begin(), out_it, num_items, AtoB{});
 
-  c2h::device_vector<C> reference(num_items, C{-43});
+  const c2h::device_vector<C> reference(num_items, C{-43});
   CHECK(output == reference);
 }
 

--- a/cub/test/catch2_test_device_transform_api.cu
+++ b/cub/test/catch2_test_device_transform_api.cu
@@ -179,7 +179,7 @@ CUB_TEST("DeviceTransform::Transform legacy size-query is unambiguous", "[device
   size_t temp_storage_bytes = 0;
   int* d_in                 = nullptr;
   int* d_out                = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess
           == cub::DeviceTransform::Transform(d_temp_storage, temp_storage_bytes, d_in, d_out, n, transform_noop_t{}));
@@ -190,7 +190,7 @@ CUB_TEST("DeviceTransform::Generate legacy size-query is unambiguous", "[device_
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   int* d_out                = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(
     cudaSuccess == cub::DeviceTransform::Generate(d_temp_storage, temp_storage_bytes, d_out, n, generate_zero_t{}));
@@ -201,8 +201,8 @@ CUB_TEST("DeviceTransform::Fill legacy size-query is unambiguous", "[device_tran
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   int* d_out                = nullptr;
-  int n                     = 0;
-  int value                 = 0;
+  const int n               = 0;
+  const int value           = 0;
 
   REQUIRE(cudaSuccess == cub::DeviceTransform::Fill(d_temp_storage, temp_storage_bytes, d_out, n, value));
 }
@@ -213,7 +213,7 @@ CUB_TEST("DeviceTransform::TransformIf legacy size-query is unambiguous", "[devi
   size_t temp_storage_bytes = 0;
   int* d_in                 = nullptr;
   int* d_out                = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess
           == cub::DeviceTransform::TransformIf(
@@ -228,7 +228,7 @@ CUB_TEST("DeviceTransform::TransformStableArgumentAddresses legacy size-query is
   size_t temp_storage_bytes = 0;
   int* d_in                 = nullptr;
   int* d_out                = nullptr;
-  int n                     = 0;
+  const int n               = 0;
 
   REQUIRE(cudaSuccess
           == cub::DeviceTransform::TransformStableArgumentAddresses(

--- a/cub/test/catch2_test_device_transform_env.cu
+++ b/cub/test/catch2_test_device_transform_env.cu
@@ -67,7 +67,7 @@ template <typename F>
 void check_graph_nodes_with_different_streams(F call_cub_api)
 {
   // create stream and begin capture
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   // REQUIRE(cudaStreamCreate(&stream) == cudaSuccess);
   REQUIRE(cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal) == cudaSuccess);
 
@@ -135,8 +135,8 @@ CUB_TEST("DeviceTransform::Transform custom stream", "[device][transform]", CUB_
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
-  cuda::constant_iterator<type> a{13};
-  cuda::counting_iterator<type> b{42};
+  const cuda::constant_iterator<type> a{13};
+  const cuda::counting_iterator<type> b{42};
   c2h::device_vector<type> result(num_items, thrust::no_init);
 
   check_graph_nodes_with_different_streams([&](auto streamish) {
@@ -203,8 +203,8 @@ CUB_TEST("DeviceTransform::TransformIf custom stream", "[device][transform]", CU
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
-  cuda::constant_iterator<type> a{13};
-  cuda::counting_iterator<type> b{42};
+  const cuda::constant_iterator<type> a{13};
+  const cuda::counting_iterator<type> b{42};
   c2h::device_vector<type> result(num_items, 1337);
 
   check_graph_nodes_with_different_streams([&](auto streamish) {
@@ -235,8 +235,8 @@ CUB_TEST("DeviceTransform::TransformStableArgumentAddresses custom stream", "[de
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
-  cuda::constant_iterator<type> a{13};
-  cuda::counting_iterator<type> b{42};
+  const cuda::constant_iterator<type> a{13};
+  const cuda::counting_iterator<type> b{42};
   c2h::device_vector<type> result(num_items, thrust::no_init);
 
   check_graph_nodes_with_different_streams([&](auto streamish) {
@@ -276,7 +276,7 @@ CUB_TEST("DeviceTransform::Transform can be tuned", "[reduce][device]", CUB_SMAL
           == cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
+  const c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
   REQUIRE(result == expected);
 }
 
@@ -284,13 +284,13 @@ CUB_TEST("DeviceTransform::Transform can be tuned with custom stream", "[reduce]
 {
   c2h::device_vector<unsigned> result(3 * 8, thrust::no_init);
 
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   auto env = cuda::std::execution::env{cuda::stream_ref{stream}, cuda::execution::tune(my_policy_selector{})};
   REQUIRE(cudaSuccess
           == cub::DeviceTransform::Transform(cuda::std::tuple{}, result.data(), result.size(), get_thread_id{}, env));
   stream.sync();
 
-  c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
+  const c2h::device_vector<unsigned> expected{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
   REQUIRE(result == expected);
 }
 

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -41,7 +41,7 @@ CUB_TEST("Device transform reduce works with pointers", "[reduce][device]", CUB_
 
   const int num_items = GENERATE_COPY(take(3, random(min_items, max_items)));
 
-  item_t init{42};
+  const item_t init{42};
   c2h::device_vector<item_t> out(1);
   c2h::device_vector<item_t> in(num_items + 1);
   c2h::gen(C2H_SEED(2), in);

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -123,7 +123,7 @@ struct stream_registry_factory_t
   CUB_RUNTIME_FUNCTION cudaError_t MultiProcessorCount(int& sm_count) const
   {
     int device_ordinal;
-    cudaError_t error = cudaGetDevice(&device_ordinal);
+    const cudaError_t error = cudaGetDevice(&device_ordinal);
     if (cudaSuccess != error)
     {
       return error;
@@ -155,7 +155,7 @@ struct stream_registry_factory_t
   CUB_RUNTIME_FUNCTION cudaError_t MaxGridDimX(int& max_grid_dim_x) const
   {
     int device_ordinal;
-    cudaError_t error = cudaGetDevice(&device_ordinal);
+    const cudaError_t error = cudaGetDevice(&device_ordinal);
     if (cudaSuccess != error)
     {
       return error;
@@ -289,7 +289,7 @@ void launch(ActionT action, Args... args)
   using tpl_t = cuda::std::tuple<Args...>;
   using env_t = cuda::std::tuple_element_t<env_idx, tpl_t>;
   tpl_t tuple(args...);
-  env_t env = cuda::std::get<env_idx>(tuple);
+  const env_t env = cuda::std::get<env_idx>(tuple);
 
   // Environment-based API should use default stream if not specified in the environment
   cudaStream_t stream{nullptr};
@@ -326,8 +326,8 @@ void launch(ActionT action, Args... args)
   cuda::std::apply(
     [stream, action](auto... args) {
       // Make sure specified stream is used
-      stream_scope scope(stream);
-      cudaError_t error = action(args...);
+      const stream_scope scope(stream);
+      const cudaError_t error = action(args...);
       REQUIRE(cudaSuccess == error);
     },
     fixed_args);
@@ -392,7 +392,7 @@ void launch(ActionT action, Args... args)
   using tpl_t = cuda::std::tuple<Args...>;
   using env_t = cuda::std::tuple_element_t<env_idx, tpl_t>;
   tpl_t tuple(args...);
-  env_t env = cuda::std::get<env_idx>(tuple);
+  const env_t env = cuda::std::get<env_idx>(tuple);
 
   static_assert(cuda::std::execution::__queryable_with<env_t, get_expected_allocation_size_t>,
                 "Unit tests using env launch wrappers (declared with DECLARE_LAUNCH_WRAPPER) must pass "
@@ -444,7 +444,7 @@ void launch(ActionT action, Args... args)
   using tpl_t = cuda::std::tuple<Args...>;
   using env_t = cuda::std::tuple_element_t<env_idx, tpl_t>;
   tpl_t tuple(args...);
-  env_t env = cuda::std::get<env_idx>(tuple);
+  const env_t env = cuda::std::get<env_idx>(tuple);
 
   // Environment-based API should use default stream if not specified in the environment
   cudaStream_t stream{nullptr};
@@ -490,9 +490,9 @@ void launch(ActionT action, Args... args)
   cuda::std::apply(
     [stream, kernels, action](auto... args) {
       // Make sure specified stream and kernels are used
-      stream_scope allowed_stream(stream);
-      kernel_scope allowed_kernels(kernels);
-      cudaError_t error = action(args...);
+      const stream_scope allowed_stream(stream);
+      const kernel_scope allowed_kernels(kernels);
+      const cudaError_t error = action(args...);
       REQUIRE(cudaSuccess == error);
     },
     fixed_args);

--- a/cub/test/catch2_test_grid_even_share.cu
+++ b/cub/test/catch2_test_grid_even_share.cu
@@ -67,7 +67,7 @@ CUB_TEST("GridEvenShare works with num_items > 0", "[grid][even_share]", CUB_SMA
 
   grid_share.DispatchInit(num_items, max_grid_size, tile_items);
 
-  int expected_grid_size = cuda::std::min(
+  const int expected_grid_size = cuda::std::min(
     max_grid_size,
     static_cast<int>(
       cuda::std::min(static_cast<offset_t>(INT_MAX), static_cast<offset_t>(cuda::ceil_div(num_items, tile_items)))));

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -154,7 +154,7 @@ CUB_TEST("Test texture transform iterator", "[iterator]", CUB_SMALL, types)
   c2h::gen(C2H_SEED(1), d_data);
   c2h::host_vector<T> h_data(d_data.begin(), d_data.end());
 
-  transform_op_t<T> op;
+  const transform_op_t<T> op;
   const auto h_reference = c2h::host_vector<T>{
     op(h_data[0]),
     op(h_data[100]),
@@ -169,7 +169,7 @@ CUB_TEST("Test texture transform iterator", "[iterator]", CUB_SMALL, types)
   TextureIterator d_tex_itr;
   CubDebugExit(
     d_tex_itr.BindTexture(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data())), sizeof(T) * TEST_VALUES));
-  cuda::transform_iterator<transform_op_t<T>, TextureIterator> xform_itr(d_tex_itr, op);
+  const cuda::transform_iterator<transform_op_t<T>, TextureIterator> xform_itr(d_tex_itr, op);
   test_iterator(xform_itr, h_reference);
   CubDebugExit(d_tex_itr.UnbindTexture());
 }

--- a/cub/test/catch2_test_launch_wrapper.cu
+++ b/cub/test/catch2_test_launch_wrapper.cu
@@ -112,7 +112,7 @@ CUB_TEST("Launch wrapper works with predefined invocables", "[test][utils]", CUB
 {
   INFO("Launch = " << TEST_LAUNCH);
 
-  int n = 42;
+  const int n = 42;
   c2h::device_vector<int> in(n, 21);
   c2h::device_vector<int> out(n);
 
@@ -170,7 +170,7 @@ struct custom_x0_5_invocable
 
 CUB_TEST("Launch wrapper works with custom invocables", "[test][utils]", CUB_SMALL)
 {
-  int n = 42;
+  const int n = 42;
   c2h::device_vector<int> in(n, 21);
   c2h::device_vector<int> out(n);
 

--- a/cub/test/catch2_test_memcpy_vectorized_copy.cu
+++ b/cub/test/catch2_test_memcpy_vectorized_copy.cu
@@ -24,9 +24,9 @@ CUB_TEST("The vectorized copy used by DeviceMemcpy works", "[memcpy]", CUB_SMALL
   constexpr std::uint32_t threads_per_block = 8;
 
   // Test the vectorized_copy for various aligned and misaligned input and output pointers.
-  std::size_t in_offset  = GENERATE(0, 1, sizeof(uint32_t) - 1);
-  std::size_t out_offset = GENERATE(0, 1, sizeof(vector_t) - 1);
-  std::size_t copy_size =
+  const std::size_t in_offset  = GENERATE(0, 1, sizeof(uint32_t) - 1);
+  const std::size_t out_offset = GENERATE(0, 1, sizeof(vector_t) - 1);
+  const std::size_t copy_size =
     GENERATE_COPY(0, 1, sizeof(uint32_t), sizeof(vector_t), 2 * threads_per_block * sizeof(vector_t));
   CAPTURE(in_offset, out_offset, copy_size);
 

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -272,16 +272,17 @@ CUB_TEST_CASE("Test nvrtc", "[test][nvrtc]", CUB_SMALL)
   const std::string arch = std::string("-arch=sm_") + std::to_string(ptx_version / 10);
   const std::string std  = std::string("-std=c++") + std::to_string(_CCCL_STD_VER - 2000);
 
-  constexpr int num_includes         = 6;
+  constexpr int num_includes = 6;
+  // NOLINTNEXTLINE(misc-const-correctness)
   const char* includes[num_includes] = {
     NVRTC_CUB_PATH, NVRTC_THRUST_PATH, NVRTC_LIBCUDACXX_PATH, NVRTC_CTK_PATH, arch.c_str(), std.c_str()};
 
   std::size_t log_size{};
-  nvrtcResult compile_result = nvrtcCompileProgram(prog, num_includes, includes);
+  const nvrtcResult compile_result = nvrtcCompileProgram(prog, num_includes, includes);
 
   REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLogSize(prog, &log_size));
 
-  std::unique_ptr<char[]> log{new char[log_size]};
+  const std::unique_ptr<char[]> log{new char[log_size]};
   REQUIRE(NVRTC_SUCCESS == nvrtcGetProgramLog(prog, log.get()));
   INFO("nvrtc log = " << log.get());
   REQUIRE(NVRTC_SUCCESS == compile_result);
@@ -289,7 +290,7 @@ CUB_TEST_CASE("Test nvrtc", "[test][nvrtc]", CUB_SMALL)
   std::size_t code_size{};
   REQUIRE(NVRTC_SUCCESS == nvrtcGetCUBINSize(prog, &code_size));
 
-  std::unique_ptr<char[]> code{new char[code_size]};
+  const std::unique_ptr<char[]> code{new char[code_size]};
   REQUIRE(NVRTC_SUCCESS == nvrtcGetCUBIN(prog, code.get()));
   REQUIRE(NVRTC_SUCCESS == nvrtcDestroyProgram(&prog));
 

--- a/cub/test/catch2_test_radix_operations.cu
+++ b/cub/test/catch2_test_radix_operations.cu
@@ -101,8 +101,8 @@ CUB_TEST("Radix operations extract digits from fundamental types", "[radix][oper
       std::uint32_t digit = extractor.Digit(val);
       std::memcpy(output_buffer, &digit, sizeof(std::uint32_t));
 
-      digit_bits_t result    = buffer_to_digit_bits(output_buffer, 0, num_bits);
-      digit_bits_t reference = buffer_to_digit_bits(input_buffer, current_bit, num_bits);
+      const digit_bits_t result    = buffer_to_digit_bits(output_buffer, 0, num_bits);
+      const digit_bits_t reference = buffer_to_digit_bits(input_buffer, current_bit, num_bits);
 
       REQUIRE(reference == result);
     }
@@ -272,8 +272,8 @@ void test_tuple()
       std::uint32_t digit = extractor.Digit(tpl);
       std::memcpy(output_buffer, &digit, sizeof(std::uint32_t));
 
-      digit_bits_t result    = buffer_to_digit_bits(output_buffer, 0, num_bits);
-      digit_bits_t reference = buffer_to_digit_bits(input_buffer, current_bit, num_bits);
+      const digit_bits_t result    = buffer_to_digit_bits(output_buffer, 0, num_bits);
+      const digit_bits_t reference = buffer_to_digit_bits(input_buffer, current_bit, num_bits);
 
       // Provides readable error messages:
       //  00000000000000000000000000000000
@@ -406,11 +406,11 @@ CUB_TEST(
   using traits       = cub::detail::radix::traits_t<key_t>;
   using decomposer_t = cub::detail::identity_decomposer_t;
 
-  c2h::host_vector<char> output_buffer_mem(sizeof(key_t));
-  c2h::host_vector<char> input_buffer_mem(sizeof(key_t));
+  const c2h::host_vector<char> output_buffer_mem(sizeof(key_t));
+  const c2h::host_vector<char> input_buffer_mem(sizeof(key_t));
 
-  key_t ref = cuda::std::numeric_limits<key_t>::lowest();
-  key_t val = traits::min_raw_binary_key(decomposer_t{});
+  const key_t ref = cuda::std::numeric_limits<key_t>::lowest();
+  const key_t val = traits::min_raw_binary_key(decomposer_t{});
 
   REQUIRE(ref == val);
 }
@@ -430,7 +430,7 @@ CUB_TEST("Radix operations infere minimal value for pair types",
   tpl_t ref;
   tpl_to_min(ref);
 
-  tpl_t val = traits::min_raw_binary_key(decomposer_t{});
+  const tpl_t val = traits::min_raw_binary_key(decomposer_t{});
 
   REQUIRE(ref == val);
 }
@@ -446,8 +446,8 @@ CUB_TEST(
   using traits       = cub::detail::radix::traits_t<key_t>;
   using decomposer_t = cub::detail::identity_decomposer_t;
 
-  key_t ref = cuda::std::numeric_limits<key_t>::max();
-  key_t val = traits::max_raw_binary_key(decomposer_t{});
+  const key_t ref = cuda::std::numeric_limits<key_t>::max();
+  const key_t val = traits::max_raw_binary_key(decomposer_t{});
 
   REQUIRE(ref == val);
 }
@@ -467,7 +467,7 @@ CUB_TEST("Radix operations infere maximal value for pair types",
   tpl_t ref;
   tpl_to_max(ref);
 
-  tpl_t val = traits::max_raw_binary_key(decomposer_t{});
+  const tpl_t val = traits::max_raw_binary_key(decomposer_t{});
 
   REQUIRE(ref == val);
 }
@@ -517,7 +517,7 @@ CUB_TEST("Radix operations reorder values for pair types",
   REQUIRE(l_2 == cuda::std::numeric_limits<T2>::lowest());
 
   {
-    tpl_t ref{T1{0}, T2{0}};
+    const tpl_t ref{T1{0}, T2{0}};
     const tpl_t unordered_val = tpl_t{l_1, l_2};
     const tpl_t ordered_val   = conversion_policy::to_bit_ordered(decomposer_t{}, unordered_val);
 
@@ -586,8 +586,8 @@ CUB_TEST_CASE("Radix operations treat -0/+0 as being equal", "[radix][operations
   using decomposer_t      = fp_aggregate_decomposer_t;
   using extractor_t       = cub::detail::radix::custom_digit_extractor_t<decomposer_t>;
 
-  fp_aggregate_t negative{-0.0, -0.0f};
-  fp_aggregate_t positive{+0.0, +0.0f};
+  const fp_aggregate_t negative{-0.0, -0.0f};
+  const fp_aggregate_t positive{+0.0, +0.0f};
   fp_aggregate_t ordered_negative = conversion_policy::to_bit_ordered(decomposer_t{}, negative);
   fp_aggregate_t ordered_positibe = conversion_policy::to_bit_ordered(decomposer_t{}, positive);
 

--- a/cub/test/catch2_test_temporary_storage_layout.cu
+++ b/cub/test/catch2_test_temporary_storage_layout.cu
@@ -61,7 +61,7 @@ CUB_TEST("Test partially filled storage", "[temporary_storage_layout]", CUB_SMAL
 
   const std::size_t temp_storage_bytes = temporary_storage.get_size();
 
-  std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[temp_storage_bytes]);
+  const std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[temp_storage_bytes]);
 
   temporary_storage.map_to_buffer(temp_storage.get(), temp_storage_bytes);
 
@@ -108,7 +108,7 @@ CUB_TEST("Test grow", "[temporary_storage_layout]", CUB_SMALL, num_storage_slots
   CHECK(preset_layout.get_size() == postset_layout.get_size());
 
   const std::size_t tmp_storage_bytes = preset_layout.get_size();
-  std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[tmp_storage_bytes]);
+  const std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[tmp_storage_bytes]);
 
   preset_layout.map_to_buffer(temp_storage.get(), tmp_storage_bytes);
   postset_layout.map_to_buffer(temp_storage.get(), tmp_storage_bytes);
@@ -147,7 +147,7 @@ CUB_TEST("Test double grow", "[temporary_storage_layout]", CUB_SMALL, num_storag
   CHECK(preset_layout.get_size() == postset_layout.get_size());
 
   const std::size_t tmp_storage_bytes = preset_layout.get_size();
-  std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[tmp_storage_bytes]);
+  const std::unique_ptr<std::uint8_t[]> temp_storage(new std::uint8_t[tmp_storage_bytes]);
 
   preset_layout.map_to_buffer(temp_storage.get(), tmp_storage_bytes);
   postset_layout.map_to_buffer(temp_storage.get(), tmp_storage_bytes);

--- a/cub/test/catch2_test_thread_operators.cu
+++ b/cub/test/catch2_test_thread_operators.cu
@@ -61,11 +61,11 @@ CUSTOM_TYPE_FACTORY(Eq, bool, ==, false);
 
 CUB_TEST("InequalityWrapper", "[thread_operator]", CUB_SMALL)
 {
-  cuda::std::equal_to<> wrapped_op{};
+  const cuda::std::equal_to<> wrapped_op{};
   cub::InequalityWrapper<cuda::std::equal_to<>> op{wrapped_op};
 
   constexpr int const_magic_val = 42;
-  int magic_val                 = const_magic_val;
+  const int magic_val           = const_magic_val;
 
   CHECK(op(const_magic_val, const_magic_val) == false);
   CHECK(op(const_magic_val, magic_val) == false);

--- a/cub/test/catch2_test_thread_scan_exclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_exclusive_partial.cu
@@ -171,7 +171,7 @@ CUB_TEST("ThreadScanExclusive Integral Type Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<output_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<output_t> reference_result(num_items, static_cast<output_t>(filler));
 
   compute_exclusive_scan_reference(
@@ -229,7 +229,7 @@ CUB_TEST("ThreadScanExclusive Floating-Point Type Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<value_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<value_t> reference_result(num_items, filler);
 
   compute_exclusive_scan_reference(
@@ -292,7 +292,7 @@ CUB_TEST("ThreadScanExclusive Narrow PrecisionType Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<output_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<output_t> reference_result(num_items, filler);
 
   compute_exclusive_scan_reference(
@@ -328,8 +328,8 @@ CUB_TEST("ThreadScanExclusive Container Tests", "[scan][thread]", CUB_SMALL)
   c2h::device_vector<int> d_out(max_size, thrust::no_init);
   using dist_param = dist_interval<int, cuda::std::plus<>, max_size>;
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<int> h_in = d_in;
-  const int valid_items      = GENERATE_COPY(
+  const c2h::host_vector<int> h_in = d_in;
+  const int valid_items            = GENERATE_COPY(
     take(1, random(2, max_size - 2)),
     take(1, random(max_size + 2, cuda::std::numeric_limits<int>::max())),
     values({1, max_size - 1, max_size, max_size + 1}));

--- a/cub/test/catch2_test_thread_scan_inclusive_partial.cu
+++ b/cub/test/catch2_test_thread_scan_inclusive_partial.cu
@@ -179,7 +179,7 @@ CUB_TEST("ThreadScanInclusive Integral Type Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<output_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<output_t> reference_result(num_items, static_cast<output_t>(filler));
 
   compute_inclusive_scan_reference(
@@ -240,7 +240,7 @@ CUB_TEST("ThreadScanInclusive Floating-Point Type Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<output_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<output_t> reference_result(num_items, filler);
 
   compute_inclusive_scan_reference(
@@ -297,7 +297,7 @@ CUB_TEST("ThreadScanInclusive Narrow PrecisionType Tests",
   c2h::device_vector<value_t> d_in(num_items, thrust::no_init);
   c2h::device_vector<output_t> d_out(num_items, thrust::no_init);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   c2h::host_vector<output_t> reference_result(num_items, filler);
 
   compute_inclusive_scan_reference(
@@ -328,8 +328,8 @@ CUB_TEST("ThreadScanInclusive Container Tests", "[scan][thread]", CUB_SMALL)
   c2h::device_vector<int> d_out(max_size, thrust::no_init);
   using dist_param = dist_interval<int, cuda::std::plus<>, max_size>;
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<int> h_in = d_in;
-  const int valid_items      = GENERATE_COPY(
+  const c2h::host_vector<int> h_in = d_in;
+  const int valid_items            = GENERATE_COPY(
     take(1, random(2, cuda::std::max(2, max_size - 1))),
     take(1, random(max_size + 2, cuda::std::numeric_limits<int>::max())),
     values({1, max_size, max_size + 1}));

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -49,16 +49,16 @@ CUB_TEST("CUB correctly identifies the ptx version the kernel was compiled for",
   c2h::device_vector<int> cuda_cc(single_item);
 
   // Query the arch the kernel was actually compiled for
-  int ptx_version = [&]() -> int {
+  const int ptx_version = [&]() -> int {
     int* buffer{};
     cudaMallocHost(&buffer, sizeof(*buffer));
     get_cuda_cc_from_kernel(thrust::raw_pointer_cast(cuda_cc.data()), buffer);
-    int result = *buffer;
+    const int result = *buffer;
     cudaFreeHost(buffer);
     return result;
   }();
 
-  int kernel_cuda_cc = cuda_cc[0];
+  const int kernel_cuda_cc = cuda_cc[0];
 
   // Host cub::PtxVersion
   int host_ptx_version{};
@@ -298,7 +298,7 @@ __global__ void test_max_potential_dynamic_smem_bytes_device(int* result)
 
 CUB_TEST("MaxPotentialDynamicSmemBytes", "[util][launch]", CUB_SMALL)
 {
-  cuda::device_ref device{0};
+  const cuda::device_ref device{0};
 
   // Calculate the expected max potential dynamic shared memory size.
   const auto max_smem_per_block_optin = device.attribute(cuda::device_attributes::max_shared_memory_per_block_optin);

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -86,18 +86,18 @@ CUB_TEST("Test FutureValue", "[util][type]", CUB_SMALL)
 {
   // read
   int value;
-  cub::FutureValue<int> fv{&value};
+  cub::FutureValue<int> fv{&value}; // NOLINT(misc-const-correctness)
   value = 42;
   CHECK(fv == 42);
   value = 43;
   CHECK(fv == 43);
 
   // CTAD
-  cub::FutureValue fv2{&value};
+  cub::FutureValue fv2{&value}; // NOLINT(misc-const-correctness): decltype must not be const-qualified
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(fv2), cub::FutureValue<int, int*>>);
 
   c2h::device_vector<int> v(0);
-  cub::FutureValue fv3{v.begin()};
+  cub::FutureValue fv3{v.begin()}; // NOLINT(misc-const-correctness): decltype must not be const-qualified
   STATIC_REQUIRE(
     cuda::std::is_same_v<decltype(fv3), cub::FutureValue<int, typename c2h::device_vector<int>::iterator>>);
 }

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -283,8 +283,8 @@ struct dispatch_dummy_algorithm_t
     cudaError error = cudaSuccess;
 
     // Compute temporary storage requirements
-    void* allocations[1]            = {nullptr};
-    std::size_t allocation_sizes[1] = {total_vsmem};
+    void* allocations[1]                  = {nullptr};
+    const std::size_t allocation_sizes[1] = {total_vsmem};
     error = cub::detail::alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes);
     if (cudaSuccess != error)
     {
@@ -387,7 +387,7 @@ CUB_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", CUB_S
   using offset_t = int32_t;
 
   constexpr offset_t target_size = 10000000;
-  const offset_t num_items       = target_size / sizeof(item_t);
+  constexpr offset_t num_items   = target_size / sizeof(item_t);
 
   // Prepare input and output buffers for a simple copy algorithm test
   c2h::device_vector<uint8_t> in(num_items * sizeof(item_t));
@@ -405,18 +405,18 @@ CUB_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", CUB_S
   using fallback_agent_t  = agent_dummy_algorithm_t<fallback_policy_t, item_t*, item_t*, offset_t>;
 
   // Get the information as it is expected from the vsmem helper to work as expected
-  std::size_t default_smem_size  = sizeof(typename default_agent_t::TempStorage);
-  std::size_t fallback_smem_size = sizeof(typename fallback_agent_t::TempStorage);
-  bool expected_to_use_fallback =
+  constexpr std::size_t default_smem_size  = sizeof(typename default_agent_t::TempStorage);
+  constexpr std::size_t fallback_smem_size = sizeof(typename fallback_agent_t::TempStorage);
+  constexpr bool expected_to_use_fallback =
     default_smem_size > cub::detail::max_smem_per_block && fallback_smem_size <= cub::detail::max_smem_per_block;
-  std::size_t expected_smem_per_block = expected_to_use_fallback ? fallback_smem_size : default_smem_size;
-  bool expected_needs_vsmem           = expected_smem_per_block > cub::detail::max_smem_per_block;
-  std::size_t expected_threads_per_block =
+  constexpr std::size_t expected_smem_per_block = expected_to_use_fallback ? fallback_smem_size : default_smem_size;
+  constexpr bool expected_needs_vsmem           = expected_smem_per_block > cub::detail::max_smem_per_block;
+  constexpr std::size_t expected_threads_per_block =
     expected_to_use_fallback ? fallback_policy_t::BLOCK_THREADS : default_policy_t::BLOCK_THREADS;
-  std::size_t expected_items_per_thread =
+  constexpr std::size_t expected_items_per_thread =
     expected_to_use_fallback ? fallback_policy_t::ITEMS_PER_THREAD : default_policy_t::ITEMS_PER_THREAD;
-  std::size_t expected_tile_size       = expected_threads_per_block * expected_items_per_thread;
-  std::size_t expected_vsmem_per_block = (expected_needs_vsmem ? expected_smem_per_block : 0ULL);
+  constexpr std::size_t expected_tile_size       = expected_threads_per_block * expected_items_per_thread;
+  constexpr std::size_t expected_vsmem_per_block = (expected_needs_vsmem ? expected_smem_per_block : 0ULL);
 
   // Setup vsmem test
   launch_config_test_info_t* launch_config_info = nullptr;
@@ -437,13 +437,13 @@ CUB_TEST("Virtual shared memory works within algorithms", "[util][vsmem]", CUB_S
   // Make sure the launch configuration information retrieved from the vsmem helper is correct
   REQUIRE(launch_config_info->config_assumes_tile_size == expected_tile_size);
   REQUIRE(launch_config_info->config_assumes_threads_per_block == expected_threads_per_block);
-  if (expected_vsmem_per_block == 0)
+  if constexpr (expected_vsmem_per_block == 0)
   {
     REQUIRE(launch_config_info->config_vsmem_per_block == 0);
   }
   else
   {
-    // The virtual shared memory helper pads vsmem to a multiple of a line size, hence the range check
+    // The virtual shared memory helper pads vsmem to a multiple of a line size, hence the range check.
     REQUIRE(launch_config_info->config_vsmem_per_block >= expected_vsmem_per_block);
   }
 

--- a/cub/test/catch2_test_warp_bitonic_sort.cu
+++ b/cub/test/catch2_test_warp_bitonic_sort.cu
@@ -82,7 +82,7 @@ __global__ void warp_bitonic_sort_kernel(KeyT* in, KeyT* out, int valid_items, A
   __shared__ storage_t storage[TotalWarps];
 
   // Instantiate warp-scope algorithm
-  warp_bitonic_sort_t warp_sort{storage[warp_id]};
+  warp_bitonic_sort_t warp_sort{storage[warp_id]}; // NOLINT(misc-const-correctness)
 
   const int warp_offset = valid_items * warp_id;
 
@@ -138,7 +138,7 @@ __global__ void warp_bitonic_sort_kernel(
   __shared__ storage_t storage[TotalWarps];
 
   // Instantiate warp-scope algorithm
-  warp_bitonic_sort_t warp_sort{storage[warp_id]};
+  warp_bitonic_sort_t warp_sort{storage[warp_id]}; // NOLINT(misc-const-correctness)
 
   const int warp_offset = valid_items * warp_id;
 

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -205,7 +205,7 @@ c2h::host_vector<T> compute_host_reference(const c2h::device_vector<T>& d_input,
 {
   c2h::host_vector<T> input = d_input;
 
-  int num_warps = cuda::ceil_div(static_cast<int>(d_input.size()), tile_size);
+  const int num_warps = cuda::ceil_div(static_cast<int>(d_input.size()), tile_size);
   for (int warp_id = 0; warp_id < num_warps; warp_id++)
   {
     const int warp_data_begin = tile_size * warp_id;

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -29,7 +29,7 @@ __global__ void warp_load_kernel(InputIteratorT input_iterator, ActionT action, 
   const int linear_tid = static_cast<int>(threadIdx.x);
 
   const int warp_id = linear_tid / LOGICAL_WARP_THREADS;
-  warp_load_t load(storage[warp_id]);
+  warp_load_t load(storage[warp_id]); // NOLINT(misc-const-correctness)
 
   // Test WarpLoad specialization
   T reg[ITEMS_PER_THREAD];

--- a/cub/test/catch2_test_warp_merge_sort.cu
+++ b/cub/test/catch2_test_warp_merge_sort.cu
@@ -333,7 +333,7 @@ void compute_host_reference(
 {
   for (unsigned int segment_id = 0; segment_id < num_segments; segment_id++)
   {
-    unsigned int segment_size = segment_sizes[segment_id];
+    const unsigned int segment_size = segment_sizes[segment_id];
     std::stable_sort(h_data, h_data + segment_size);
     std::fill(h_data + segment_size, h_data + logical_warp_items, oob_default);
     h_data += logical_warp_items;
@@ -435,8 +435,8 @@ CUB_TEST("Warp sort keys-only on partial warp-tile works",
     d_in, d_out, d_segment_sizes.cbegin(), oob_default, warp_sort_delegate{});
 
   // Prepare verification data
-  c2h::host_vector<type> h_in_out     = d_in;
-  c2h::host_vector<int> segment_sizes = d_segment_sizes;
+  c2h::host_vector<type> h_in_out           = d_in;
+  const c2h::host_vector<int> segment_sizes = d_segment_sizes;
   compute_host_reference(h_in_out.begin(), segment_sizes, params::total_warps, oob_default, params::logical_warp_items);
 
   // Verify results
@@ -518,7 +518,7 @@ CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
   // Prepare verification data
   c2h::host_vector<key_type> h_keys_in_out     = d_keys_in;
   c2h::host_vector<value_type> h_values_in_out = d_values_in;
-  c2h::host_vector<int> segment_sizes          = d_segment_sizes;
+  const c2h::host_vector<int> segment_sizes    = d_segment_sizes;
   auto cpu_kv_pairs = thrust::make_zip_iterator(h_keys_in_out.begin(), h_values_in_out.begin());
   compute_host_reference(
     cpu_kv_pairs,

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -21,7 +21,7 @@ __global__ void warp_combine_scan_kernel(T* in, T* inclusive_out, T* exclusive_o
     cub::RowMajorTid(static_cast<int>(blockDim.x), static_cast<int>(blockDim.y), static_cast<int>(blockDim.z));
 
   // Get warp index
-  int warp_id = tid / LOGICAL_WARP_THREADS;
+  const int warp_id = tid / LOGICAL_WARP_THREADS;
 
   T inc_out, exc_out;
   T thread_data = in[tid];
@@ -60,7 +60,7 @@ __global__ void warp_scan_kernel(T* in, T* out, ActionT action)
     cub::RowMajorTid(static_cast<int>(blockDim.x), static_cast<int>(blockDim.y), static_cast<int>(blockDim.z));
 
   // Get warp index
-  int warp_id = tid / LOGICAL_WARP_THREADS;
+  const int warp_id = tid / LOGICAL_WARP_THREADS;
 
   T thread_data = in[tid];
 
@@ -262,7 +262,7 @@ c2h::host_vector<T> compute_host_reference(
 
   // The accumulator variable is used to calculate warp_aggregate without
   // taking initial_value into consideration in both exclusive and inclusive scan.
-  int num_warps = cuda::ceil_div(static_cast<int>(result.size()), logical_warp_threads);
+  const int num_warps = cuda::ceil_div(static_cast<int>(result.size()), logical_warp_threads);
   c2h::host_vector<T> warp_accumulator(num_warps);
   if (mode == scan_mode::exclusive)
   {

--- a/cub/test/catch2_test_warp_scan_api.cu
+++ b/cub/test/catch2_test_warp_scan_api.cu
@@ -40,9 +40,9 @@ __global__ void InclusiveWarpScanKernel(int* output)
   // Allocate WarpScan shared memory for 4 warps
   __shared__ typename warp_scan_t::TempStorage temp_storage[num_warps];
 
-  int warp_id       = static_cast<int>(threadIdx.x / 32);
-  int initial_value = 3;
-  int thread_data   = static_cast<int>(threadIdx.x % 32) + warp_id;
+  const int warp_id       = static_cast<int>(threadIdx.x / 32);
+  const int initial_value = 3;
+  int thread_data         = static_cast<int>(threadIdx.x % 32) + warp_id;
 
   // warp #0 input: {0, 1, 2, 3, ..., 31}
   // warp #1 input: {1, 2, 3, 4, ..., 32}
@@ -92,9 +92,9 @@ __global__ void InclusiveWarpScanKernelAggr(int* output, int* d_warp_aggregate)
   // Allocate WarpScan shared memory for 4 warps
   __shared__ typename warp_scan_t::TempStorage temp_storage[num_warps];
 
-  int warp_id       = static_cast<int>(threadIdx.x / 32);
-  int initial_value = 3; // for each warp
-  int thread_data   = 1;
+  const int warp_id       = static_cast<int>(threadIdx.x / 32);
+  const int initial_value = 3; // for each warp
+  int thread_data         = 1;
   int warp_aggregate;
 
   // warp #0 input: {1, 1, 1, 1, ..., 1}
@@ -131,9 +131,9 @@ CUB_TEST("Warp array-based inclusive scan aggregate works with initial value", "
 
   for (int i = 0; i < num_warps; ++i)
   {
-    auto start   = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
-    auto end     = start + 32;
-    int init_val = 3;
+    auto start         = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
+    auto end           = start + 32;
+    const int init_val = 3;
 
     cuda::std::fill(start, end, 1); // initialize host input for every warp
 
@@ -166,15 +166,15 @@ __global__ void InclusiveWarpScanPartialKernel(int* output)
   // Allocate WarpScan shared memory for 4 warps
   __shared__ typename warp_scan_t::TempStorage temp_storage[num_warps];
 
-  int warp_id = static_cast<int>(threadIdx.x / 32);
+  const int warp_id = static_cast<int>(threadIdx.x / 32);
 
-  int initial_value = 3;
-  int thread_data   = static_cast<int>(threadIdx.x % 32) + warp_id;
+  const int initial_value = 3;
+  int thread_data         = static_cast<int>(threadIdx.x % 32) + warp_id;
   if (threadIdx.x % 2 == 1)
   {
     thread_data = -thread_data;
   }
-  int valid_items = 40 - warp_id * 16;
+  const int valid_items = 40 - warp_id * 16;
 
   // warp #0 input: {0, -1, 2, -3, ..., 28, -29, 30, -31}, valid_items: 40 (effectively 32)
   // warp #1 input: {1, -2, 3, -4, ..., 29, -30, 31, -32}, valid_items: 24
@@ -206,9 +206,9 @@ CUB_TEST("Warp array-based partial inclusive scan works with initial value", "[s
 
   for (int i = 0; i < num_warps; ++i)
   {
-    auto start      = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
-    auto end        = start + 32;
-    int valid_items = cuda::std::clamp(40 - i * 16, 0, 32);
+    auto start            = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
+    auto end              = start + 32;
+    const int valid_items = cuda::std::clamp(40 - i * 16, 0, 32);
 
     cuda::std::iota(start, end, i); // initialize host input for every warp
     cuda::std::transform(start, end, start, [i](int val) {
@@ -244,11 +244,11 @@ __global__ void InclusiveWarpScanPartialKernelAggr(int* output, int* d_warp_aggr
   // Allocate WarpScan shared memory for 4 warps
   __shared__ typename warp_scan_t::TempStorage temp_storage[num_warps];
 
-  int warp_id       = static_cast<int>(threadIdx.x / 32);
-  int lane_id       = static_cast<int>(threadIdx.x % 32);
-  int initial_value = 3; // for each warp
-  int thread_data   = (lane_id < num_warps - 1 - warp_id) ? 0 : 1;
-  int valid_items   = 40 - warp_id * 16;
+  const int warp_id       = static_cast<int>(threadIdx.x / 32);
+  const int lane_id       = static_cast<int>(threadIdx.x % 32);
+  const int initial_value = 3; // for each warp
+  int thread_data         = (lane_id < num_warps - 1 - warp_id) ? 0 : 1;
+  const int valid_items   = 40 - warp_id * 16;
   int warp_aggregate;
 
   // warp #0 input: {0, 0, 0, 1, ..., 1}, valid_items: 40 (effectively 32)
@@ -285,10 +285,10 @@ CUB_TEST("Warp array-based partial inclusive scan aggregate works with initial v
 
   for (int i = 0; i < num_warps; ++i)
   {
-    auto start      = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
-    auto end        = start + 32;
-    int valid_items = cuda::std::clamp(40 - i * 16, 0, 32);
-    int init_val    = 3;
+    auto start            = expected.begin() + i * 32; // NOLINT(bugprone-misplaced-widening-cast)
+    auto end              = start + 32;
+    const int valid_items = cuda::std::clamp(40 - i * 16, 0, 32);
+    const int init_val    = 3;
 
     cuda::std::fill(start + num_warps - 1 - i, end, 1); // initialize host input for every warp
 

--- a/cub/test/catch2_test_warp_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_warp_scan_partial_helper.cuh
@@ -23,7 +23,7 @@ warp_combine_scan_kernel(T* in, T* inclusive_out, T* exclusive_out, ActionT acti
     cub::RowMajorTid(static_cast<int>(blockDim.x), static_cast<int>(blockDim.y), static_cast<int>(blockDim.z));
 
   // Get warp index
-  int warp_id = tid / LogicalWarpThreads;
+  const int warp_id = tid / LogicalWarpThreads;
 
   T inc_out     = filler;
   T exc_out     = filler;
@@ -70,7 +70,7 @@ __global__ void warp_scan_kernel(T* in, T* out, ActionT action, int valid_items)
     cub::RowMajorTid(static_cast<int>(blockDim.x), static_cast<int>(blockDim.y), static_cast<int>(blockDim.z));
 
   // Get warp index
-  int warp_id = tid / LogicalWarpThreads;
+  const int warp_id = tid / LogicalWarpThreads;
 
   T thread_data = in[tid];
 
@@ -114,7 +114,7 @@ c2h::host_vector<T> compute_host_reference(
 
   // The accumulator variable is used to calculate warp_aggregate without
   // taking initial_value into consideration in both exclusive and inclusive scan.
-  int num_warps = static_cast<int>(result.size()) / logical_warp_threads;
+  const int num_warps = static_cast<int>(result.size()) / logical_warp_threads;
   c2h::host_vector<T> warp_accumulator(num_warps);
   if (mode == scan_mode::exclusive)
   {

--- a/cub/test/catch2_test_warp_store.cu
+++ b/cub/test/catch2_test_warp_store.cu
@@ -33,7 +33,7 @@ __global__ void warp_store_kernel(OutputIteratorT output_iterator, ActionT actio
   }
 
   const int warp_id = tid / LOGICAL_WARP_THREADS;
-  warp_store_t store(storage[warp_id]);
+  warp_store_t store(storage[warp_id]); // NOLINT(misc-const-correctness)
 
   action(store, output_iterator + (warp_id * tile_size), reg);
 }

--- a/cub/test/internal/catch2_test_fast_div_mod.cu
+++ b/cub/test/internal/catch2_test_fast_div_mod.cu
@@ -30,7 +30,7 @@ CUB_TEST("FastDivMod random", "[FastDivMod][Random]", CUB_SMALL, index_types)
   constexpr auto max_value = +cuda::std::numeric_limits<index_type>::max();
   auto dividend            = GENERATE_COPY(take(20, random(+index_type{1}, max_value)));
   auto divisor             = GENERATE_COPY(take(20, random(+index_type{1}, max_value)));
-  fast_div_mod<index_type> div_mod(static_cast<index_type>(divisor));
+  fast_div_mod<index_type> div_mod(static_cast<index_type>(divisor)); // NOLINT(misc-const-correctness)
   CAPTURE(c2h::type_name<index_type>(), dividend, divisor);
   static_assert(std::is_same_v<decltype(dividend / divisor), decltype(div_mod(dividend).quotient)>,
                 "quotient type mismatch");
@@ -45,11 +45,11 @@ CUB_TEST("FastDivMod edge cases", "[FastDivMod][EdgeCases]", CUB_SMALL, index_ty
   constexpr auto max_value = cuda::std::numeric_limits<index_type>::max();
   CAPTURE(c2h::type_name<index_type>());
   // divisor/dividend == max
-  fast_div_mod<index_type> div_mod_max(max_value);
+  fast_div_mod<index_type> div_mod_max(max_value); // NOLINT(misc-const-correctness)
   REQUIRE(1 == div_mod_max(max_value).quotient);
   REQUIRE(0 == div_mod_max(max_value).remainder);
   // divisor == 10, dividend == 0
-  fast_div_mod<index_type> div_mod_min(10);
+  fast_div_mod<index_type> div_mod_min(10); // NOLINT(misc-const-correctness)
   REQUIRE(0 == div_mod_min(0).quotient);
   REQUIRE(0 == div_mod_min(0).remainder);
 }

--- a/cub/test/mersenne.h
+++ b/cub/test/mersenne.h
@@ -119,7 +119,7 @@ inline void init_by_array(unsigned int init_key[], int key_length)
 inline unsigned int genrand_int32()
 {
   unsigned int y;
-  static unsigned int mag01[2] = {0x0, MATRIX_A};
+  static const unsigned int mag01[2] = {0x0, MATRIX_A}; // NOLINT(misc-const-correctness)
 
   /* mag01[x] = x * MATRIX_A  for x=0,1 */
 

--- a/cub/test/test_allocator.cu
+++ b/cub/test/test_allocator.cu
@@ -385,7 +385,7 @@ int main(int argc, char** argv)
     //
 
     // Allocate 768 bytes on the next gpu
-    int next_gpu = (initial_gpu + 1) % num_gpus;
+    const int next_gpu = (initial_gpu + 1) % num_gpus;
     char* d_768B_2;
     CubDebugExit(allocator.DeviceAllocate(next_gpu, (void**) &d_768B_2, 768));
 
@@ -469,7 +469,7 @@ int main(int argc, char** argv)
     cub::detail::EmptyKernel<void><<<1, 32>>>();
   }
   gpu_timer.Stop();
-  float cuda_empty_elapsed_millis = gpu_timer.ElapsedMillis();
+  const float cuda_empty_elapsed_millis = gpu_timer.ElapsedMillis();
 
   // CUDA
   gpu_timer.Start();

--- a/cub/test/test_block_radix_rank.cu
+++ b/cub/test/test_block_radix_rank.cu
@@ -62,7 +62,7 @@ __launch_bounds__(ThreadsPerBlock, 1) __global__ void kernel(Key* d_keys, int* d
     cub::LoadDirectBlocked(threadIdx.x, d_keys, keys);
   }
 
-  cub::BFEDigitExtractor<Key> extractor(0, RadixBits);
+  cub::BFEDigitExtractor<Key> extractor(0, RadixBits); // NOLINT(misc-const-correctness)
   block_radix_rank(temp_storage).RankKeys(keys, ranks, extractor);
 
   if (uses_warp_striped_arrangement)
@@ -97,7 +97,7 @@ struct pair_t
 template <bool DESCENDING, typename Key>
 void Initialize(GenMode gen_mode, Key* h_keys, int* h_reference_ranks, int num_items, int num_bits)
 {
-  std::unique_ptr<pair_t<Key>[]> h_pairs_storage(new pair_t<Key>[num_items]);
+  const std::unique_ptr<pair_t<Key>[]> h_pairs_storage(new pair_t<Key>[num_items]);
   pair_t<Key>* h_pairs = h_pairs_storage.get();
 
   for (int i = 0; i < num_items; ++i)
@@ -144,8 +144,8 @@ void TestDriver(GenMode gen_mode)
   constexpr int tile_size = ThreadsPerBlock * ItemsPerThread;
 
   // Allocate host arrays
-  std::unique_ptr<Key[]> h_keys(new Key[tile_size]);
-  std::unique_ptr<int[]> h_reference_ranks(new int[tile_size]);
+  const std::unique_ptr<Key[]> h_keys(new Key[tile_size]);
+  const std::unique_ptr<int[]> h_reference_ranks(new int[tile_size]);
 
   // Initialize problem and solution on host
   Initialize<Descending>(gen_mode, h_keys.get(), h_reference_ranks.get(), tile_size, RadixBits);
@@ -207,7 +207,7 @@ void Test()
     cub::detail::block_radix_rank_t<RankAlgorithm, ThreadsPerBlock, RadixBits, Descending, ScanAlgorithm>;
   using storage_t = typename block_radix_rank::TempStorage;
 
-  cuda::std::bool_constant<(sizeof(storage_t) <= cub::detail::max_smem_per_block)> fits_smem_capacity;
+  const cuda::std::bool_constant<(sizeof(storage_t) <= cub::detail::max_smem_per_block)> fits_smem_capacity;
 
   TestValid<RankAlgorithm, ThreadsPerBlock, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(
     fits_smem_capacity);

--- a/cub/test/test_device_batch_copy.cu
+++ b/cub/test/test_device_batch_copy.cu
@@ -184,7 +184,7 @@ try
 {
   // Range segment data (their offsets and sizes)
   c2h::host_vector<RangeSizeT> h_range_sizes(num_ranges);
-  cuda::counting_iterator<RangeOffsetT> iota(0);
+  const cuda::counting_iterator<RangeOffsetT> iota(0);
   auto d_range_srcs = cuda::transform_iterator(iota, RepeatIndex<AtomicT>{});
   c2h::host_vector<ByteOffsetT> h_offsets(num_ranges + 1);
 
@@ -207,11 +207,11 @@ try
   // Device-side resources
   c2h::device_vector<AtomicT> d_out(num_total_items);
   c2h::device_vector<ByteOffsetT> d_offsets(h_offsets);
-  c2h::device_vector<RangeSizeT> d_range_sizes(h_range_sizes);
+  const c2h::device_vector<RangeSizeT> d_range_sizes(h_range_sizes);
 
   // Prepare d_range_dsts
   using AtomicIterT = typename c2h::device_vector<AtomicT>::iterator;
-  OffsetToIteratorOp<AtomicIterT> dst_transform_op{d_out.begin()};
+  const OffsetToIteratorOp<AtomicIterT> dst_transform_op{d_out.begin()};
   auto d_range_dsts = cuda::transform_iterator(d_offsets.begin(), dst_transform_op);
 
   // Get temporary storage requirements
@@ -322,10 +322,10 @@ void nontrivial_constructor_test()
 
   for (int i = 0; i < num_buffers; i++)
   {
-    object_with_non_trivial_ctor ha(a[i]);
-    object_with_non_trivial_ctor hb(b[i]);
-    int ia = ha.field;
-    int ib = hb.field;
+    const object_with_non_trivial_ctor ha(a[i]);
+    const object_with_non_trivial_ctor hb(b[i]);
+    const int ia = ha.field;
+    const int ib = hb.field;
 
     if (ia != ib)
     {
@@ -388,12 +388,12 @@ int main(int argc, char** argv)
   for (const auto& size_range : size_ranges)
   {
     // The most granular type being copied.
-    using AtomicCopyT         = int64_t;
-    RangeSizeT min_range_size = static_cast<RangeSizeT>(cuda::round_up(size_range.first, sizeof(AtomicCopyT)));
-    RangeSizeT max_range_size =
+    using AtomicCopyT               = int64_t;
+    const RangeSizeT min_range_size = static_cast<RangeSizeT>(cuda::round_up(size_range.first, sizeof(AtomicCopyT)));
+    const RangeSizeT max_range_size =
       static_cast<RangeSizeT>(cuda::round_up(size_range.second, static_cast<RangeSizeT>(sizeof(AtomicCopyT))));
-    double average_range_size      = (min_range_size + max_range_size) / 2.0;
-    RangeOffsetT target_num_ranges = static_cast<RangeOffsetT>(target_copy_size / average_range_size);
+    const double average_range_size      = (min_range_size + max_range_size) / 2.0;
+    const RangeOffsetT target_num_ranges = static_cast<RangeOffsetT>(target_copy_size / average_range_size);
 
     // Run tests with output ranges being consecutive
     RunTest<AtomicCopyT, RangeOffsetT, RangeSizeT, ByteOffsetT>(
@@ -407,12 +407,12 @@ int main(int argc, char** argv)
   for (const auto& size_range : size_ranges)
   {
     // The most granular type being copied.
-    using AtomicCopyT         = cuda::std::tuple<int64_t, int32_t, int16_t, char, char>;
-    RangeSizeT min_range_size = static_cast<RangeSizeT>(cuda::round_up(size_range.first, sizeof(AtomicCopyT)));
-    RangeSizeT max_range_size =
+    using AtomicCopyT               = cuda::std::tuple<int64_t, int32_t, int16_t, char, char>;
+    const RangeSizeT min_range_size = static_cast<RangeSizeT>(cuda::round_up(size_range.first, sizeof(AtomicCopyT)));
+    const RangeSizeT max_range_size =
       static_cast<RangeSizeT>(cuda::round_up(size_range.second, static_cast<RangeSizeT>(sizeof(AtomicCopyT))));
-    double average_range_size      = (min_range_size + max_range_size) / 2.0;
-    RangeOffsetT target_num_ranges = static_cast<RangeOffsetT>(target_copy_size / average_range_size);
+    const double average_range_size      = (min_range_size + max_range_size) / 2.0;
+    const RangeOffsetT target_num_ranges = static_cast<RangeOffsetT>(target_copy_size / average_range_size);
 
     // Run tests with output ranges being consecutive
     RunTest<AtomicCopyT, RangeOffsetT, RangeSizeT, ByteOffsetT>(
@@ -428,7 +428,7 @@ int main(int argc, char** argv)
   //---------------------------------------------------------------------
   using ByteOffset64T = uint64_t;
   using RangeSize64T  = uint64_t;
-  ByteOffset64T large_target_copy_size =
+  const ByteOffset64T large_target_copy_size =
     static_cast<ByteOffset64T>(::cuda::std::numeric_limits<uint32_t>::max()) + (128ULL * 1024ULL * 1024ULL);
   // Make sure min_range_size is in fact smaller than max range size
   constexpr RangeOffsetT single_range = 1;

--- a/cub/test/test_nvtx_disabled.cu
+++ b/cub/test/test_nvtx_disabled.cu
@@ -16,7 +16,7 @@ CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 int main()
 {
-  cuda::counting_iterator<int> it{0};
+  const cuda::counting_iterator<int> it{0};
   cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{});
   cudaDeviceSynchronize();
 }

--- a/cub/test/test_nvtx_in_usercode.cu
+++ b/cub/test/test_nvtx_in_usercode.cu
@@ -12,9 +12,9 @@ CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 int main()
 {
-  nvtx3::scoped_range range("user-range"); // user-side use of unversioned NVTX API
+  const nvtx3::scoped_range range("user-range"); // user-side use of unversioned NVTX API
 
-  cuda::counting_iterator<int> it{0};
+  const cuda::counting_iterator<int> it{0};
   cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{}); // internal use of NVTX
   cudaDeviceSynchronize();
 }

--- a/cub/test/test_nvtx_in_usercode_explicit.cu
+++ b/cub/test/test_nvtx_in_usercode_explicit.cu
@@ -11,9 +11,9 @@ CUB_TEST_MEMORY_CLASS(CUB_SMALL);
 
 int main()
 {
-  nvtx3::v1::scoped_range range("user-range"); // user-side use of explicit NVTX API
+  const nvtx3::v1::scoped_range range("user-range"); // user-side use of explicit NVTX API
 
-  cuda::counting_iterator<int> it{0};
+  const cuda::counting_iterator<int> it{0};
   cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{}); // internal use of NVTX
   cudaDeviceSynchronize();
 }

--- a/cub/test/test_nvtx_standalone.cu
+++ b/cub/test/test_nvtx_standalone.cu
@@ -19,7 +19,7 @@ int main()
 {
   _CCCL_NVTX_RANGE_SCOPE("main");
 
-  cuda::counting_iterator<int> it{0};
+  const cuda::counting_iterator<int> it{0};
   cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{});
   cudaDeviceSynchronize();
 }

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -102,7 +102,7 @@ struct CommandLineArgs
       }
 
       string key, val;
-      string::size_type pos = arg.find('=');
+      const string::size_type pos = arg.find('=');
       if (pos == string::npos)
       {
         key = string(arg, 2, arg.length() - 2);
@@ -195,7 +195,7 @@ struct CommandLineArgs
       {
         if (keys[i] == string(arg_name))
         {
-          string val_string(values[i]);
+          const string val_string(values[i]);
           istringstream str_stream(val_string);
           string::size_type old_pos = 0;
           string::size_type new_pos = 0;
@@ -391,7 +391,7 @@ void RandomBits(K& key, int entropy_reduction = 0, int begin_bit = 0, int end_bi
     // Generate random word_buff
     for (int j = 0; j < NUM_WORDS; j++)
     {
-      int current_bit = j * WORD_BYTES * 8;
+      const int current_bit = j * WORD_BYTES * 8;
 
       unsigned int word = 0xffffffff;
       word &= 0xffffffff << ::cuda::std::max(0, begin_bit - current_bit);
@@ -421,7 +421,7 @@ template <typename T>
 T RandomValue(T max)
 {
   unsigned int bits;
-  unsigned int max_int = (unsigned int) -1;
+  const unsigned int max_int = (unsigned int) -1;
   do
   {
     RandomBits(bits);
@@ -1089,8 +1089,8 @@ int CompareResults(float* computed, float* reference, OffsetT len, bool verbose 
   {
     if (computed[i] != reference[i])
     {
-      float difference = std::abs(computed[i] - reference[i]);
-      float fraction   = difference / std::abs(reference[i]);
+      const float difference = std::abs(computed[i] - reference[i]);
+      const float fraction   = difference / std::abs(reference[i]);
 
       if (fraction > 0.00015)
       {
@@ -1128,8 +1128,8 @@ int CompareResults(double* computed, double* reference, OffsetT len, bool verbos
   {
     if (computed[i] != reference[i])
     {
-      double difference = std::abs(computed[i] - reference[i]);
-      double fraction   = difference / std::abs(reference[i]);
+      const double difference = std::abs(computed[i] - reference[i]);
+      const double fraction   = difference / std::abs(reference[i]);
 
       if (fraction > 0.00015)
       {
@@ -1210,7 +1210,7 @@ int CompareDeviceResults(
   }
 
   // Check
-  int retval = CompareResults(h_data, h_reference, num_items, verbose);
+  const int retval = CompareResults(h_data, h_reference, num_items, verbose);
 
   // Cleanup
   if (h_data)
@@ -1394,8 +1394,8 @@ struct CpuTimer
 
   float ElapsedMillis()
   {
-    float sec  = static_cast<float>(stop.ru_utime.tv_sec - start.ru_utime.tv_sec);
-    float usec = static_cast<float>(stop.ru_utime.tv_usec - start.ru_utime.tv_usec);
+    const float sec  = static_cast<float>(stop.ru_utime.tv_sec - start.ru_utime.tv_sec);
+    const float usec = static_cast<float>(stop.ru_utime.tv_usec - start.ru_utime.tv_usec);
 
     return (sec * 1000) + (usec / 1000);
   }

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -60,7 +60,7 @@ __global__ void thread_reduce_kernel_span(const T* d_in, T* d_out, ReduceOperato
   {
     thread_data[i] = d_in[i];
   }
-  cuda::std::span<T, NUM_ITEMS> span(thread_data);
+  const cuda::std::span<T, NUM_ITEMS> span(thread_data);
   *d_out = cub::ThreadReduce(span, reduce_operator);
 }
 
@@ -75,7 +75,7 @@ __global__ void thread_reduce_kernel_mdspan(const T* d_in, T* d_out, ReduceOpera
     thread_data[i] = d_in[i];
   }
   using Extent = cuda::std::extents<int, NUM_ITEMS>;
-  cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NUM_ITEMS>{});
+  const cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NUM_ITEMS>{});
   *d_out = cub::ThreadReduce(mdspan, reduce_operator);
 }
 

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_partial.cu
@@ -65,7 +65,7 @@ thread_reduce_partial_kernel_span(const T* d_in, T* d_out, ReduceOperator reduce
   {
     thread_data[i] = d_in[i];
   }
-  cuda::std::span<T, NumItems> span(thread_data);
+  const cuda::std::span<T, NumItems> span(thread_data);
   *d_out = cub::detail::ThreadReducePartial(span, reduce_operator, valid_items);
 }
 
@@ -81,7 +81,7 @@ thread_reduce_partial_kernel_mdspan(const T* d_in, T* d_out, ReduceOperator redu
     thread_data[i] = d_in[i];
   }
   using Extent = cuda::std::extents<int, NumItems>;
-  cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NumItems>{});
+  const cuda::std::mdspan<T, Extent> mdspan(thread_data, cuda::std::extents<int, NumItems>{});
   *d_out = cub::detail::ThreadReducePartial(mdspan, reduce_operator, valid_items);
 }
 
@@ -137,8 +137,8 @@ CUB_TEST("ThreadReduce Integral Type Tests",
   c2h::device_vector<value_t> d_in(num_items);
   c2h::device_vector<accum_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
-  const int bounded_valid_items  = cuda::std::min(valid_items, num_items);
+  const c2h::host_vector<value_t> h_in = d_in;
+  const int bounded_valid_items        = cuda::std::min(valid_items, num_items);
   auto reference_result =
     compute_single_problem_reference(h_in.cbegin(), h_in.cbegin() + bounded_valid_items, reduce_op, operator_identity);
   thread_reduce_partial_kernel<num_items>
@@ -170,8 +170,8 @@ CUB_TEST("ThreadReduce Floating-Point Type Tests",
   c2h::device_vector<value_t> d_in(num_items);
   c2h::device_vector<accum_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
-  const int bounded_valid_items  = cuda::std::min(valid_items, num_items);
+  const c2h::host_vector<value_t> h_in = d_in;
+  const int bounded_valid_items        = cuda::std::min(valid_items, num_items);
   auto reference_result =
     compute_single_problem_reference(h_in.cbegin(), h_in.cbegin() + bounded_valid_items, reduce_op, operator_identity);
   thread_reduce_partial_kernel<num_items>
@@ -204,7 +204,7 @@ CUB_TEST("ThreadReduce Narrow PrecisionType Tests",
   c2h::device_vector<value_t> d_in(num_items);
   c2h::device_vector<accum_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<value_t> h_in = d_in;
+  const c2h::host_vector<value_t> h_in = d_in;
   CAPTURE(h_in, dist_param::min(), dist_param::max());
   CAPTURE(c2h::type_name<value_t>(), c2h::type_name<decltype(reduce_op)>(), valid_items, num_items, operator_identity);
   const int bounded_valid_items = cuda::std::min(valid_items, num_items);
@@ -230,8 +230,8 @@ CUB_TEST("ThreadReduce Container Tests", "[reduce][thread]", CUB_SMALL)
   c2h::device_vector<int> d_in(max_size);
   c2h::device_vector<int> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, dist_param::min(), dist_param::max());
-  c2h::host_vector<int> h_in = d_in;
-  const int valid_items      = GENERATE_COPY(
+  const c2h::host_vector<int> h_in = d_in;
+  const int valid_items            = GENERATE_COPY(
     take(1, random(2, max_size - 2)),
     take(1, random(max_size + 2, cuda::std::numeric_limits<int>::max())),
     values({1, max_size - 1, max_size, max_size + 1}));

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -50,7 +50,7 @@ __device__ void warp_reduce_function(T& thread_data, Output* output, ReductionOp
   {
     return;
   }
-  warp_reduce_t warp_reduce{storage[logical_warp]};
+  const warp_reduce_t warp_reduce{storage[logical_warp]};
   using result_t = decltype(reduction_op(warp_reduce, thread_data));
   result_t result;
   if constexpr (EnableNumItems)
@@ -228,10 +228,10 @@ _CCCL_DIAG_POP
 
 std::array<unsigned, 3> get_test_config(unsigned logical_warp_threads, unsigned items_per_thread = 1)
 {
-  bool is_power_of_two = cuda::is_power_of_two(logical_warp_threads);
-  auto logical_warps   = is_power_of_two ? warp_size / logical_warp_threads : 1;
-  auto input_size      = total_warps * warp_size * items_per_thread;
-  auto output_size     = total_warps * logical_warps;
+  const bool is_power_of_two = cuda::is_power_of_two(logical_warp_threads);
+  auto logical_warps         = is_power_of_two ? warp_size / logical_warp_threads : 1;
+  auto input_size            = total_warps * warp_size * items_per_thread;
+  auto output_size           = total_warps * logical_warps;
   return {input_size, output_size, logical_warps};
 }
 
@@ -254,7 +254,7 @@ CUB_TEST("WarpReduce::Sum, full_type_list",
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<cuda::std::plus<>, T>{});
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<cuda::std::plus<>>(h_in, h_out, logical_warps, logical_warp_threads);
   verify_results(h_out, d_out);
@@ -277,7 +277,7 @@ CUB_TEST("WarpReduce::Sum/Max/Min, builtin types",
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<predefined_op, T>{});
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads);
   verify_results(h_out, d_out);
@@ -300,7 +300,7 @@ CUB_TEST("WarpReduce::Max/Min, floating-point redux types",
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<predefined_op, T>{});
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads);
   if constexpr (cuda::std::is_same_v<T, float>)
@@ -324,7 +324,7 @@ CUB_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", CUB_SMALL, fu
   c2h::gen(C2H_SEED(1), d_in);
   warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<custom_plus, T>{});
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<cuda::std::plus<>>(h_in, h_out, logical_warps, logical_warp_threads);
   verify_results(h_out, d_out);
@@ -351,7 +351,7 @@ CUB_TEST("WarpReduce::Sum/Max/Min Partial",
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_launch<logical_warp_threads, true>(d_in, d_out, warp_reduce_t<predefined_op, T>{}, valid_items);
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads, valid_items);
   verify_results(h_out, d_out);
@@ -369,7 +369,7 @@ CUB_TEST("WarpReduce::Sum", "[reduce][warp][generic][partial]", CUB_SMALL, full_
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_launch<logical_warp_threads, true>(d_in, d_out, warp_reduce_t<custom_plus, T>{}, valid_items);
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<cuda::std::plus<>>(h_in, h_out, logical_warps, logical_warp_threads, valid_items);
   verify_results(h_out, d_out);
@@ -395,7 +395,7 @@ CUB_TEST("WarpReduce::Sum/Max/Min Multiple Items Per Thread",
   c2h::gen(C2H_SEED(10), d_in);
   warp_reduce_multiple_items_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<predefined_op, T>{});
 
-  c2h::host_vector<T> h_in = d_in;
+  const c2h::host_vector<T> h_in = d_in;
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads, 0, num_items_per_thread);
   verify_results(h_out, d_out);

--- a/cub/test/warp/catch2_test_warp_reduce_batched.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched.cu
@@ -257,8 +257,8 @@ void test_warp_reduce_batched(ReductionOp reduction_op = ReductionOp{})
 
   c2h::device_vector<T> d_output(total_batches);
 
-  input_2d_mdspan_t<T> d_input_md(thrust::raw_pointer_cast(d_input.data()), total_batches, LogicalWarpThreads);
-  cuda::std::span<T> d_output_span(thrust::raw_pointer_cast(d_output.data()), total_batches);
+  const input_2d_mdspan_t<T> d_input_md(thrust::raw_pointer_cast(d_input.data()), total_batches, LogicalWarpThreads);
+  const cuda::std::span<T> d_output_span(thrust::raw_pointer_cast(d_output.data()), total_batches);
   if constexpr (CondParticipation)
   {
     warp_reduce_batched_cond_part_kernel<Mode, SyncPhysicalWarp, Batches, LogicalWarpThreads>
@@ -285,12 +285,12 @@ void test_warp_reduce_batched(ReductionOp reduction_op = ReductionOp{})
   REQUIRE(err == cudaSuccess);
 
   // Host-side: construct mdspans once; pass to reference and verify
-  c2h::host_vector<T> h_input  = d_input;
-  c2h::host_vector<T> h_output = d_output;
+  c2h::host_vector<T> h_input        = d_input;
+  const c2h::host_vector<T> h_output = d_output;
 
   c2h::host_vector<T> h_reference(total_batches);
-  input_2d_mdspan_t<const T> h_input_md(h_input.data(), total_batches, LogicalWarpThreads);
-  cuda::std::span<T> h_reference_span(h_reference.data(), total_batches);
+  const input_2d_mdspan_t<const T> h_input_md(h_input.data(), total_batches, LogicalWarpThreads);
+  const cuda::std::span<T> h_reference_span(h_reference.data(), total_batches);
 
   compute_host_reference(h_input_md, h_reference_span, reduction_op);
 

--- a/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
+++ b/cub/test/warp/catch2_test_warp_reduce_batched_api.cu
@@ -31,7 +31,7 @@ __global__ __launch_bounds__(64) void WarpReduceBatchedOverviewKernel(int* out)
   thread_data[1] = tid;
   thread_data[2] = tid + 1;
 
-  int result = WarpReduceBatched{temp_storage[warp_id]}.Reduce(thread_data, cuda::maximum{});
+  const int result = WarpReduceBatched{temp_storage[warp_id]}.Reduce(thread_data, cuda::maximum{});
   // results across threads: [30, 31, 32, ?, ?, ..., ?, 62, 63, 64, ?, ?, ..., ?]
   // example-end warp-reduce-batched-overview
 
@@ -50,7 +50,7 @@ CUB_TEST("WarpReduceBatched overview documentation kernel", "[warp][reduce][batc
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{30, 31, 32, 62, 63, 64};
+  const c2h::host_vector<int> expected{30, 31, 32, 62, 63, 64};
   REQUIRE(expected == d_out);
 }
 
@@ -93,7 +93,7 @@ CUB_TEST("WarpReduceBatched::Reduce documentation kernel", "[warp][reduce][batch
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{14, 15, 16};
+  const c2h::host_vector<int> expected{14, 15, 16};
   REQUIRE(expected == d_out);
 }
 
@@ -153,7 +153,7 @@ CUB_TEST("WarpReduceBatched::ReduceToStriped documentation kernel", "[warp][redu
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
+  const c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
   REQUIRE(expected == d_out);
 }
 
@@ -214,7 +214,7 @@ CUB_TEST("WarpReduceBatched::ReduceToBlocked documentation kernel", "[warp][redu
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
+  const c2h::host_vector<int> expected{0, 1, 2, 4, 5, 6};
   REQUIRE(expected == d_out);
 }
 
@@ -233,8 +233,8 @@ __global__ __launch_bounds__(8) void WarpReduceBatchedSumApiKernel(int* out)
   const int tid             = static_cast<int>(threadIdx.x);
   const int logical_warp_id = tid / logical_warp_threads;
 
-  cuda::std::array<int, num_batches> inputs{tid - 1, tid, tid + 1};
-  int result = WarpReduceBatched{temp_storage[logical_warp_id]}.Sum(inputs);
+  const cuda::std::array<int, num_batches> inputs{tid - 1, tid, tid + 1};
+  const int result = WarpReduceBatched{temp_storage[logical_warp_id]}.Sum(inputs);
   // results across threads:
   // [2, 6, 10, ?, 18, 22, 26, ?]
   // example-end warp-reduce-batched-sum
@@ -253,7 +253,7 @@ CUB_TEST("WarpReduceBatched::Sum documentation kernel", "[warp][reduce][batched]
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{2, 6, 10, 18, 22, 26};
+  const c2h::host_vector<int> expected{2, 6, 10, 18, 22, 26};
   REQUIRE(expected == d_out);
 }
 
@@ -301,7 +301,7 @@ CUB_TEST("WarpReduceBatched::SumToStriped documentation kernel", "[warp][reduce]
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
+  const c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
   REQUIRE(expected == d_out);
 }
 
@@ -349,6 +349,6 @@ CUB_TEST("WarpReduceBatched::SumToBlocked documentation kernel", "[warp][reduce]
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());
 
-  c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
+  const c2h::host_vector<int> expected{-3, -1, 1, 3, 5, 1, 3, 5, 7, 9, 5, 7, 9, 11, 13, 9, 11, 13, 15, 17};
   REQUIRE(expected == d_out);
 }

--- a/cub/test/warp/catch2_test_warp_segmented_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_segmented_reduce.cu
@@ -22,7 +22,7 @@ __global__ void warp_reduce_kernel(T* in, T* out, ActionT action)
   const int tid = static_cast<int>(threadIdx.x);
 
   // Get warp index
-  int warp_id = tid / LOGICAL_WARP_THREADS;
+  const int warp_id = tid / LOGICAL_WARP_THREADS;
 
   // Load data
   T thread_data = in[tid];
@@ -153,8 +153,8 @@ void compute_host_reference(
   // Accumulate segments (lane 0 of each warp is implicitly a segment head)
   for (int warp = 0; warp < warps; ++warp)
   {
-    int warp_offset = warp * logical_warp_threads;
-    int item_offset = warp_offset + valid_warp_threads - 1;
+    const int warp_offset = warp * logical_warp_threads;
+    int item_offset       = warp_offset + valid_warp_threads - 1;
 
     // Last item in warp
     auto head_aggregate = h_in[item_offset];
@@ -286,9 +286,9 @@ CUB_TEST("Warp segmented sum works", "[reduce][warp]", CUB_SMALL, full_type_list
     d_in, d_out, warp_seg_sum_t{thrust::raw_pointer_cast(d_flags.data())});
 
   // Prepare verification data
-  c2h::host_vector<type> h_in       = d_in;
-  c2h::host_vector<uint8_t> h_flags = d_flags;
-  c2h::host_vector<type> h_out      = h_in;
+  const c2h::host_vector<type> h_in       = d_in;
+  const c2h::host_vector<uint8_t> h_flags = d_flags;
+  c2h::host_vector<type> h_out            = h_in;
   compute_host_reference(
     segmented_mod,
     h_in,
@@ -337,9 +337,9 @@ CUB_TEST("Warp segmented reduction works",
     d_in, d_out, warp_seg_reduction_t{thrust::raw_pointer_cast(d_flags.data()), red_op_t{}});
 
   // Prepare verification data
-  c2h::host_vector<type> h_in       = d_in;
-  c2h::host_vector<uint8_t> h_flags = d_flags;
-  c2h::host_vector<type> h_out      = h_in;
+  const c2h::host_vector<type> h_in       = d_in;
+  const c2h::host_vector<uint8_t> h_flags = d_flags;
+  c2h::host_vector<type> h_out            = h_in;
   compute_host_reference(
     segmented_mod,
     h_in,


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `cub/test/`
  - `cub/benchmarks/`
  - `cub/examples/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.