### PR TITLE
[Thrust] `misc-const-correctness`

### DIFF
--- a/thrust/thrust/detail/allocator/copy_construct_range.h
+++ b/thrust/thrust/detail/allocator/copy_construct_range.h
@@ -80,8 +80,8 @@ _CCCL_HOST_DEVICE Pointer uninitialized_copy_with_allocator(
     using IteratorTuple = ::cuda::std::tuple<InputIterator, Pointer>;
     using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-    ZipIterator begin = thrust::make_zip_iterator(first, result);
-    ZipIterator end   = begin;
+    const ZipIterator begin = thrust::make_zip_iterator(first, result);
+    ZipIterator end         = begin;
 
     // get a zip_iterator pointing to the end
     const thrust::detail::it_difference_t<InputIterator> n = ::cuda::std::distance(first, last);

--- a/thrust/thrust/detail/allocator/temporary_allocator.h
+++ b/thrust/thrust/detail/allocator/temporary_allocator.h
@@ -63,7 +63,7 @@ public:
 
   _CCCL_HOST_DEVICE pointer allocate(size_type cnt)
   {
-    pointer_and_size result = thrust::get_temporary_buffer<T>(system(), cnt);
+    const pointer_and_size result = thrust::get_temporary_buffer<T>(system(), cnt);
 
     // handle failure
     if (result.second < cnt)
@@ -97,7 +97,7 @@ public:
     // Deallocate must be noexcept to be safe in destructors and during exception unwinding.
     // Clear CUDA error state and leak the memory rather than propagating exception.
     // Memory is leaked, but this matches standard allocator behavior when deallocation fails.
-    _CCCL_CATCH (std::exception & e)
+    _CCCL_CATCH (const std::exception& e)
     {
       // if we have some context about the thrown exception, log it
       NV_IF_TARGET(NV_IS_HOST, {

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -90,16 +90,16 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const co
 
   T oos = T(1.0) / s;
 
-  T ars = x.real() * oos;
-  T ais = x.imag() * oos;
-  T brs = y.real() * oos;
-  T bis = y.imag() * oos;
+  const T ars = x.real() * oos;
+  const T ais = x.imag() * oos;
+  const T brs = y.real() * oos;
+  const T bis = y.imag() * oos;
 
   s = (brs * brs) + (bis * bis);
 
   oos = T(1.0) / s;
 
-  complex<T> quot(((ars * brs) + (ais * bis)) * oos, ((ais * brs) - (ars * bis)) * oos);
+  const complex<T> quot(((ars * brs) + (ais * bis)) * oos, ((ais * brs) - (ars * bis)) * oos);
   return quot;
 }
 
@@ -165,8 +165,8 @@ _CCCL_HOST_DEVICE inline float norm(const complex<float>& z)
   if (::cuda::std::abs(z.real()) < ::cuda::std::sqrt(FLT_MIN)
       && ::cuda::std::abs(z.imag()) < ::cuda::std::sqrt(FLT_MIN))
   {
-    float a = z.real() * 4.0f;
-    float b = z.imag() * 4.0f;
+    const float a = z.real() * 4.0f;
+    const float b = z.imag() * 4.0f;
     return (a * a + b * b) / 16.0f;
   }
 
@@ -179,8 +179,8 @@ _CCCL_HOST_DEVICE inline double norm(const complex<double>& z)
   if (::cuda::std::abs(z.real()) < ::cuda::std::sqrt(DBL_MIN)
       && ::cuda::std::abs(z.imag()) < ::cuda::std::sqrt(DBL_MIN))
   {
-    double a = z.real() * 4.0;
-    double b = z.imag() * 4.0;
+    const double a = z.real() * 4.0;
+    const double b = z.imag() * 4.0;
     return (a * a + b * b) / 16.0;
   }
 

--- a/thrust/thrust/detail/complex/catrig.h
+++ b/thrust/thrust/detail/complex/catrig.h
@@ -62,7 +62,7 @@ _CCCL_HOST_DEVICE inline void raise_inexact()
 {
   const volatile float tiny = 7.888609052210118054117286e-31; /* 0x1p-100; */
   // needs the volatile to prevent compiler from ignoring it
-  [[maybe_unused]] volatile float junk = 1 + tiny;
+  [[maybe_unused]] const volatile float junk = 1 + tiny;
 }
 
 _CCCL_HOST_DEVICE inline complex<double> clog_for_large_values(complex<double> z);
@@ -384,7 +384,7 @@ _CCCL_HOST_DEVICE inline complex<double> casinh(complex<double> z)
  */
 _CCCL_HOST_DEVICE inline complex<double> casin(complex<double> z)
 {
-  complex<double> w = casinh(complex<double>(z.imag(), z.real()));
+  const complex<double> w = casinh(complex<double>(z.imag(), z.real()));
 
   return (complex<double>(w.imag(), w.real()));
 }
@@ -754,7 +754,7 @@ _CCCL_HOST_DEVICE inline complex<double> catanh(complex<double> z)
  */
 _CCCL_HOST_DEVICE inline complex<double> catan(complex<double> z)
 {
-  complex<double> w = catanh(complex<double>(z.imag(), z.real()));
+  const complex<double> w = catanh(complex<double>(z.imag(), z.real()));
   return (complex<double>(w.imag(), w.real()));
 }
 } // namespace detail::complex

--- a/thrust/thrust/detail/complex/catrigf.h
+++ b/thrust/thrust/detail/complex/catrigf.h
@@ -245,7 +245,7 @@ _CCCL_HOST_DEVICE inline complex<float> casinhf(complex<float> z)
 
 _CCCL_HOST_DEVICE inline complex<float> casinf(complex<float> z)
 {
-  complex<float> w = casinhf(complex<float>(z.imag(), z.real()));
+  const complex<float> w = casinhf(complex<float>(z.imag(), z.real()));
 
   return (complex<float>(w.imag(), w.real()));
 }
@@ -532,7 +532,7 @@ _CCCL_HOST_DEVICE inline complex<float> catanhf(complex<float> z)
 
 _CCCL_HOST_DEVICE inline complex<float> catanf(complex<float> z)
 {
-  complex<float> w = catanhf(complex<float>(z.imag(), z.real()));
+  const complex<float> w = catanhf(complex<float>(z.imag(), z.real()));
   return (complex<float>(w.imag(), w.real()));
 }
 } // namespace detail::complex

--- a/thrust/thrust/detail/complex/csinh.h
+++ b/thrust/thrust/detail/complex/csinh.h
@@ -93,7 +93,7 @@ _CCCL_HOST_DEVICE inline complex<double> csinh(const complex<double>& z)
     else if (ix < 0x4096bbaa)
     {
       /* x < 1455: scale to avoid overflow */
-      complex<double> z_ = ldexp_cexp(complex<double>(::cuda::std::fabs(x), y), -1);
+      const complex<double> z_ = ldexp_cexp(complex<double>(::cuda::std::fabs(x), y), -1);
       return (complex<double>(z_.real() * ::cuda::std::copysign(1.0, x), z_.imag()));
     }
     else

--- a/thrust/thrust/detail/complex/csinhf.h
+++ b/thrust/thrust/detail/complex/csinhf.h
@@ -95,7 +95,7 @@ _CCCL_HOST_DEVICE inline complex<float> csinhf(const complex<float>& z)
     else if (ix < 0x4340b1e7)
     {
       /* x < 192.7: scale to avoid overflow */
-      complex<float> z_ = ldexp_cexpf(complex<float>(::cuda::std::fabsf(x), y), -1);
+      const complex<float> z_ = ldexp_cexpf(complex<float>(::cuda::std::fabsf(x), y), -1);
       return (complex<float>(z_.real() * ::cuda::std::copysignf(1.0f, x), z_.imag()));
     }
     else

--- a/thrust/thrust/detail/complex/ctanh.h
+++ b/thrust/thrust/detail/complex/ctanh.h
@@ -153,7 +153,7 @@ _CCCL_HOST_DEVICE inline complex<double> ctanh(const complex<double>& z)
    */
   if (ix >= 0x40360000)
   { /* x >= 22 */
-    double exp_mx = ::cuda::std::exp(-fabs(x));
+    const double exp_mx = ::cuda::std::exp(-fabs(x));
     return (complex<double>(::cuda::std::copysign(1.0, x),
                             4.0 * ::cuda::std::sin(y) * ::cuda::std::cos(y) * exp_mx * exp_mx));
   }

--- a/thrust/thrust/detail/complex/ctanhf.h
+++ b/thrust/thrust/detail/complex/ctanhf.h
@@ -92,7 +92,7 @@ _CCCL_HOST_DEVICE inline complex<float> ctanhf(const complex<float>& z)
 
   if (ix >= 0x41300000)
   { /* x >= 11 */
-    float exp_mx = ::cuda::std::expf(-::cuda::std::fabsf(x));
+    const float exp_mx = ::cuda::std::expf(-::cuda::std::fabsf(x));
     return (complex<float>(::cuda::std::copysignf(1.0f, x),
                            4.0f * ::cuda::std::sinf(y) * ::cuda::std::cosf(y) * exp_mx * exp_mx));
   }

--- a/thrust/thrust/detail/copy.inl
+++ b/thrust/thrust/detail/copy.inl
@@ -109,8 +109,8 @@ OutputIterator copy(InputIterator first, InputIterator last, OutputIterator resu
     detail::should_enable_nvtx_for_policy<System1>() || detail::should_enable_nvtx_for_policy<System2>(),
     "thrust::copy");
 
-  System1 system1;
-  System2 system2;
+  const System1 system1;
+  const System2 system2;
 
   return thrust::detail::two_system_copy(system1, system2, first, last, result);
 } // end copy()
@@ -124,8 +124,8 @@ OutputIterator copy_n(InputIterator first, Size n, OutputIterator result)
     detail::should_enable_nvtx_for_policy<System1>() || detail::should_enable_nvtx_for_policy<System2>(),
     "thrust::copy_n");
 
-  System1 system1;
-  System2 system2;
+  const System1 system1;
+  const System2 system2;
 
   return thrust::detail::two_system_copy_n(system1, system2, first, n, result);
 } // end copy_n()

--- a/thrust/thrust/detail/copy.inl
+++ b/thrust/thrust/detail/copy.inl
@@ -109,8 +109,9 @@ OutputIterator copy(InputIterator first, InputIterator last, OutputIterator resu
     detail::should_enable_nvtx_for_policy<System1>() || detail::should_enable_nvtx_for_policy<System2>(),
     "thrust::copy");
 
-  const System1 system1;
-  const System2 system2;
+  // thrust systems must be mutable
+  System1 system1; // NOLINT(misc-const-correctness)
+  System2 system2; // NOLINT(misc-const-correctness)
 
   return thrust::detail::two_system_copy(system1, system2, first, last, result);
 } // end copy()
@@ -124,8 +125,9 @@ OutputIterator copy_n(InputIterator first, Size n, OutputIterator result)
     detail::should_enable_nvtx_for_policy<System1>() || detail::should_enable_nvtx_for_policy<System2>(),
     "thrust::copy_n");
 
-  const System1 system1;
-  const System2 system2;
+  // thrust systems must be mutable
+  System1 system1; // NOLINT(misc-const-correctness)
+  System2 system2; // NOLINT(misc-const-correctness)
 
   return thrust::detail::two_system_copy_n(system1, system2, first, n, result);
 } // end copy_n()

--- a/thrust/thrust/detail/count.inl
+++ b/thrust/thrust/detail/count.inl
@@ -80,7 +80,7 @@ thrust::detail::it_difference_t<InputIterator> count_if(InputIterator first, Inp
 
   using System = typename thrust::iterator_system<InputIterator>::type;
 
-  System system;
+  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
 
   return thrust::count_if(select_system(system), first, last, pred);
 } // end count_if()

--- a/thrust/thrust/detail/count.inl
+++ b/thrust/thrust/detail/count.inl
@@ -80,7 +80,8 @@ thrust::detail::it_difference_t<InputIterator> count_if(InputIterator first, Inp
 
   using System = typename thrust::iterator_system<InputIterator>::type;
 
-  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
+  // thrust systems must be mutable
+  System system; // NOLINT(misc-const-correctness)
 
   return thrust::count_if(select_system(system), first, last, pred);
 } // end count_if()

--- a/thrust/thrust/detail/equal.inl
+++ b/thrust/thrust/detail/equal.inl
@@ -68,8 +68,10 @@ bool equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
   using System1 = typename thrust::iterator_system<InputIterator1>::type;
   using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
+  // NOLINTBEGIN(misc-const-correctness): select_system requires mutable lvalues
   System1 system1;
   System2 system2;
+  // NOLINTEND(misc-const-correctness)
 
   return thrust::equal(select_system(system1, system2), first1, last1, first2);
 }

--- a/thrust/thrust/detail/equal.inl
+++ b/thrust/thrust/detail/equal.inl
@@ -68,10 +68,9 @@ bool equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
   using System1 = typename thrust::iterator_system<InputIterator1>::type;
   using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
-  // NOLINTBEGIN(misc-const-correctness): select_system requires mutable lvalues
-  System1 system1;
-  System2 system2;
-  // NOLINTEND(misc-const-correctness)
+  // thrust systems must be mutable
+  System1 system1; // NOLINT(misc-const-correctness)
+  System2 system2; // NOLINT(misc-const-correctness)
 
   return thrust::equal(select_system(system1, system2), first1, last1, first2);
 }

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -39,7 +39,7 @@ get_temporary_buffer(thrust::detail::execute_with_allocator<Allocator, BaseSyste
   // of type T?
   const size_type num_elements = static_cast<size_type>(::cuda::ceil_div(sizeof(T) * n, sizeof(value_type)));
 
-  void_pointer ptr = alloc_traits::allocate(system.get_allocator(), num_elements);
+  const void_pointer ptr = alloc_traits::allocate(system.get_allocator(), num_elements);
 
   // Return the pointer and the number of elements of type T allocated.
   return ::cuda::std::make_pair(thrust::reinterpret_pointer_cast<T*>(ptr), n);
@@ -56,9 +56,9 @@ _CCCL_HOST void return_temporary_buffer(
   using value_type      = typename alloc_traits::value_type;
   using T               = typename ::cuda::std::pointer_traits<Pointer>::element_type;
 
-  size_type num_elements = ::cuda::ceil_div(sizeof(T) * n, sizeof(value_type));
+  const size_type num_elements = ::cuda::ceil_div(sizeof(T) * n, sizeof(value_type));
 
-  pointer to_ptr = thrust::reinterpret_pointer_cast<pointer>(p);
+  const pointer to_ptr = thrust::reinterpret_pointer_cast<pointer>(p);
   alloc_traits::deallocate(system.get_allocator(), to_ptr, num_elements);
 }
 } // namespace detail

--- a/thrust/thrust/detail/for_each.inl
+++ b/thrust/thrust/detail/for_each.inl
@@ -54,7 +54,7 @@ InputIterator for_each(InputIterator first, InputIterator last, UnaryFunction f)
   _CCCL_NVTX_RANGE_SCOPE_IF(detail::should_enable_nvtx_for_policy<System>(), "thrust::for_each");
   using thrust::system::detail::generic::select_system;
 
-  System system;
+  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
   return thrust::for_each(select_system(system), first, last, f);
 } // end for_each()
 
@@ -76,7 +76,7 @@ InputIterator for_each_n(InputIterator first, Size n, UnaryFunction f)
   _CCCL_NVTX_RANGE_SCOPE_IF(detail::should_enable_nvtx_for_policy<System>(), "thrust::for_each_n");
   using thrust::system::detail::generic::select_system;
 
-  System system;
+  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
   return thrust::for_each_n(select_system(system), first, n, f);
 } // end for_each_n()
 

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -40,7 +40,7 @@ public:
     R_bits = total_bits - L_bits;
     R_mask = (1ull << R_bits) - 1;
 
-    thrust::uniform_int_distribution<std::uint32_t> dist;
+    thrust::uniform_int_distribution<std::uint32_t> dist; // NOLINT(misc-const-correctness)
     for (auto& k : key)
     {
       k = dist(g);
@@ -64,13 +64,13 @@ public:
     {
       constexpr uint64_t m0  = 0xD2B74407B1CE6E93;
       const uint64_t product = m0 * L;
-      uint32_t F_k           = (product >> 32) ^ k;
-      uint32_t B_k           = static_cast<uint32_t>(product);
-      uint32_t L_prime       = F_k ^ R;
+      const uint32_t F_k     = (product >> 32) ^ k;
+      const uint32_t B_k     = static_cast<uint32_t>(product);
+      const uint32_t L_prime = F_k ^ R;
 
-      uint32_t R_prime = (B_k << (R_bits - L_bits)) | R >> L_bits;
-      L                = L_prime & L_mask;
-      R                = R_prime & R_mask;
+      const uint32_t R_prime = (B_k << (R_bits - L_bits)) | R >> L_bits;
+      L                      = L_prime & L_mask;
+      R                      = R_prime & R_mask;
     }
     // Combine the left and right sides together to get result
     return (static_cast<uint64_t>(L) << R_bits) | static_cast<uint64_t>(R);

--- a/thrust/thrust/detail/reduce.inl
+++ b/thrust/thrust/detail/reduce.inl
@@ -207,7 +207,7 @@ detail::it_value_t<InputIterator> reduce(InputIterator first, InputIterator last
 
   using System = typename thrust::iterator_system<InputIterator>::type;
 
-  System system;
+  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
 
   return thrust::reduce(select_system(system), first, last);
 }

--- a/thrust/thrust/detail/reduce.inl
+++ b/thrust/thrust/detail/reduce.inl
@@ -207,7 +207,8 @@ detail::it_value_t<InputIterator> reduce(InputIterator first, InputIterator last
 
   using System = typename thrust::iterator_system<InputIterator>::type;
 
-  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
+  // thrust systems must be mutable
+  System system; // NOLINT(misc-const-correctness)
 
   return thrust::reduce(select_system(system), first, last);
 }

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -210,9 +210,9 @@ public:
 
   _CCCL_HOST_DEVICE value_type operator++(int)
   {
-    value_type tmp    = *this;
-    value_type result = tmp++;
-    *this             = ::cuda::std::move(tmp);
+    value_type tmp          = *this;
+    const value_type result = tmp++;
+    *this                   = ::cuda::std::move(tmp);
     return result;
   }
 

--- a/thrust/thrust/detail/temporary_buffer.h
+++ b/thrust/thrust/detail/temporary_buffer.h
@@ -43,7 +43,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
 down_cast_pair(Pair p)
 {
   // XXX should use a hypothetical thrust::static_pointer_cast here
-  thrust::pointer<T, DerivedPolicy> ptr =
+  const thrust::pointer<T, DerivedPolicy> ptr =
     thrust::pointer<T, DerivedPolicy>(static_cast<T*>(thrust::raw_pointer_cast(p.first)));
 
   using result_type =

--- a/thrust/thrust/detail/transform_reduce.inl
+++ b/thrust/thrust/detail/transform_reduce.inl
@@ -60,7 +60,7 @@ OutputType transform_reduce(
 
   using System = typename thrust::iterator_system<InputIterator>::type;
 
-  System system;
+  System system; // NOLINT(misc-const-correctness): select_system requires a mutable lvalue
 
   return thrust::transform_reduce(select_system(system), first, last, unary_op, init, binary_op);
 } // end transform_reduce()

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -272,7 +272,7 @@ void vector_base<T, Alloc>::range_init(InputIterator first, InputIterator last)
   using traversal = typename iterator_traversal<InputIterator>::type;
   if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
   {
-    size_type new_size = ::cuda::std::distance(first, last);
+    const size_type new_size = ::cuda::std::distance(first, last);
 
     allocate_and_copy(new_size, first, last, m_storage);
     m_size = new_size;
@@ -590,7 +590,7 @@ void vector_base<T, Alloc>::push_back(const value_type& x)
 template <typename T, typename Alloc>
 void vector_base<T, Alloc>::pop_back()
 {
-  iterator e           = end();
+  const iterator e     = end();
   iterator ptr_to_back = e;
   --ptr_to_back;
   m_storage.destroy(ptr_to_back, e);
@@ -610,7 +610,7 @@ typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::erase(iterator f
 {
   // overlap copy the range [last,end()) to first
   // XXX this copy only potentially overlaps
-  iterator i = thrust::detail::overlapped_copy(last, end(), first);
+  const iterator i = thrust::detail::overlapped_copy(last, end(), first);
 
   // destroy everything after i
   m_storage.destroy(i, end());
@@ -654,7 +654,7 @@ template <typename T, typename Alloc>
 typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::insert(iterator position, const T& x)
 {
   // find the index of the insertion
-  size_type index = ::cuda::std::distance(begin(), position);
+  const size_type index = ::cuda::std::distance(begin(), position);
 
   // make the insertion
   insert(position, 1, x);
@@ -709,7 +709,7 @@ void vector_base<T, Alloc>::copy_insert(iterator position, ForwardIterator first
       // we've got room for all of them
       // how many existing elements will we displace?
       const size_type num_displaced_elements = end() - position;
-      iterator old_end                       = end();
+      const iterator old_end                 = end();
 
       if (num_displaced_elements > num_new_elements)
       {
@@ -889,8 +889,8 @@ void vector_base<T, Alloc>::fill_insert(iterator position, size_type n, const T&
   {
     // we've got room for all of them
     const size_type num_displaced_elements = end() - position;
-    iterator old_end                       = end();
-    iterator mid                           = position + n;
+    const iterator old_end                 = end();
+    const iterator mid                     = position + n;
 
     if (num_displaced_elements > n)
     {
@@ -992,7 +992,7 @@ void vector_base<T, Alloc>::range_assign(InputIterator first, InputIterator last
     else if (size() >= n)
     {
       // we can already accommodate the new range
-      iterator new_end = thrust::copy(first, last, begin());
+      const iterator new_end = thrust::copy(first, last, begin());
 
       // destroy the elements we don't need
       m_storage.destroy(new_end, end());
@@ -1069,7 +1069,7 @@ void vector_base<T, Alloc>::fill_assign(size_type n, const T& x)
   else
   {
     // fill to existing elements
-    iterator new_end = thrust::fill_n(begin(), n, x);
+    const iterator new_end = thrust::fill_n(begin(), n, x);
 
     // erase the elements after the fill
     erase(new_end, end());
@@ -1130,7 +1130,7 @@ bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 fi
 template <typename InputIterator1, typename InputIterator2>
 bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, thrust::detail::false_type)
 {
-  it_difference_t<InputIterator1> n = ::cuda::std::distance(first1, last1);
+  const it_difference_t<InputIterator1> n = ::cuda::std::distance(first1, last1);
 
   using FromSystem1 = typename thrust::iterator_system<InputIterator1>::type;
   using FromSystem2 = typename thrust::iterator_system<InputIterator2>::type;
@@ -1140,9 +1140,9 @@ bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 fi
   FromSystem1 from_system1;
   FromSystem2 from_system2;
   thrust::host_system_tag to_system;
-  thrust::detail::move_to_system<InputIterator1, FromSystem1, thrust::host_system_tag> rng1(
+  const thrust::detail::move_to_system<InputIterator1, FromSystem1, thrust::host_system_tag> rng1(
     from_system1, to_system, first1, last1);
-  thrust::detail::move_to_system<InputIterator2, FromSystem2, thrust::host_system_tag> rng2(
+  const thrust::detail::move_to_system<InputIterator2, FromSystem2, thrust::host_system_tag> rng2(
     from_system2, to_system, first2, first2 + n);
 
   return thrust::equal(rng1.begin(), rng1.end(), rng2.begin());

--- a/thrust/thrust/device_free.h
+++ b/thrust/thrust/device_free.h
@@ -61,7 +61,7 @@ inline void device_free(thrust::device_ptr<void> ptr)
   using system = thrust::iterator_system<thrust::device_ptr<void>>::type;
 
   // XXX lower to select_system(system) here
-  system s;
+  const system s;
 
   thrust::free(s, ptr);
 }

--- a/thrust/thrust/device_malloc.h
+++ b/thrust/thrust/device_malloc.h
@@ -61,7 +61,7 @@ device_ptr<T> device_malloc(const std::size_t n)
 {
   // using system::detail::generic::select_system;
   // XXX lower to select_system(system) here
-  iterator_system_t<device_ptr<void>> s;
+  const iterator_system_t<device_ptr<void>> s;
   return thrust::device_ptr<T>(thrust::malloc<T>(s, n).get());
 }
 

--- a/thrust/thrust/mr/disjoint_pool.h
+++ b/thrust/thrust/mr/disjoint_pool.h
@@ -119,8 +119,8 @@ public:
   {
     assert(m_options.validate());
 
-    pointer_vector free(m_bookkeeper);
-    pool p(free);
+    const pointer_vector free(m_bookkeeper);
+    const pool p(free);
     m_pools.resize(::cuda::ceil_ilog2(m_options.largest_block_size) - m_smallest_block_log2 + 1, p);
   }
 
@@ -142,8 +142,8 @@ public:
   {
     assert(m_options.validate());
 
-    pointer_vector free(m_bookkeeper);
-    pool p(free);
+    const pointer_vector free(m_bookkeeper);
+    const pool p(free);
     m_pools.resize(::cuda::ceil_ilog2(m_options.largest_block_size) - m_smallest_block_log2 + 1, p);
   }
 
@@ -379,7 +379,7 @@ public:
         // allocate a new block
         if (it != m_cached_oversized.end())
         {
-          std::size_t size_factor = (*it).size / bytes;
+          const std::size_t size_factor = (*it).size / bytes;
           if (size_factor >= m_options.cached_size_cutoff_factor)
           {
             it = m_cached_oversized.end();
@@ -396,7 +396,7 @@ public:
         // allocate a new block
         if (it != m_cached_oversized.end())
         {
-          std::size_t alignment_factor = (*it).alignment / alignment;
+          const std::size_t alignment_factor = (*it).alignment / alignment;
           if (alignment_factor >= m_options.cached_alignment_cutoff_factor)
           {
             it = m_cached_oversized.end();
@@ -420,15 +420,15 @@ public:
 
     // the request is NOT for oversized and/or overaligned memory
     // allocate a block from an appropriate bucket
-    std::size_t bytes_log2 = ::cuda::ceil_ilog2(bytes);
-    std::size_t pool_idx   = bytes_log2 - m_smallest_block_log2;
-    pool& bucket           = m_pools[pool_idx];
+    const std::size_t bytes_log2 = ::cuda::ceil_ilog2(bytes);
+    const std::size_t pool_idx   = bytes_log2 - m_smallest_block_log2;
+    pool& bucket                 = m_pools[pool_idx];
 
     // if the free list of the bucket has no elements, allocate a new chunk
     // and split it into blocks pushed to the free list
     if (bucket.free_blocks.empty())
     {
-      std::size_t bucket_size = static_cast<std::size_t>(1) << bytes_log2;
+      const std::size_t bucket_size = static_cast<std::size_t>(1) << bytes_log2;
 
       std::size_t n = bucket.previous_allocated_count;
       if (n == 0)
@@ -480,14 +480,15 @@ public:
     // the deallocated block is oversized and/or overaligned
     if (n > m_options.largest_block_size || alignment > m_options.alignment)
     {
-      typename oversized_block_vector::iterator it = find_if(m_oversized.begin(), m_oversized.end(), equal_pointers(p));
+      const typename oversized_block_vector::iterator it =
+        find_if(m_oversized.begin(), m_oversized.end(), equal_pointers(p));
       assert(it != m_oversized.end());
 
-      oversized_block_descriptor oversized = *it;
+      const oversized_block_descriptor oversized = *it;
 
       if (m_options.cache_oversized)
       {
-        typename oversized_block_vector::iterator position =
+        const typename oversized_block_vector::iterator position =
           lower_bound(m_cached_oversized.begin(), m_cached_oversized.end(), oversized);
         m_cached_oversized.insert(position, oversized);
         return;
@@ -501,9 +502,9 @@ public:
     }
 
     // push the block to the front of the appropriate bucket's free list
-    std::size_t n_log2   = ::cuda::ceil_ilog2(n);
-    std::size_t pool_idx = n_log2 - m_smallest_block_log2;
-    pool& bucket         = m_pools[pool_idx];
+    const std::size_t n_log2   = ::cuda::ceil_ilog2(n);
+    const std::size_t pool_idx = n_log2 - m_smallest_block_log2;
+    pool& bucket               = m_pools[pool_idx];
 
     bucket.free_blocks.push_back(p);
   }

--- a/thrust/thrust/mr/disjoint_sync_pool.h
+++ b/thrust/thrust/mr/disjoint_sync_pool.h
@@ -75,19 +75,19 @@ public:
    */
   void release()
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     upstream_pool.release();
   }
 
   [[nodiscard]] void_ptr do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     return upstream_pool.do_allocate(bytes, alignment);
   }
 
   void do_deallocate(void_ptr p, std::size_t n, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     upstream_pool.do_deallocate(p, n, alignment);
   }
 

--- a/thrust/thrust/mr/pool.h
+++ b/thrust/thrust/mr/pool.h
@@ -108,7 +108,7 @@ public:
   {
     assert(m_options.validate());
 
-    pool p = {block_descriptor_ptr(), 0};
+    const pool p = {block_descriptor_ptr(), 0};
     m_pools.resize(::cuda::ceil_ilog2(m_options.largest_block_size) - m_smallest_block_log2 + 1, p);
   }
 
@@ -129,7 +129,7 @@ public:
   {
     assert(m_options.validate());
 
-    pool p = {block_descriptor_ptr(), 0};
+    const pool p = {block_descriptor_ptr(), 0};
     m_pools.resize(::cuda::ceil_ilog2(m_options.largest_block_size) - m_smallest_block_log2 + 1, p);
   }
 
@@ -220,10 +220,10 @@ public:
     // deallocate memory allocated for the buckets
     while (::cuda::std::to_address(m_allocated))
     {
-      chunk_descriptor_ptr alloc = m_allocated;
-      m_allocated                = thrust::raw_reference_cast(*m_allocated).next;
+      const chunk_descriptor_ptr alloc = m_allocated;
+      m_allocated                      = thrust::raw_reference_cast(*m_allocated).next;
 
-      void_ptr p = static_cast<void_ptr>(
+      const void_ptr p = static_cast<void_ptr>(
         static_cast<char_ptr>(static_cast<void_ptr>(alloc)) - thrust::raw_reference_cast(*alloc).size);
       m_upstream->do_deallocate(
         p, thrust::raw_reference_cast(*alloc).size + sizeof(chunk_descriptor), m_options.alignment);
@@ -232,12 +232,12 @@ public:
     // deallocate cached oversized/overaligned memory
     while (::cuda::std::to_address(m_oversized))
     {
-      oversized_block_descriptor_ptr alloc = m_oversized;
-      m_oversized                          = thrust::raw_reference_cast(*m_oversized).next;
+      const oversized_block_descriptor_ptr alloc = m_oversized;
+      m_oversized                                = thrust::raw_reference_cast(*m_oversized).next;
 
-      oversized_block_descriptor desc = thrust::raw_reference_cast(*alloc);
+      const oversized_block_descriptor desc = thrust::raw_reference_cast(*alloc);
 
-      void_ptr p = static_cast<void_ptr>(static_cast<char_ptr>(static_cast<void_ptr>(alloc)) - desc.current_size);
+      const void_ptr p = static_cast<void_ptr>(static_cast<char_ptr>(static_cast<void_ptr>(alloc)) - desc.current_size);
       m_upstream->do_deallocate(p, desc.size + sizeof(oversized_block_descriptor), desc.alignment);
     }
 
@@ -266,7 +266,7 @@ public:
           // allocate a new block
           if (is_good)
           {
-            std::size_t size_factor = desc.size / bytes;
+            const std::size_t size_factor = desc.size / bytes;
             if (size_factor >= m_options.cached_size_cutoff_factor)
             {
               is_good = false;
@@ -278,7 +278,7 @@ public:
           // allocate a new block
           if (is_good)
           {
-            std::size_t alignment_factor = desc.alignment / alignment;
+            const std::size_t alignment_factor = desc.alignment / alignment;
             if (alignment_factor >= m_options.cached_alignment_cutoff_factor)
             {
               is_good = false;
@@ -332,8 +332,8 @@ public:
       }
 
       // no fitting cached block found; allocate a new one that's just up to the specs
-      void_ptr allocated = m_upstream->do_allocate(bytes + sizeof(oversized_block_descriptor), alignment);
-      oversized_block_descriptor_ptr block =
+      const void_ptr allocated = m_upstream->do_allocate(bytes + sizeof(oversized_block_descriptor), alignment);
+      const oversized_block_descriptor_ptr block =
         static_cast<oversized_block_descriptor_ptr>(static_cast<void_ptr>(static_cast<char_ptr>(allocated) + bytes));
 
       oversized_block_descriptor desc;
@@ -358,9 +358,9 @@ public:
 
     // the request is NOT for oversized and/or overaligned memory
     // allocate a block from an appropriate bucket
-    std::size_t bytes_log2 = ::cuda::ceil_ilog2(bytes);
-    std::size_t bucket_idx = bytes_log2 - m_smallest_block_log2;
-    pool& bucket           = thrust::raw_reference_cast(m_pools[bucket_idx]);
+    const std::size_t bytes_log2 = ::cuda::ceil_ilog2(bytes);
+    const std::size_t bucket_idx = bytes_log2 - m_smallest_block_log2;
+    pool& bucket                 = thrust::raw_reference_cast(m_pools[bucket_idx]);
 
     bytes = static_cast<std::size_t>(1) << bytes_log2;
 
@@ -390,13 +390,13 @@ public:
         }
       }
 
-      std::size_t descriptor_size = (std::max) (sizeof(block_descriptor), m_options.alignment);
-      std::size_t block_size      = bytes + descriptor_size;
+      const std::size_t descriptor_size = (std::max) (sizeof(block_descriptor), m_options.alignment);
+      std::size_t block_size            = bytes + descriptor_size;
       block_size += m_options.alignment - block_size % m_options.alignment;
-      std::size_t chunk_size = block_size * n;
+      const std::size_t chunk_size = block_size * n;
 
-      void_ptr allocated = m_upstream->do_allocate(chunk_size + sizeof(chunk_descriptor), m_options.alignment);
-      chunk_descriptor_ptr chunk =
+      const void_ptr allocated = m_upstream->do_allocate(chunk_size + sizeof(chunk_descriptor), m_options.alignment);
+      const chunk_descriptor_ptr chunk =
         static_cast<chunk_descriptor_ptr>(static_cast<void_ptr>(static_cast<char_ptr>(allocated) + chunk_size));
 
       chunk_descriptor chunk_desc;
@@ -407,7 +407,7 @@ public:
 
       for (std::size_t i = 0; i < n; ++i)
       {
-        block_descriptor_ptr block = static_cast<block_descriptor_ptr>(
+        const block_descriptor_ptr block = static_cast<block_descriptor_ptr>(
           static_cast<void_ptr>(static_cast<char_ptr>(allocated) + block_size * i + bytes));
 
         block_descriptor block_desc;
@@ -418,8 +418,8 @@ public:
     }
 
     // allocate a block from the front of the bucket's free list
-    block_descriptor_ptr block = bucket.free_list;
-    bucket.free_list           = thrust::raw_reference_cast(*block).next;
+    const block_descriptor_ptr block = bucket.free_list;
+    bucket.free_list                 = thrust::raw_reference_cast(*block).next;
     return static_cast<void_ptr>(static_cast<char_ptr>(static_cast<void_ptr>(block)) - bytes);
   }
 
@@ -491,13 +491,14 @@ public:
     }
 
     // push the block to the front of the appropriate bucket's free list
-    std::size_t n_log2     = ::cuda::ceil_ilog2(n);
-    std::size_t bucket_idx = n_log2 - m_smallest_block_log2;
-    pool& bucket           = thrust::raw_reference_cast(m_pools[bucket_idx]);
+    const std::size_t n_log2     = ::cuda::ceil_ilog2(n);
+    const std::size_t bucket_idx = n_log2 - m_smallest_block_log2;
+    pool& bucket                 = thrust::raw_reference_cast(m_pools[bucket_idx]);
 
     n = static_cast<std::size_t>(1) << n_log2;
 
-    block_descriptor_ptr block = static_cast<block_descriptor_ptr>(static_cast<void_ptr>(static_cast<char_ptr>(p) + n));
+    const block_descriptor_ptr block =
+      static_cast<block_descriptor_ptr>(static_cast<void_ptr>(static_cast<char_ptr>(p) + n));
 
     block_descriptor desc;
     desc.next        = bucket.free_list;

--- a/thrust/thrust/mr/sync_pool.h
+++ b/thrust/thrust/mr/sync_pool.h
@@ -71,19 +71,19 @@ public:
    */
   void release()
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     upstream_pool.release();
   }
 
   [[nodiscard]] void_ptr do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     return upstream_pool.do_allocate(bytes, alignment);
   }
 
   void do_deallocate(void_ptr p, std::size_t n, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-    lock_t lock(mtx);
+    const lock_t lock(mtx);
     upstream_pool.do_deallocate(p, n, alignment);
   }
 

--- a/thrust/thrust/random/detail/mod.h
+++ b/thrust/thrust/random/detail/mod.h
@@ -73,7 +73,7 @@ struct static_mod<T, a, c, m, true>
 template <typename T, T a, T c, T m>
 _CCCL_HOST_DEVICE T mod(T x)
 {
-  static_mod<T, a, c, m> f;
+  const static_mod<T, a, c, m> f;
   return f(x);
 } // end static_mod
 } // namespace random::detail

--- a/thrust/thrust/random/detail/uniform_int_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_int_distribution.inl
@@ -59,7 +59,7 @@ uniform_int_distribution<IntType>::operator()(UniformRandomNumberGenerator& urng
 
   // add one to the right end of the interval because it is half-open
   // XXX adding 1.0 to a potentially large floating point number seems like a bad idea
-  uniform_real_distribution<float_type> real_dist(real_min, real_max + float_type(1));
+  uniform_real_distribution<float_type> real_dist(real_min, real_max + float_type(1)); // NOLINT(misc-const-correctness)
 
   return static_cast<result_type>(real_dist(urng));
 } // end uniform_int_distribution::operator()()

--- a/thrust/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/thrust/system/cuda/detail/copy_if.h
@@ -148,7 +148,7 @@ THRUST_RUNTIME_FUNCTION OutputIt copy_if_with_stencil(
   // Get number of selected items
   status = cuda_cub::synchronize(policy);
   cuda_cub::throw_on_error(status, "copy_if failed on sync");
-  offset_t num_selected = get_value(policy, d_num_selected_out);
+  const offset_t num_selected = get_value(policy, d_num_selected_out);
   ::cuda::std::advance(output, num_selected);
   return output;
 }

--- a/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
+++ b/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
@@ -150,7 +150,7 @@ struct _CCCL_VISIBILITY_HIDDEN triple_chevron
   size_t _CCCL_DEVICE argument_pack_size(size_t size, Args const&...) const
   {
     // TODO(bgruber): replace by fold over comma in C++17 (make sure order of evaluation is left to right!)
-    [[maybe_unused]] int dummy[] = {(size = align_up<Args>(size) + sizeof(Args), 0)...};
+    [[maybe_unused]] const int dummy[] = {(size = align_up<Args>(size) + sizeof(Args), 0)...};
     return size;
   }
 
@@ -170,7 +170,7 @@ struct _CCCL_VISIBILITY_HIDDEN triple_chevron
   _CCCL_DEVICE void fill_arguments(char* buffer, size_t offset, Args const&... args) const
   {
     // TODO(bgruber): replace by fold over comma in C++17 (make sure order of evaluation is left to right!)
-    [[maybe_unused]] int dummy[] = {(copy_arg(buffer, offset, args), 0)...};
+    [[maybe_unused]] const int dummy[] = {(copy_arg(buffer, offset, args), 0)...};
   }
 
 #ifdef THRUST_RDC_ENABLED

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -332,7 +332,7 @@ THRUST_RUNTIME_FUNCTION inline size_t get_max_shared_memory_per_block()
 
 THRUST_RUNTIME_FUNCTION inline size_t vshmem_size(size_t shmem_per_block, size_t num_blocks)
 {
-  size_t max_shmem_per_block = get_max_shared_memory_per_block();
+  const size_t max_shmem_per_block = get_max_shared_memory_per_block();
   if (shmem_per_block > max_shmem_per_block)
   {
     return shmem_per_block * num_blocks;

--- a/thrust/thrust/system/cuda/detail/for_each.h
+++ b/thrust/thrust/system/cuda/detail/for_each.h
@@ -51,8 +51,8 @@ template <class Derived, class Input, class UnaryOp>
 Input _CCCL_HOST_DEVICE_API _CCCL_FORCEINLINE
 for_each(execution_policy<Derived>& policy, Input first, Input last, UnaryOp op)
 {
-  using size_type = thrust::detail::it_difference_t<Input>;
-  size_type count = static_cast<size_type>(::cuda::std::distance(first, last));
+  using size_type       = thrust::detail::it_difference_t<Input>;
+  const size_type count = static_cast<size_type>(::cuda::std::distance(first, last));
 
   return THRUST_NS_QUALIFIER::cuda_cub::for_each_n(policy, first, count, op);
 }

--- a/thrust/thrust/system/cuda/detail/malloc_and_free.h
+++ b/thrust/thrust/system/cuda/detail/malloc_and_free.h
@@ -67,7 +67,7 @@ _CCCL_HOST_DEVICE void* malloc(execution_policy<DerivedPolicy>&, std::size_t n)
 #else // not __CUB_CACHING_MALLOC
   NV_IF_TARGET(
     NV_IS_HOST,
-    (cudaError_t status = cudaMalloc(&result, n);
+    (const cudaError_t status = cudaMalloc(&result, n);
 
      if (status != cudaSuccess) {
        cudaGetLastError(); // Clear global CUDA error state.
@@ -96,7 +96,7 @@ _CCCL_HOST_DEVICE void free(execution_policy<DerivedPolicy>&, Pointer ptr)
       thrust::free(thrust::seq, ptr);));
 #else // not __CUB_CACHING_MALLOC
   NV_IF_TARGET(NV_IS_HOST,
-               (cudaError_t status = cudaFree(thrust::raw_pointer_cast(ptr));
+               (const cudaError_t status = cudaFree(thrust::raw_pointer_cast(ptr));
                 cuda_cub::throw_on_error(status, "device free failed");),
                ( // NV_IS_DEVICE
                  thrust::free(thrust::seq, ptr);));

--- a/thrust/thrust/system/cuda/detail/memory.inl
+++ b/thrust/thrust/system/cuda/detail/memory.inl
@@ -29,7 +29,7 @@ _CCCL_HOST_DEVICE pointer<void> malloc(std::size_t n)
 template <typename T>
 _CCCL_HOST_DEVICE pointer<T> malloc(std::size_t n)
 {
-  pointer<void> raw_ptr = thrust::cuda_cub::malloc(sizeof(T) * n);
+  const pointer<void> raw_ptr = thrust::cuda_cub::malloc(sizeof(T) * n);
   return pointer<T>(reinterpret_cast<T*>(raw_ptr.get()));
 } // end malloc()
 

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -176,9 +176,9 @@ THRUST_RUNTIME_FUNCTION ::cuda::std::pair<SelectedOutIt, RejectedOutIt> stable_p
     return ::cuda::std::make_pair(selected_result, rejected_result);
   }
 
-  using output_it_wrapper_t = cub::detail::select::partition_distinct_output_t<SelectedOutIt, RejectedOutIt>;
-  std::size_t num_items     = static_cast<std::size_t>(::cuda::std::distance(first, last));
-  std::size_t num_selected =
+  using output_it_wrapper_t   = cub::detail::select::partition_distinct_output_t<SelectedOutIt, RejectedOutIt>;
+  const std::size_t num_items = static_cast<std::size_t>(::cuda::std::distance(first, last));
+  const std::size_t num_selected =
     partition(policy, first, last, stencil, output_it_wrapper_t{selected_result, rejected_result}, predicate);
   return ::cuda::std::make_pair(selected_result + num_selected, rejected_result + num_items - num_selected);
 }
@@ -193,15 +193,15 @@ THRUST_RUNTIME_FUNCTION InputIt inplace_partition(
   }
 
   // Element type of the input iterator
-  using value_t         = thrust::detail::it_value_t<InputIt>;
-  std::size_t num_items = static_cast<std::size_t>(::cuda::std::distance(first, last));
+  using value_t               = thrust::detail::it_value_t<InputIt>;
+  const std::size_t num_items = static_cast<std::size_t>(::cuda::std::distance(first, last));
 
   // Allocate temporary storage, which will serve as the input to the partition
   thrust::detail::temporary_array<value_t, Derived> tmp(policy, num_items);
   cuda_cub::uninitialized_copy(policy, first, last, tmp.begin());
 
   // Partition input from temporary storage to the user-provided range [`first`, `last`)
-  std::size_t num_selected =
+  const std::size_t num_selected =
     partition(policy, tmp.data().get(), tmp.data().get() + num_items, stencil, first, predicate);
   return first + num_selected;
 }

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -175,7 +175,7 @@ _CCCL_HOST_DEVICE T reduce(execution_policy<Derived>& policy, InputIt first, Inp
 {
   using size_type = thrust::detail::it_difference_t<InputIt>;
   // FIXME: Check for RA iterator.
-  size_type num_items = static_cast<size_type>(::cuda::std::distance(first, last));
+  const size_type num_items = static_cast<size_type>(::cuda::std::distance(first, last));
   return cuda_cub::reduce_n(policy, first, num_items, init, binary_op);
 }
 
@@ -199,7 +199,7 @@ reduce_into(execution_policy<Derived>& policy, InputIt first, InputIt last, Outp
 {
   using size_type = thrust::detail::it_difference_t<InputIt>;
   // FIXME: Check for RA iterator.
-  size_type num_items = static_cast<size_type>(::cuda::std::distance(first, last));
+  const size_type num_items = static_cast<size_type>(::cuda::std::distance(first, last));
   cuda_cub::reduce_n_into(policy, first, num_items, output, init, binary_op);
 }
 

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -321,7 +321,7 @@ struct ReduceByKeyAgent
       {
         if (segment_flags[ITEM])
         {
-          int idx                   = static_cast<int>(segment_indices[ITEM] - num_tile_segments_prefix);
+          const int idx             = static_cast<int>(segment_indices[ITEM] - num_tile_segments_prefix);
           storage.raw_exchange[idx] = scatter_items[ITEM];
         }
       }
@@ -330,10 +330,10 @@ struct ReduceByKeyAgent
 
       for (int item = static_cast<int>(threadIdx.x); item < num_tile_segments; item += BLOCK_THREADS)
       {
-        size_type idx         = num_tile_segments_prefix + item;
-        key_value_pair_t pair = storage.raw_exchange[item];
-        keys_output_it[idx]   = pair.key;
-        values_output_it[idx] = pair.value;
+        const size_type idx         = num_tile_segments_prefix + item;
+        const key_value_pair_t pair = storage.raw_exchange[item];
+        keys_output_it[idx]         = pair.key;
+        values_output_it[idx]       = pair.value;
       }
     }
 
@@ -509,7 +509,7 @@ struct ReduceByKeyAgent
         BlockLoadKeys(storage.load_keys).Load(keys_load_it + tile_offset, keys);
       }
 
-      key_type tile_pred_key = (threadIdx.x == 0) ? key_type(keys_load_it[tile_offset - 1]) : key_type();
+      const key_type tile_pred_key = (threadIdx.x == 0) ? key_type(keys_load_it[tile_offset - 1]) : key_type();
 
       __syncthreads();
 
@@ -537,7 +537,7 @@ struct ReduceByKeyAgent
       size_value_pair_t tile_aggregate;
       TilePrefixCallback prefix_op(tile_state, storage.scan_storage.prefix, scan_op, tile_idx);
       scan_tile(scan_items, tile_aggregate, prefix_op);
-      size_value_pair_t tile_inclusive_prefix = prefix_op.GetInclusivePrefix();
+      const size_value_pair_t tile_inclusive_prefix = prefix_op.GetInclusivePrefix();
 
       // Unzip values and segment indices
       zip_keys_and_values(pred_keys, segment_indices, scan_items, scatter_items);
@@ -594,7 +594,7 @@ struct ReduceByKeyAgent
       // Blocks are launched in increasing order,
       // so just assign one tile per block
       //
-      int tile_idx       = static_cast<int>(blockIdx.x);
+      const int tile_idx = static_cast<int>(blockIdx.x);
       Size tile_offset   = static_cast<Size>(tile_idx) * ITEMS_PER_TILE;
       Size num_remaining = num_items - tile_offset;
 
@@ -707,10 +707,10 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
   AgentPlan init_plan          = init_agent::get_plan();
 
   // Number of input tiles
-  int tile_size  = reduce_by_key_plan.items_per_tile;
-  Size num_tiles = ::cuda::ceil_div(num_items, tile_size);
+  const int tile_size = reduce_by_key_plan.items_per_tile;
+  Size num_tiles      = ::cuda::ceil_div(num_items, tile_size);
 
-  size_t vshmem_size = core::detail::vshmem_size(reduce_by_key_plan.shared_memory_size, num_tiles);
+  const size_t vshmem_size = core::detail::vshmem_size(reduce_by_key_plan.shared_memory_size, num_tiles);
 
   size_t allocation_sizes[2] = {9, vshmem_size};
   status                     = ScanTileState::AllocationSize(static_cast<int>(num_tiles), allocation_sizes[0]);
@@ -729,13 +729,14 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
   status = tile_state.Init(static_cast<int>(num_tiles), allocations[0], allocation_sizes[0]);
   _CUDA_CUB_RET_IF_FAIL(status);
 
-  init_agent ia(init_plan, num_tiles, stream, "reduce_by_key::init_agent");
+  const init_agent ia(init_plan, num_tiles, stream, "reduce_by_key::init_agent");
   ia.launch(tile_state, num_tiles, num_runs_output_it);
   _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
   char* vshmem_ptr = vshmem_size > 0 ? (char*) allocations[1] : nullptr;
 
-  reduce_by_key_agent rbka(reduce_by_key_plan, num_items, stream, vshmem_ptr, "reduce_by_keys::reduce_by_key_agent");
+  const reduce_by_key_agent rbka(
+    reduce_by_key_plan, num_items, stream, vshmem_ptr, "reduce_by_keys::reduce_by_key_agent");
   rbka.launch(
     keys_input_it,
     values_input_it,
@@ -849,7 +850,7 @@ THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> reduce_b
 {
   using size_type = thrust::detail::it_difference_t<KeysInputIt>;
 
-  size_type num_items = ::cuda::std::distance(keys_first, keys_last);
+  const size_type num_items = ::cuda::std::distance(keys_first, keys_last);
 
   ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> result = ::cuda::std::make_pair(keys_output, values_output);
 

--- a/thrust/thrust/system/cuda/detail/remove.h
+++ b/thrust/thrust/system/cuda/detail/remove.h
@@ -76,7 +76,7 @@ template <class Derived, class InputIt, class OutputIt, class T>
 OutputIt _CCCL_HOST_DEVICE
 remove_copy(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, const T& value)
 {
-  ::cuda::equal_to_value<T> pred{value};
+  const ::cuda::equal_to_value<T> pred{value};
   return cuda_cub::remove_copy_if(policy, first, last, result, pred);
 }
 } // namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/reverse.h
+++ b/thrust/thrust/system/cuda/detail/reverse.h
@@ -49,7 +49,7 @@ void _CCCL_HOST_DEVICE reverse(execution_policy<Derived>& policy, ItemsIt first,
   using difference_type = thrust::detail::it_difference_t<ItemsIt>;
 
   // find the midpoint of [first,last)
-  difference_type N = ::cuda::std::distance(first, last);
+  const difference_type N = ::cuda::std::distance(first, last);
   ItemsIt mid(first);
   ::cuda::std::advance(mid, N / 2);
 

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -50,8 +50,8 @@ binary_search_iteration(It data, Size& begin, Size& end, T key, int shift, Comp 
   IntT scale = (1 << shift) - 1;
   Size mid   = (begin + scale * end) >> shift;
 
-  T key2    = data[mid];
-  bool pred = UpperBound ? !comp(key, key2) : comp(key2, key);
+  T key2          = data[mid];
+  const bool pred = UpperBound ? !comp(key, key2) : comp(key2, key);
   if (pred)
   {
     begin = mid + 1;
@@ -114,10 +114,10 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE Size merge_path(It1 a, Size aCount, It2 b, Si
 
   while (begin < end)
   {
-    Size mid  = (begin + end) >> 1;
-    T aKey    = a[mid];
-    T bKey    = b[diag - 1 - mid];
-    bool pred = UpperBound ? comp(aKey, bKey) : !comp(bKey, aKey);
+    Size mid        = (begin + end) >> 1;
+    const T aKey    = a[mid];
+    const T bKey    = b[diag - 1 - mid];
+    const bool pred = UpperBound ? comp(aKey, bKey) : !comp(bKey, aKey);
     if (pred)
     {
       begin = mid + 1;
@@ -142,7 +142,7 @@ balanced_path(It1 keys1, It2 keys2, Size num_keys1, Size num_keys2, Size diag, S
   bool star = false;
   if (index2 < num_keys2)
   {
-    T x = keys2[index2];
+    const T x = keys2[index2];
 
     // Search for the beginning of the duplicate run in both A and B.
     Size start1 = biased_binary_search<false>(keys1, index1, x, levels, compare_op);
@@ -165,7 +165,7 @@ balanced_path(It1 keys1, It2 keys2, Size num_keys1, Size num_keys2, Size diag, S
     advance2      = min<Size>(advance2, run2);
     Size advance1 = total_run - advance2;
 
-    bool round_up = (advance1 == advance2 + 1) && (advance2 < run2);
+    const bool round_up = (advance1 == advance2 + 1) && (advance2 < run2);
     if (round_up)
     {
       star = true;
@@ -360,14 +360,14 @@ struct SetOpAgent
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD - 1; ++ITEM)
         {
-          int idx      = BLOCK_THREADS * ITEM + threadIdx.x;
-          output[ITEM] = (idx < count1) ? static_cast<T>(input1[idx]) : static_cast<T>(input2[idx - count1]);
+          const int idx = BLOCK_THREADS * ITEM + threadIdx.x;
+          output[ITEM]  = (idx < count1) ? static_cast<T>(input1[idx]) : static_cast<T>(input2[idx - count1]);
         }
 
         // last ITEM might be a conditional load even for full tiles
         // please check first before attempting to load.
-        int ITEM = ITEMS_PER_THREAD - 1;
-        int idx  = BLOCK_THREADS * ITEM + threadIdx.x;
+        const int ITEM = ITEMS_PER_THREAD - 1;
+        const int idx  = BLOCK_THREADS * ITEM + threadIdx.x;
         if (idx < count1 + count2)
         {
           output[ITEM] = (idx < count1) ? static_cast<T>(input1[idx]) : static_cast<T>(input2[idx - count1]);
@@ -378,7 +378,7 @@ struct SetOpAgent
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
-          int idx = BLOCK_THREADS * ITEM + threadIdx.x;
+          const int idx = BLOCK_THREADS * ITEM + threadIdx.x;
           if (idx < count1 + count2)
           {
             output[ITEM] = (idx < count1) ? static_cast<T>(input1[idx]) : static_cast<T>(input2[idx - count1]);
@@ -393,8 +393,8 @@ struct SetOpAgent
       _CCCL_PRAGMA_UNROLL_FULL()
       for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
       {
-        int idx     = BLOCK_THREADS * ITEM + threadIdx.x;
-        output[idx] = input[ITEM];
+        const int idx = BLOCK_THREADS * ITEM + threadIdx.x;
+        output[idx]   = input[ITEM];
       }
     }
 
@@ -437,7 +437,7 @@ struct SetOpAgent
       CompareOp compare_op,
       SetOp set_op)
     {
-      int active_mask = set_op(keys, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op);
+      const int active_mask = set_op(keys, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op);
 
       return active_mask;
     }
@@ -449,8 +449,8 @@ struct SetOpAgent
     template <bool IS_LAST_TILE>
     void _CCCL_DEVICE_API _CCCL_FORCEINLINE consume_tile(Size tile_idx)
     {
-      ::cuda::std::pair<Size, Size> partition_beg = partitions[tile_idx + 0];
-      ::cuda::std::pair<Size, Size> partition_end = partitions[tile_idx + 1];
+      const ::cuda::std::pair<Size, Size> partition_beg = partitions[tile_idx + 0];
+      const ::cuda::std::pair<Size, Size> partition_end = partitions[tile_idx + 1];
 
       Size keys1_beg = partition_beg.first;
       Size keys1_end = partition_end.first;
@@ -459,8 +459,8 @@ struct SetOpAgent
 
       // number of keys per tile
       //
-      int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
-      int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
+      const int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
+      const int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
 
       // load keys into shared memory for further processing
       key_type keys_loc[ITEMS_PER_THREAD];
@@ -471,9 +471,9 @@ struct SetOpAgent
 
       __syncthreads();
 
-      int diag_loc = min<int>(ITEMS_PER_THREAD * threadIdx.x, num_keys1 + num_keys2);
+      const int diag_loc = min<int>(ITEMS_PER_THREAD * threadIdx.x, num_keys1 + num_keys2);
 
-      ::cuda::std::pair<int, int> partition_loc = balanced_path(
+      const ::cuda::std::pair<int, int> partition_loc = balanced_path(
         &storage.load_storage.keys_shared[0],
         &storage.load_storage.keys_shared[num_keys1],
         num_keys1,
@@ -482,32 +482,33 @@ struct SetOpAgent
         4,
         compare_op);
 
-      int keys1_beg_loc = partition_loc.first;
-      int keys2_beg_loc = partition_loc.second;
+      const int keys1_beg_loc = partition_loc.first;
+      const int keys2_beg_loc = partition_loc.second;
 
       // compute difference between next and current thread
       // to obtain number of elements per thread
-      int value = threadIdx.x == 0 ? (num_keys1 << 16) | num_keys2 : (partition_loc.first << 16) | partition_loc.second;
+      const int value =
+        threadIdx.x == 0 ? (num_keys1 << 16) | num_keys2 : (partition_loc.first << 16) | partition_loc.second;
 
-      int dst                          = threadIdx.x == 0 ? BLOCK_THREADS - 1 : threadIdx.x - 1;
+      const int dst                    = threadIdx.x == 0 ? BLOCK_THREADS - 1 : threadIdx.x - 1;
       storage.load_storage.offset[dst] = value;
 
       __syncthreads();
 
-      ::cuda::std::pair<int, int> partition1_loc = ::cuda::std::make_pair(
+      const ::cuda::std::pair<int, int> partition1_loc = ::cuda::std::make_pair(
         storage.load_storage.offset[threadIdx.x] >> 16, storage.load_storage.offset[threadIdx.x] & 0xFFFF);
 
-      int keys1_end_loc = partition1_loc.first;
-      int keys2_end_loc = partition1_loc.second;
+      const int keys1_end_loc = partition1_loc.first;
+      const int keys2_end_loc = partition1_loc.second;
 
-      int num_keys1_loc = keys1_end_loc - keys1_beg_loc;
-      int num_keys2_loc = keys2_end_loc - keys2_beg_loc;
+      const int num_keys1_loc = keys1_end_loc - keys1_beg_loc;
+      const int num_keys2_loc = keys2_end_loc - keys2_beg_loc;
 
       // perform serial set operation
       //
       int indices[ITEMS_PER_THREAD];
 
-      int active_mask = serial_set_op(
+      const int active_mask = serial_set_op(
         &storage.load_storage.keys_shared[0],
         keys1_beg_loc,
         keys2_beg_loc + num_keys1,
@@ -636,8 +637,8 @@ struct SetOpAgent
         , partitions(partitions_)
         , output_count(output_count_)
     {
-      int tile_idx  = static_cast<int>(blockIdx.x);
-      int num_tiles = static_cast<int>(gridDim.x);
+      const int tile_idx  = static_cast<int>(blockIdx.x);
+      const int num_tiles = static_cast<int>(gridDim.x);
 
       if (tile_idx < num_tiles - 1)
       {
@@ -717,7 +718,7 @@ struct PartitionAgent
     if (partition_idx < num_partitions)
     {
       Size partition_at = min<Size>(partition_idx * items_per_tile, keys1_count + keys2_count);
-      ::cuda::std::pair<Size, Size> diag =
+      const ::cuda::std::pair<Size, Size> diag =
         balanced_path(keys1, keys2, keys1_count, keys2_count, partition_at, 4ll, compare_op);
       partitions[partition_idx] = diag;
     }
@@ -766,10 +767,10 @@ struct serial_set_intersection
   {
     int active_mask = 0;
 
-    int aBegin = keys1_beg;
-    int bBegin = keys2_beg;
-    int aEnd   = keys1_beg + keys1_count;
-    int bEnd   = keys2_beg + keys2_count;
+    int aBegin     = keys1_beg;
+    int bBegin     = keys2_beg;
+    const int aEnd = keys1_beg + keys1_count;
+    const int bEnd = keys2_beg + keys2_count;
 
     T aKey = keys[aBegin];
     T bKey = keys[bBegin];
@@ -777,8 +778,8 @@ struct serial_set_intersection
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < ITEMS_PER_THREAD; ++i)
     {
-      bool pA = compare_op(aKey, bKey);
-      bool pB = compare_op(bKey, aKey);
+      const bool pA = compare_op(aKey, bKey);
+      const bool pB = compare_op(bKey, aKey);
 
       // The outputs must come from A by definition of set intersection.
       output[i]  = aKey;
@@ -821,11 +822,11 @@ struct serial_set_symmetric_difference
   {
     int active_mask = 0;
 
-    int aBegin = keys1_beg;
-    int bBegin = keys2_beg;
-    int aEnd   = keys1_beg + keys1_count;
-    int bEnd   = keys2_beg + keys2_count;
-    int end    = aEnd + bEnd;
+    int aBegin     = keys1_beg;
+    int bBegin     = keys2_beg;
+    const int aEnd = keys1_beg + keys1_count;
+    const int bEnd = keys2_beg + keys2_count;
+    const int end  = aEnd + bEnd;
 
     T aKey = keys[aBegin];
     T bKey = keys[bBegin];
@@ -883,11 +884,11 @@ struct serial_set_difference
   {
     int active_mask = 0;
 
-    int aBegin = keys1_beg;
-    int bBegin = keys2_beg;
-    int aEnd   = keys1_beg + keys1_count;
-    int bEnd   = keys2_beg + keys2_count;
-    int end    = aEnd + bEnd;
+    int aBegin     = keys1_beg;
+    int bBegin     = keys2_beg;
+    const int aEnd = keys1_beg + keys1_count;
+    const int bEnd = keys2_beg + keys2_count;
+    const int end  = aEnd + bEnd;
 
     T aKey = keys[aBegin];
     T bKey = keys[bBegin];
@@ -945,11 +946,11 @@ struct serial_set_union
   {
     int active_mask = 0;
 
-    int aBegin = keys1_beg;
-    int bBegin = keys2_beg;
-    int aEnd   = keys1_beg + keys1_count;
-    int bEnd   = keys2_beg + keys2_count;
-    int end    = aEnd + bEnd;
+    int aBegin     = keys1_beg;
+    int bBegin     = keys2_beg;
+    const int aEnd = keys1_beg + keys1_count;
+    const int bEnd = keys2_beg + keys2_count;
+    const int end  = aEnd + bEnd;
 
     T aKey = keys[aBegin];
     T bKey = keys[bBegin];
@@ -1037,15 +1038,15 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   AgentPlan init_plan      = init_agent::get_plan();
   AgentPlan partition_plan = partition_agent::get_plan();
 
-  int tile_size  = set_op_plan.items_per_tile;
-  Size num_tiles = (keys_total + tile_size - 1) / tile_size;
+  const int tile_size = set_op_plan.items_per_tile;
+  Size num_tiles      = (keys_total + tile_size - 1) / tile_size;
 
   size_t tile_agent_storage;
   status = ScanTileState::AllocationSize(static_cast<int>(num_tiles), tile_agent_storage);
   _CUDA_CUB_RET_IF_FAIL(status);
 
-  size_t vshmem_storage          = core::detail::vshmem_size(set_op_plan.shared_memory_size, num_tiles);
-  size_t partition_agent_storage = (num_tiles + 1) * sizeof(Size) * 2;
+  const size_t vshmem_storage          = core::detail::vshmem_size(set_op_plan.shared_memory_size, num_tiles);
+  const size_t partition_agent_storage = (num_tiles + 1) * sizeof(Size) * 2;
 
   void* allocations[3]       = {nullptr, nullptr, nullptr};
   size_t allocation_sizes[3] = {tile_agent_storage, partition_agent_storage, vshmem_storage};
@@ -1065,15 +1066,15 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   ::cuda::std::pair<Size, Size>* partitions = (::cuda::std::pair<Size, Size>*) allocations[1];
   char* vshmem_ptr                          = vshmem_storage > 0 ? (char*) allocations[2] : nullptr;
 
-  init_agent ia(init_plan, num_tiles, stream, "set_op::init_agent");
+  const init_agent ia(init_plan, num_tiles, stream, "set_op::init_agent");
   ia.launch(tile_state, num_tiles);
   _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
-  partition_agent pa(partition_plan, num_tiles + 1, stream, "set_op::partition agent");
+  const partition_agent pa(partition_plan, num_tiles + 1, stream, "set_op::partition agent");
   pa.launch(keys1, keys2, num_keys1, num_keys2, num_tiles + 1, partitions, compare_op, tile_size);
   _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
-  set_op_agent sa(set_op_plan, keys_total, stream, vshmem_ptr, "set_op::set_op_agent");
+  const set_op_agent sa(set_op_plan, keys_total, stream, vshmem_ptr, "set_op::set_op_agent");
   sa.launch(
     keys1,
     keys2,
@@ -1118,8 +1119,8 @@ THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> set_oper
 {
   using size_type = thrust::detail::it_difference_t<KeysIt1>;
 
-  size_type num_keys1 = static_cast<size_type>(::cuda::std::distance(keys1_first, keys1_last));
-  size_type num_keys2 = static_cast<size_type>(::cuda::std::distance(keys2_first, keys2_last));
+  const size_type num_keys1 = static_cast<size_type>(::cuda::std::distance(keys1_first, keys1_last));
+  const size_type num_keys2 = static_cast<size_type>(::cuda::std::distance(keys2_first, keys2_last));
 
   if (num_keys1 + num_keys2 == 0)
   {
@@ -1192,7 +1193,7 @@ THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> set_oper
   status = cuda_cub::synchronize(policy);
   cuda_cub::throw_on_error(status, "set_operations failed to synchronize");
 
-  std::size_t output_count = cuda_cub::get_value(policy, d_output_count);
+  const std::size_t output_count = cuda_cub::get_value(policy, d_output_count);
 
   return ::cuda::std::make_pair(keys_output + output_count, values_output + output_count);
 }

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -106,7 +106,7 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
     return cudaSuccess;
   }
 
-  thrust::detail::integral_constant<bool, SORT_ITEMS::value> sort_items{};
+  const thrust::detail::integral_constant<bool, SORT_ITEMS::value> sort_items{};
 
   return doit_step(d_temp_storage, temp_storage_bytes, keys, items, keys_count, compare_op, stream, sort_items);
 }
@@ -118,7 +118,7 @@ THRUST_RUNTIME_FUNCTION void merge_sort(
 {
   using size_type = thrust::detail::it_difference_t<KeysIt>;
 
-  size_type count = static_cast<size_type>(::cuda::std::distance(keys_first, keys_last));
+  const size_type count = static_cast<size_type>(::cuda::std::distance(keys_first, keys_last));
 
   size_t storage_size = 0;
   cudaStream_t stream = cuda_cub::stream(policy);
@@ -234,10 +234,10 @@ THRUST_RUNTIME_FUNCTION void radix_sort(execution_policy<Derived>& policy, Key* 
     dispatch<SORT_ITEMS, CompareOp>::doit(nullptr, temp_storage_bytes, keys_buffer, items_buffer, keys_count, stream);
   cuda_cub::throw_on_error(status, "radix_sort: failed on 1st step");
 
-  size_t keys_temp_storage  = ::cuda::round_up(sizeof(Key) * keys_count, 128);
-  size_t items_temp_storage = ::cuda::round_up(sizeof(Item) * items_count, 128);
+  const size_t keys_temp_storage  = ::cuda::round_up(sizeof(Key) * keys_count, 128);
+  const size_t items_temp_storage = ::cuda::round_up(sizeof(Item) * items_count, 128);
 
-  size_t storage_size = keys_temp_storage + items_temp_storage + temp_storage_bytes;
+  const size_t storage_size = keys_temp_storage + items_temp_storage + temp_storage_bytes;
 
   // Allocate temporary storage.
   thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, storage_size);

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -40,7 +40,7 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
   using value_type  = ::cuda::std::remove_cvref_t<result_type>;
 
   using size_type              = thrust::detail::it_difference_t<InputIt>;
-  size_type num_items          = static_cast<size_type>(::cuda::std::distance(first, last));
+  const size_type num_items    = static_cast<size_type>(::cuda::std::distance(first, last));
   using transformed_iterator_t = transform_iterator<TransformOp, InputIt, value_type, value_type>;
 
   return cuda_cub::inclusive_scan_n(policy, transformed_iterator_t(first, transform_op), num_items, result, scan_op);
@@ -61,7 +61,7 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
   using value_type  = ::cuda::std::remove_cvref_t<result_type>;
 
   using size_type              = thrust::detail::it_difference_t<InputIt>;
-  size_type num_items          = static_cast<size_type>(::cuda::std::distance(first, last));
+  const size_type num_items    = static_cast<size_type>(::cuda::std::distance(first, last));
   using transformed_iterator_t = transform_iterator<TransformOp, InputIt, value_type, value_type>;
 
   return cuda_cub::inclusive_scan_n(
@@ -82,7 +82,7 @@ OutputIt _CCCL_HOST_DEVICE transform_exclusive_scan(
   using result_type = ::cuda::std::remove_cvref_t<InitialValueType>;
 
   using size_type              = thrust::detail::it_difference_t<InputIt>;
-  size_type num_items          = static_cast<size_type>(::cuda::std::distance(first, last));
+  const size_type num_items    = static_cast<size_type>(::cuda::std::distance(first, last));
   using transformed_iterator_t = transform_iterator<TransformOp, InputIt, result_type, result_type>;
 
   return cuda_cub::exclusive_scan_n(

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -82,7 +82,7 @@ THRUST_RUNTIME_FUNCTION cudaError_t unique_by_key_impl(
   std::size_t allocation_sizes[2] = {0, sizeof(OffsetT)};
   void* allocations[2]            = {nullptr, nullptr};
 
-  thrust::detail::wrapped_function<BinaryPred, bool> wrapped_pred{binary_pred};
+  const thrust::detail::wrapped_function<BinaryPred, bool> wrapped_pred{binary_pred};
 
   // Query temp storage
   cudaError_t status = cub::DeviceSelect::UniqueByKey(

--- a/thrust/thrust/system/cuda/memory_resource.h
+++ b/thrust/thrust/system/cuda/memory_resource.h
@@ -43,7 +43,7 @@ public:
   Pointer do_allocate(std::size_t bytes, [[maybe_unused]] std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
     void* ret;
-    cudaError_t status = Alloc(&ret, bytes);
+    const cudaError_t status = Alloc(&ret, bytes);
 
     if (status != cudaSuccess)
     {

--- a/thrust/thrust/system/detail/error_category.inl
+++ b/thrust/thrust/system/detail/error_category.inl
@@ -40,7 +40,7 @@ bool error_category ::equivalent(int code, const error_condition& condition) con
 
 bool error_category ::equivalent(const error_code& code, int condition) const
 {
-  bool result = (this->operator==(code.category())) && (code.value() == condition);
+  const bool result = (this->operator==(code.category())) && (code.value() == condition);
   return result;
 } // end error_code::equivalent()
 

--- a/thrust/thrust/system/detail/generic/adjacent_difference.inl
+++ b/thrust/thrust/system/detail/generic/adjacent_difference.inl
@@ -27,7 +27,7 @@ _CCCL_HOST_DEVICE OutputIterator adjacent_difference(
   thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
   using InputType = thrust::detail::it_value_t<InputIterator>;
-  ::cuda::std::minus<InputType> binary_op;
+  const ::cuda::std::minus<InputType> binary_op;
 
   return thrust::adjacent_difference(exec, first, last, result, binary_op);
 } // end adjacent_difference()

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -66,7 +66,7 @@ struct bsf
   {
     RandomAccessIterator iter = thrust::system::detail::generic::scalar::lower_bound(begin, end, value, comp);
 
-    thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+    const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
     return iter != end && !wrapped_comp(value, *iter);
   }
@@ -144,7 +144,7 @@ _CCCL_HOST_DEVICE OutputType binary_search(
 
   { // copy value to device
     using value_in_system_t = typename thrust::iterator_system<const T*>::type;
-    value_in_system_t value_in_system;
+    const value_in_system_t value_in_system;
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
                                  thrust::detail::derived_cast(thrust::detail::strip_const(exec))),
@@ -160,7 +160,7 @@ _CCCL_HOST_DEVICE OutputType binary_search(
   OutputType output;
   { // copy result to host and return
     using result_out_system_t = typename thrust::iterator_system<OutputType*>::type;
-    result_out_system_t result_out_system;
+    const result_out_system_t result_out_system;
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(exec)),
                                  thrust::detail::derived_cast(thrust::detail::strip_const(result_out_system))),

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -144,7 +144,8 @@ _CCCL_HOST_DEVICE OutputType binary_search(
 
   { // copy value to device
     using value_in_system_t = typename thrust::iterator_system<const T*>::type;
-    const value_in_system_t value_in_system;
+    // thrust systems must be mutable
+    value_in_system_t value_in_system; // NOLINT(misc-const-correctness)
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
                                  thrust::detail::derived_cast(thrust::detail::strip_const(exec))),
@@ -160,7 +161,8 @@ _CCCL_HOST_DEVICE OutputType binary_search(
   OutputType output;
   { // copy result to host and return
     using result_out_system_t = typename thrust::iterator_system<OutputType*>::type;
-    const result_out_system_t result_out_system;
+    // thrust systems must be mutable
+    result_out_system_t result_out_system; // NOLINT(misc-const-correctness)
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(exec)),
                                  thrust::detail::derived_cast(thrust::detail::strip_const(result_out_system))),

--- a/thrust/thrust/system/detail/generic/copy.inl
+++ b/thrust/thrust/system/detail/generic/copy.inl
@@ -44,7 +44,7 @@ copy_n(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, Size 
   using iterator_tuple = ::cuda::std::tuple<InputIterator, OutputIterator>;
   using zip_iter       = thrust::zip_iterator<iterator_tuple>;
 
-  zip_iter zipped = thrust::make_zip_iterator(first, result);
+  const zip_iter zipped = thrust::make_zip_iterator(first, result);
 
   return ::cuda::std::get<1>(thrust::for_each_n(exec, zipped, n, functor_type{xfrm_type()}).get_iterator_tuple());
 } // end copy_n()

--- a/thrust/thrust/system/detail/generic/count.inl
+++ b/thrust/thrust/system/detail/generic/count.inl
@@ -61,8 +61,8 @@ count_if(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, Inp
   using InputType = thrust::detail::it_value_t<InputIterator>;
   using CountType = thrust::detail::it_difference_t<InputIterator>;
 
-  thrust::system::detail::generic::count_if_transform<InputType, Predicate, CountType> unary_op(pred);
-  ::cuda::std::plus<CountType> binary_op;
+  const thrust::system::detail::generic::count_if_transform<InputType, Predicate, CountType> unary_op(pred);
+  const ::cuda::std::plus<CountType> binary_op;
   return thrust::transform_reduce(exec, first, last, unary_op, CountType(0), binary_op);
 } // end count_if()
 } // namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/find.inl
+++ b/thrust/thrust/system/detail/generic/find.inl
@@ -87,8 +87,8 @@ find_if(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, Inpu
   IteratorTuple iter_tuple =
     ::cuda::std::make_tuple(XfrmIterator(first, pred), thrust::counting_iterator<difference_type>(0));
 
-  ZipIterator begin = thrust::make_zip_iterator(iter_tuple);
-  ZipIterator end   = begin + n;
+  const ZipIterator begin = thrust::make_zip_iterator(iter_tuple);
+  const ZipIterator end   = begin + n;
 
   for (ZipIterator interval_begin = begin; interval_begin < end; interval_begin += interval_size)
   {

--- a/thrust/thrust/system/detail/generic/inner_product.inl
+++ b/thrust/thrust/system/detail/generic/inner_product.inl
@@ -29,8 +29,8 @@ _CCCL_HOST_DEVICE OutputType inner_product(
   InputIterator2 first2,
   OutputType init)
 {
-  ::cuda::std::plus<OutputType> binary_op1;
-  ::cuda::std::multiplies<OutputType> binary_op2;
+  const ::cuda::std::plus<OutputType> binary_op1;
+  const ::cuda::std::multiplies<OutputType> binary_op2;
   return thrust::inner_product(exec, first1, last1, first2, init, binary_op1, binary_op2);
 } // end inner_product()
 

--- a/thrust/thrust/system/detail/generic/mismatch.inl
+++ b/thrust/thrust/system/detail/generic/mismatch.inl
@@ -44,10 +44,10 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   using IteratorTuple = ::cuda::std::tuple<InputIterator1, InputIterator2>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_first = thrust::make_zip_iterator(first1, first2);
-  ZipIterator zipped_last  = thrust::make_zip_iterator(last1, first2);
+  const ZipIterator zipped_first = thrust::make_zip_iterator(first1, first2);
+  const ZipIterator zipped_last  = thrust::make_zip_iterator(last1, first2);
 
-  ZipIterator result =
+  const ZipIterator result =
     thrust::find_if_not(exec, zipped_first, zipped_last, thrust::detail::tuple_binary_predicate<BinaryPredicate>{pred});
 
   return ::cuda::std::make_pair(

--- a/thrust/thrust/system/detail/generic/partition.inl
+++ b/thrust/thrust/system/detail/generic/partition.inl
@@ -40,7 +40,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, last);
 
   // count the size of the true partition
-  thrust::detail::it_difference_t<ForwardIterator> num_true = thrust::count_if(exec, first, last, pred);
+  const thrust::detail::it_difference_t<ForwardIterator> num_true = thrust::count_if(exec, first, last, pred);
 
   // point to the beginning of the false partition
   ForwardIterator out_false = first;
@@ -65,7 +65,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   // count the size of the true partition
   InputIterator stencil_last = stencil;
   ::cuda::std::advance(stencil_last, temp.size());
-  thrust::detail::it_difference_t<InputIterator> num_true = thrust::count_if(exec, stencil, stencil_last, pred);
+  const thrust::detail::it_difference_t<InputIterator> num_true = thrust::count_if(exec, stencil, stencil_last, pred);
 
   // point to the beginning of the false partition
   ForwardIterator out_false = first;

--- a/thrust/thrust/system/detail/generic/remove.inl
+++ b/thrust/thrust/system/detail/generic/remove.inl
@@ -28,7 +28,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename T>
 _CCCL_HOST_DEVICE ForwardIterator
 remove(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, const T& value)
 {
-  ::cuda::equal_to_value<T> pred{value};
+  const ::cuda::equal_to_value<T> pred{value};
 
   // XXX consider using a placeholder here
   return thrust::remove_if(exec, first, last, pred);
@@ -42,7 +42,7 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy(
   OutputIterator result,
   const T& value)
 {
-  ::cuda::equal_to_value<T> pred{value};
+  const ::cuda::equal_to_value<T> pred{value};
 
   // XXX consider using a placeholder here
   return thrust::remove_copy_if(exec, first, last, result, pred);

--- a/thrust/thrust/system/detail/generic/replace.inl
+++ b/thrust/thrust/system/detail/generic/replace.inl
@@ -79,7 +79,7 @@ _CCCL_HOST_DEVICE OutputIterator replace_copy_if(
 {
   using OutputType = thrust::detail::it_value_t<OutputIterator>;
 
-  detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
+  const detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
   return thrust::transform(exec, first, last, result, op);
 } // end replace_copy_if()
 
@@ -100,7 +100,7 @@ _CCCL_HOST_DEVICE OutputIterator replace_copy_if(
 {
   using OutputType = thrust::detail::it_value_t<OutputIterator>;
 
-  detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
+  const detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
   return thrust::transform(exec, first, last, stencil, result, op);
 } // end replace_copy_if()
 
@@ -126,7 +126,7 @@ _CCCL_HOST_DEVICE void replace_if(
   Predicate pred,
   const T& new_value)
 {
-  detail::constant_unary<T> f(new_value);
+  const detail::constant_unary<T> f(new_value);
   thrust::transform_if(exec, first, last, first, first, f, pred);
 } // end replace_if()
 
@@ -139,7 +139,7 @@ _CCCL_HOST_DEVICE void replace_if(
   Predicate pred,
   const T& new_value)
 {
-  detail::constant_unary<T> f(new_value);
+  const detail::constant_unary<T> f(new_value);
   thrust::transform_if(exec, first, last, stencil, first, f, pred);
 } // end replace_if()
 

--- a/thrust/thrust/system/detail/generic/reverse.inl
+++ b/thrust/thrust/system/detail/generic/reverse.inl
@@ -31,7 +31,7 @@ reverse(thrust::execution_policy<ExecutionPolicy>& exec, BidirectionalIterator f
   using difference_type = thrust::detail::it_difference_t<BidirectionalIterator>;
 
   // find the midpoint of [first,last)
-  difference_type N = ::cuda::std::distance(first, last);
+  const difference_type N = ::cuda::std::distance(first, last);
   BidirectionalIterator mid(first);
   ::cuda::std::advance(mid, N / 2);
 

--- a/thrust/thrust/system/detail/generic/scalar/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/scalar/binary_search.inl
@@ -26,7 +26,7 @@ _CCCL_HOST_DEVICE RandomAccessIterator
 lower_bound_n(RandomAccessIterator first, Size n, const T& val, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   Size start = 0, i;
   while (start < n)
@@ -51,7 +51,7 @@ template <typename RandomAccessIterator, typename T, typename BinaryPredicate>
 _CCCL_HOST_DEVICE RandomAccessIterator
 lower_bound(RandomAccessIterator first, RandomAccessIterator last, const T& val, BinaryPredicate comp)
 {
-  thrust::detail::it_difference_t<RandomAccessIterator> n = last - first;
+  const thrust::detail::it_difference_t<RandomAccessIterator> n = last - first;
   return lower_bound_n(first, n, val, comp);
 }
 
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE RandomAccessIterator
 upper_bound_n(RandomAccessIterator first, Size n, const T& val, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   Size start = 0, i;
   while (start < n)
@@ -83,7 +83,7 @@ template <typename RandomAccessIterator, typename T, typename BinaryPredicate>
 _CCCL_HOST_DEVICE RandomAccessIterator
 upper_bound(RandomAccessIterator first, RandomAccessIterator last, const T& val, BinaryPredicate comp)
 {
-  thrust::detail::it_difference_t<RandomAccessIterator> n = last - first;
+  const thrust::detail::it_difference_t<RandomAccessIterator> n = last - first;
   return upper_bound_n(first, n, val, comp);
 }
 

--- a/thrust/thrust/system/detail/generic/set_operations.inl
+++ b/thrust/thrust/system/detail/generic/set_operations.inl
@@ -97,15 +97,15 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_differ
   using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
   using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
-  zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
-  zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
+  const zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
+  const zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
 
-  zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
-  zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
+  const zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
+  const zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
 
-  zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
+  const zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
 
-  thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
+  const thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
 
   iterator_tuple3 result =
     thrust::set_difference(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
@@ -187,17 +187,17 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_inters
 
   // fabricate a values_first2 by repeating a default-constructed value_type1
   // XXX assumes value_type1 is default-constructible
-  constant_iterator values_first2 = ::cuda::make_constant_iterator(value_type1());
+  const constant_iterator values_first2 = ::cuda::make_constant_iterator(value_type1());
 
-  zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
-  zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
+  const zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
+  const zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
 
-  zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
-  zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
+  const zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
+  const zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
 
-  zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
+  const zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
 
-  thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
+  const thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
 
   iterator_tuple3 result =
     thrust::set_intersection(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
@@ -279,15 +279,15 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmet
   using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
   using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
-  zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
-  zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
+  const zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
+  const zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
 
-  zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
-  zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
+  const zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
+  const zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
 
-  zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
+  const zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
 
-  thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
+  const thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
 
   iterator_tuple3 result =
     thrust::set_symmetric_difference(
@@ -370,15 +370,15 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_
   using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
   using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
-  zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
-  zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
+  const zip_iterator1 zipped_first1 = thrust::make_zip_iterator(keys_first1, values_first1);
+  const zip_iterator1 zipped_last1  = thrust::make_zip_iterator(keys_last1, values_first1);
 
-  zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
-  zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
+  const zip_iterator2 zipped_first2 = thrust::make_zip_iterator(keys_first2, values_first2);
+  const zip_iterator2 zipped_last2  = thrust::make_zip_iterator(keys_last2, values_first2);
 
-  zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
+  const zip_iterator3 zipped_result = thrust::make_zip_iterator(keys_result, values_result);
 
-  thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
+  const thrust::detail::compare_first<StrictWeakOrdering> comp_first{comp};
 
   iterator_tuple3 result =
     thrust::set_union(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)

--- a/thrust/thrust/system/detail/generic/shuffle.inl
+++ b/thrust/thrust/system/detail/generic/shuffle.inl
@@ -89,16 +89,16 @@ _CCCL_HOST_DEVICE void shuffle_copy(
 {
   // m is the length of the input
   // we have an available bijection of length n via a feistel cipher
-  std::size_t m = last - first;
-  thrust::detail::feistel_bijection bijection(m, g);
+  const std::size_t m = last - first;
+  const thrust::detail::feistel_bijection bijection(m, g);
   std::uint64_t n = bijection.size();
 
   // perform stream compaction over length n bijection to get length m
   // pseudorandom bijection over the original input
-  thrust::counting_iterator<std::uint64_t> indices(0);
-  thrust::transform_iterator<construct_key_flag_op, decltype(indices), key_flag_tuple> key_flag_it(
-    indices, construct_key_flag_op(m, bijection));
-  write_output_op<RandomIterator, decltype(result)> write_functor{m, first, result};
+  const thrust::counting_iterator<std::uint64_t> indices(0);
+  const thrust::transform_iterator<construct_key_flag_op, thrust::counting_iterator<std::uint64_t>, key_flag_tuple>
+    key_flag_it(indices, construct_key_flag_op(m, bijection));
+  const write_output_op<RandomIterator, OutputIterator> write_functor{m, first, result};
   auto gather_output_it =
     thrust::make_transform_output_iterator(thrust::discard_iterator<std::size_t>(), write_functor);
   // the feistel_bijection outputs a stream of permuted indices in range [0,n)

--- a/thrust/thrust/system/detail/generic/sort.inl
+++ b/thrust/thrust/system/detail/generic/sort.inl
@@ -129,8 +129,8 @@ _CCCL_HOST_DEVICE ForwardIterator is_sorted_until(
   ForwardIterator first_plus_one = first;
   ::cuda::std::advance(first_plus_one, 1);
 
-  ZipIterator zipped_first = thrust::make_zip_iterator(first_plus_one, first);
-  ZipIterator zipped_last  = thrust::make_zip_iterator(last, first);
+  const ZipIterator zipped_first = thrust::make_zip_iterator(first_plus_one, first);
+  const ZipIterator zipped_last  = thrust::make_zip_iterator(last, first);
 
   return ::cuda::std::get<0>(
     thrust::find_if(exec, zipped_first, zipped_last, thrust::detail::tuple_binary_predicate<Compare>{comp})

--- a/thrust/thrust/system/detail/generic/swap_ranges.inl
+++ b/thrust/thrust/system/detail/generic/swap_ranges.inl
@@ -49,7 +49,7 @@ _CCCL_HOST_DEVICE ForwardIterator2 swap_ranges(
   using IteratorTuple = ::cuda::std::tuple<ForwardIterator1, ForwardIterator2>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator result = thrust::for_each(
+  const ZipIterator result = thrust::for_each(
     exec,
     thrust::make_zip_iterator(first1, first2),
     thrust::make_zip_iterator(last1, first2),

--- a/thrust/thrust/system/detail/generic/tabulate.inl
+++ b/thrust/thrust/system/detail/generic/tabulate.inl
@@ -33,7 +33,7 @@ _CCCL_HOST_DEVICE void tabulate(
   // this causes problems when a zip_iterator is created in transform's implementation -- ForwardIterator is
   // incremented by a 64b difference_type and some compilers warn
   // to avoid this, specify the counting_iterator's difference_type to be the same as ForwardIterator's.
-  thrust::counting_iterator<difference_type, thrust::use_default, thrust::use_default, difference_type> iter(0);
+  const thrust::counting_iterator<difference_type, thrust::use_default, thrust::use_default, difference_type> iter(0);
 
   thrust::transform(exec, iter, iter + ::cuda::std::distance(first, last), first, unary_op);
 } // end tabulate()

--- a/thrust/thrust/system/detail/generic/temporary_buffer.inl
+++ b/thrust/thrust/system/detail/generic/temporary_buffer.inl
@@ -27,7 +27,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
 get_temporary_buffer(thrust::execution_policy<DerivedPolicy>& exec,
                      typename thrust::pointer<T, DerivedPolicy>::difference_type n)
 {
-  thrust::pointer<T, DerivedPolicy> ptr = thrust::malloc<T>(exec, n);
+  const thrust::pointer<T, DerivedPolicy> ptr = thrust::malloc<T>(exec, n);
 
   // check for a failed malloc
   if (!ptr.get())

--- a/thrust/thrust/system/detail/generic/transform.h
+++ b/thrust/thrust/system/detail/generic/transform.h
@@ -109,7 +109,7 @@ _CCCL_HOST_DEVICE OutputIterator transform(
   using IteratorTuple = ::cuda::std::tuple<InputIterator, OutputIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_result = thrust::for_each(
+  const ZipIterator zipped_result = thrust::for_each(
     exec, thrust::make_zip_iterator(first, result), thrust::make_zip_iterator(last, result), UnaryTransformFunctor{op});
 
   return ::cuda::std::get<1>(zipped_result.get_iterator_tuple());
@@ -135,7 +135,7 @@ _CCCL_HOST_DEVICE OutputIterator transform(
   using IteratorTuple = ::cuda::std::tuple<InputIterator1, InputIterator2, OutputIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_result = thrust::for_each(
+  const ZipIterator zipped_result = thrust::for_each(
     exec,
     thrust::make_zip_iterator(first1, first2, result),
     thrust::make_zip_iterator(last1, first2, result),
@@ -163,7 +163,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   using IteratorTuple = ::cuda::std::tuple<InputIterator, ForwardIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_result = thrust::for_each(
+  const ZipIterator zipped_result = thrust::for_each(
     exec,
     thrust::make_zip_iterator(first, result),
     thrust::make_zip_iterator(last, result),
@@ -193,7 +193,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   using IteratorTuple = ::cuda::std::tuple<InputIterator1, InputIterator2, ForwardIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_result = thrust::for_each(
+  const ZipIterator zipped_result = thrust::for_each(
     exec,
     thrust::make_zip_iterator(first, stencil, result),
     thrust::make_zip_iterator(last, stencil, result),
@@ -225,7 +225,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   using IteratorTuple = ::cuda::std::tuple<InputIterator1, InputIterator2, InputIterator3, ForwardIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_result = thrust::for_each(
+  const ZipIterator zipped_result = thrust::for_each(
     exec,
     thrust::make_zip_iterator(first1, first2, stencil, result),
     thrust::make_zip_iterator(last1, first2, stencil, result),

--- a/thrust/thrust/system/detail/generic/transform_reduce.inl
+++ b/thrust/thrust/system/detail/generic/transform_reduce.inl
@@ -32,8 +32,8 @@ _CCCL_HOST_DEVICE OutputType transform_reduce(
   OutputType init,
   BinaryFunction binary_op)
 {
-  thrust::transform_iterator<UnaryFunction, InputIterator, OutputType> xfrm_first(first, unary_op);
-  thrust::transform_iterator<UnaryFunction, InputIterator, OutputType> xfrm_last(last, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, OutputType> xfrm_first(first, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, OutputType> xfrm_last(last, unary_op);
 
   return thrust::reduce(exec, xfrm_first, xfrm_last, init, binary_op);
 } // end transform_reduce()

--- a/thrust/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/thrust/system/detail/generic/transform_scan.inl
@@ -40,8 +40,8 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
   using ResultType = thrust::detail::invoke_result_t<UnaryFunction, InputType>;
   using ValueType  = ::cuda::std::remove_cvref_t<ResultType>;
 
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
 
   return thrust::inclusive_scan(exec, _first, _last, result, binary_op);
 } // end transform_inclusive_scan()
@@ -65,8 +65,8 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
   using ResultType = thrust::detail::invoke_result_t<UnaryFunction, InputType>;
   using ValueType  = ::cuda::std::remove_cvref_t<ResultType>;
 
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
 
   return thrust::inclusive_scan(exec, _first, _last, result, init, binary_op);
 } // end transform_inclusive_scan()
@@ -89,8 +89,8 @@ _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
   // Use the initial value type per https://wg21.link/P0571
   using ValueType = ::cuda::std::remove_cvref_t<InitialValueType>;
 
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
-  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
+  const thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
 
   return thrust::exclusive_scan(exec, _first, _last, result, init, binary_op);
 } // end transform_exclusive_scan()

--- a/thrust/thrust/system/detail/generic/uninitialized_copy.inl
+++ b/thrust/thrust/system/detail/generic/uninitialized_copy.inl
@@ -51,8 +51,8 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy(
   using IteratorTuple = ::cuda::std::tuple<InputIterator, ForwardIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator begin = thrust::make_zip_iterator(first, result);
-  ZipIterator end   = begin;
+  const ZipIterator begin = thrust::make_zip_iterator(first, result);
+  ZipIterator end         = begin;
 
   // get a zip_iterator pointing to the end
   const thrust::detail::it_difference_t<InputIterator> n = ::cuda::std::distance(first, last);
@@ -62,7 +62,7 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy(
   using InputType  = thrust::detail::it_value_t<InputIterator>;
   using OutputType = thrust::detail::it_value_t<ForwardIterator>;
 
-  detail::uninitialized_copy_functor<InputType, OutputType> f;
+  const detail::uninitialized_copy_functor<InputType, OutputType> f;
 
   // do the for_each
   thrust::for_each(exec, begin, end, f);
@@ -96,16 +96,16 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy_n(
   using IteratorTuple = ::cuda::std::tuple<InputIterator, ForwardIterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator zipped_first = thrust::make_zip_iterator(first, result);
+  const ZipIterator zipped_first = thrust::make_zip_iterator(first, result);
 
   // create a functor
   using InputType  = thrust::detail::it_value_t<InputIterator>;
   using OutputType = thrust::detail::it_value_t<ForwardIterator>;
 
-  detail::uninitialized_copy_functor<InputType, OutputType> f;
+  const detail::uninitialized_copy_functor<InputType, OutputType> f;
 
   // do the for_each_n
-  ZipIterator zipped_last = thrust::for_each_n(exec, zipped_first, n, f);
+  const ZipIterator zipped_last = thrust::for_each_n(exec, zipped_first, n, f);
 
   // return the end of the output range
   return ::cuda::std::get<1>(zipped_last.get_iterator_tuple());

--- a/thrust/thrust/system/detail/generic/unique.inl
+++ b/thrust/thrust/system/detail/generic/unique.inl
@@ -67,7 +67,7 @@ _CCCL_HOST_DEVICE OutputIterator unique_copy(
   OutputIterator output,
   BinaryPredicate binary_pred)
 {
-  thrust::detail::head_flags<InputIterator, BinaryPredicate> stencil(first, last, binary_pred);
+  const thrust::detail::head_flags<InputIterator, BinaryPredicate> stencil(first, last, binary_pred);
 
   using namespace thrust::placeholders;
 
@@ -81,7 +81,7 @@ _CCCL_HOST_DEVICE thrust::detail::it_difference_t<ForwardIterator> unique_count(
   ForwardIterator last,
   BinaryPredicate binary_pred)
 {
-  thrust::detail::head_flags<ForwardIterator, BinaryPredicate> stencil(first, last, binary_pred);
+  const thrust::detail::head_flags<ForwardIterator, BinaryPredicate> stencil(first, last, binary_pred);
 
   using namespace thrust::placeholders;
 

--- a/thrust/thrust/system/detail/generic/unique_by_key.inl
+++ b/thrust/thrust/system/detail/generic/unique_by_key.inl
@@ -90,12 +90,12 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_
 {
   using difference_type = thrust::detail::it_difference_t<InputIterator1>;
 
-  difference_type n = ::cuda::std::distance(keys_first, keys_last);
+  const difference_type n = ::cuda::std::distance(keys_first, keys_last);
 
-  thrust::detail::head_flags<InputIterator1, BinaryPredicate> stencil(keys_first, keys_last, binary_pred);
+  const thrust::detail::head_flags<InputIterator1, BinaryPredicate> stencil(keys_first, keys_last, binary_pred);
 
   using namespace thrust::placeholders;
-  thrust::zip_iterator<::cuda::std::tuple<OutputIterator1, OutputIterator2>> result = thrust::copy_if(
+  const thrust::zip_iterator<::cuda::std::tuple<OutputIterator1, OutputIterator2>> result = thrust::copy_if(
     exec,
     thrust::make_zip_iterator(keys_first, values_first),
     thrust::make_zip_iterator(keys_first, values_first) + n,
@@ -103,7 +103,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_
     thrust::make_zip_iterator(keys_output, values_output),
     _1);
 
-  difference_type output_size = result - thrust::make_zip_iterator(keys_output, values_output);
+  const difference_type output_size = result - thrust::make_zip_iterator(keys_output, values_output);
 
   return ::cuda::std::make_pair(keys_output + output_size, values_output + output_size);
 } // end unique_by_key_copy()

--- a/thrust/thrust/system/detail/internal/decompose.h
+++ b/thrust/thrust/system/detail/internal/decompose.h
@@ -74,14 +74,14 @@ public:
   {
     if (i < m_threshold)
     {
-      index_type begin = m_large_interval * i;
-      index_type end   = begin + m_large_interval;
+      const index_type begin = m_large_interval * i;
+      const index_type end   = begin + m_large_interval;
       return range_type(begin, end);
     }
     else
     {
-      index_type begin = m_large_interval * m_threshold + m_small_interval * (i - m_threshold);
-      index_type end   = (begin + m_small_interval < m_N) ? begin + m_small_interval : m_N;
+      const index_type begin = m_large_interval * m_threshold + m_small_interval * (i - m_threshold);
+      const index_type end   = (begin + m_small_interval < m_N) ? begin + m_small_interval : m_N;
       return range_type(begin, end);
     }
   }

--- a/thrust/thrust/system/detail/sequential/adjacent_difference.h
+++ b/thrust/thrust/system/detail/sequential/adjacent_difference.h
@@ -44,9 +44,9 @@ _CCCL_HOST_DEVICE OutputIterator adjacent_difference(
 
   while (++first != last)
   {
-    InputType next = *first; // NOLINT(performance-unnecessary-copy-initialization)
-    *(++result)    = binary_op(next, curr);
-    curr           = next;
+    const InputType next = *first; // NOLINT(performance-unnecessary-copy-initialization)
+    *(++result)          = binary_op(next, curr);
+    curr                 = next;
   }
 
   return ++result;

--- a/thrust/thrust/system/detail/sequential/binary_search.h
+++ b/thrust/thrust/system/detail/sequential/binary_search.h
@@ -37,7 +37,7 @@ _CCCL_HOST_DEVICE ForwardIterator lower_bound(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   using difference_type = thrust::detail::it_difference_t<ForwardIterator>;
 
@@ -45,8 +45,8 @@ _CCCL_HOST_DEVICE ForwardIterator lower_bound(
 
   while (len > 0)
   {
-    difference_type half   = len >> 1;
-    ForwardIterator middle = first;
+    const difference_type half = len >> 1;
+    ForwardIterator middle     = first;
 
     ::cuda::std::advance(middle, half);
 
@@ -75,7 +75,7 @@ _CCCL_HOST_DEVICE ForwardIterator upper_bound(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   using difference_type = thrust::detail::it_difference_t<ForwardIterator>;
 
@@ -83,8 +83,8 @@ _CCCL_HOST_DEVICE ForwardIterator upper_bound(
 
   while (len > 0)
   {
-    difference_type half   = len >> 1;
-    ForwardIterator middle = first;
+    const difference_type half = len >> 1;
+    ForwardIterator middle     = first;
 
     ::cuda::std::advance(middle, half);
 
@@ -115,7 +115,7 @@ _CCCL_HOST_DEVICE bool binary_search(
   ForwardIterator iter = sequential::lower_bound(exec, first, last, val, comp);
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   return iter != last && !wrapped_comp(val, *iter);
 }

--- a/thrust/thrust/system/detail/sequential/copy_if.h
+++ b/thrust/thrust/system/detail/sequential/copy_if.h
@@ -36,7 +36,7 @@ _CCCL_HOST_DEVICE OutputIterator copy_if(
   OutputIterator result,
   Predicate pred)
 {
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/extrema.h
+++ b/thrust/thrust/system/detail/sequential/extrema.h
@@ -30,7 +30,7 @@ _CCCL_HOST_DEVICE ForwardIterator min_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imin = first;
 
@@ -51,7 +51,7 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imax = first;
 
@@ -72,7 +72,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_ele
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imin = first;
   ForwardIterator imax = first;

--- a/thrust/thrust/system/detail/sequential/find.h
+++ b/thrust/thrust/system/detail/sequential/find.h
@@ -28,7 +28,7 @@ _CCCL_HOST_DEVICE InputIterator
 find_if(execution_policy<DerivedPolicy>&, InputIterator first, InputIterator last, Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/for_each.h
+++ b/thrust/thrust/system/detail/sequential/for_each.h
@@ -28,7 +28,7 @@ _CCCL_HOST_DEVICE InputIterator
 for_each(sequential::execution_policy<DerivedPolicy>&, InputIterator first, InputIterator last, UnaryFunction f)
 {
   // wrap f
-  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
+  const thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
 
   for (; first != last; ++first)
   {
@@ -43,7 +43,7 @@ _CCCL_HOST_DEVICE InputIterator
 for_each_n(sequential::execution_policy<DerivedPolicy>&, InputIterator first, Size n, UnaryFunction f)
 {
   // wrap f
-  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
+  const thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
 
   for (Size i = 0; i != n; i++)
   {

--- a/thrust/thrust/system/detail/sequential/insertion_sort.h
+++ b/thrust/thrust/system/detail/sequential/insertion_sort.h
@@ -32,7 +32,7 @@ _CCCL_HOST_DEVICE void insertion_sort(RandomAccessIterator first, RandomAccessIt
   }
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   for (RandomAccessIterator i = first + 1; i != last; ++i)
   {
@@ -77,15 +77,15 @@ _CCCL_HOST_DEVICE void insertion_sort_by_key(
   }
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   RandomAccessIterator1 i1 = first1 + 1;
   RandomAccessIterator2 i2 = first2 + 1;
 
   for (; i1 != last1; ++i1, ++i2)
   {
-    value_type1 tmp1 = *i1;
-    value_type2 tmp2 = *i2; // NOLINT(performance-unnecessary-copy-initialization)
+    value_type1 tmp1       = *i1;
+    const value_type2 tmp2 = *i2; // NOLINT(performance-unnecessary-copy-initialization)
 
     if (wrapped_comp(tmp1, *first1))
     {

--- a/thrust/thrust/system/detail/sequential/merge.h
+++ b/thrust/thrust/system/detail/sequential/merge.h
@@ -40,7 +40,7 @@ _CCCL_HOST_DEVICE OutputIterator merge(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -83,7 +83,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_k
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (keys_first1 != keys_last1 && keys_first2 != keys_last2)
   {

--- a/thrust/thrust/system/detail/sequential/partition.h
+++ b/thrust/thrust/system/detail/sequential/partition.h
@@ -54,7 +54,7 @@ partition(sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, F
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (wrapped_pred(*first))
   {
@@ -94,7 +94,7 @@ _CCCL_HOST_DEVICE ForwardIterator partition(
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (wrapped_pred(*stencil_first))
   {
@@ -136,7 +136,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   using T = thrust::detail::it_value_t<ForwardIterator>;
 
@@ -178,7 +178,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   using T = thrust::detail::it_value_t<ForwardIterator>;
 
@@ -227,7 +227,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_par
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   for (; first != last; ++first)
   {
@@ -263,7 +263,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_par
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   for (; first != last; ++first, (void) ++stencil)
   {

--- a/thrust/thrust/system/detail/sequential/reduce.h
+++ b/thrust/thrust/system/detail/sequential/reduce.h
@@ -32,7 +32,7 @@ _CCCL_HOST_DEVICE OutputType reduce(
   BinaryFunction binary_op)
 {
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op{binary_op};
+  const thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op{binary_op};
 
   // initialize the result
   OutputType result = init;

--- a/thrust/thrust/system/detail/sequential/reduce_by_key.h
+++ b/thrust/thrust/system/detail/sequential/reduce_by_key.h
@@ -51,8 +51,8 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_
 
     for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, (void) ++values_first)
     {
-      InputKeyType key     = *keys_first;
-      InputValueType value = *values_first;
+      const InputKeyType key     = *keys_first;
+      const InputValueType value = *values_first;
 
       if (binary_pred(temp_key, key))
       {

--- a/thrust/thrust/system/detail/sequential/remove.h
+++ b/thrust/thrust/system/detail/sequential/remove.h
@@ -28,7 +28,7 @@ _CCCL_HOST_DEVICE ForwardIterator
 remove_if(sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   // advance iterators until wrapped_pred(*first) is true or we reach the end of input
   while (first != last && !wrapped_pred(*first))
@@ -69,7 +69,7 @@ _CCCL_HOST_DEVICE ForwardIterator remove_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   // advance iterators until wrapped_pred(*stencil) is true or we reach the end of input
   while (first != last && !wrapped_pred(*stencil))
@@ -113,7 +113,7 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {
@@ -144,7 +144,7 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
+  const thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/scan.h
+++ b/thrust/thrust/system/detail/sequential/scan.h
@@ -41,7 +41,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
   using ValueType = thrust::detail::it_value_t<InputIterator>;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
+  const thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
 
   if (first != last)
   {
@@ -78,7 +78,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
     typename ::cuda::std::__accumulator_t<BinaryFunction, thrust::detail::it_value_t<InputIterator>, InitialValueType>;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
+  const thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
 
   if (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/scan_by_key.h
+++ b/thrust/thrust/system/detail/sequential/scan_by_key.h
@@ -43,7 +43,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
   using ValueType = thrust::detail::it_value_t<InputIterator2>;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
+  const thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
 
   if (first1 != last1)
   {
@@ -54,7 +54,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
 
     for (++first1, ++first2, ++result; first1 != last1; ++first1, (void) ++first2, (void) ++result)
     {
-      KeyType key = *first1; // NOLINT(performance-unnecessary-copy-initialization)
+      const KeyType key = *first1; // NOLINT(performance-unnecessary-copy-initialization)
 
       if (binary_pred(prev_key, key))
       {
@@ -107,7 +107,7 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
 
     for (++first1, ++first2, ++result; first1 != last1; ++first1, (void) ++first2, (void) ++result)
     {
-      KeyType key = *first1; // NOLINT(performance-unnecessary-copy-initialization)
+      const KeyType key = *first1; // NOLINT(performance-unnecessary-copy-initialization)
 
       // use temp to permit in-place scans
       temp_value = *first2;

--- a/thrust/thrust/system/detail/sequential/set_operations.h
+++ b/thrust/thrust/system/detail/sequential/set_operations.h
@@ -39,7 +39,7 @@ _CCCL_HOST_DEVICE OutputIterator set_difference(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -79,7 +79,7 @@ _CCCL_HOST_DEVICE OutputIterator set_intersection(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -119,7 +119,7 @@ _CCCL_HOST_DEVICE OutputIterator set_symmetric_difference(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -161,7 +161,7 @@ _CCCL_HOST_DEVICE OutputIterator set_union(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
+  const thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {

--- a/thrust/thrust/system/detail/sequential/stable_merge_sort.h
+++ b/thrust/thrust/system/detail/sequential/stable_merge_sort.h
@@ -178,7 +178,7 @@ _CCCL_HOST_DEVICE void iterative_stable_merge_sort(
   using value_type      = thrust::detail::it_value_t<RandomAccessIterator>;
   using difference_type = thrust::detail::it_difference_t<RandomAccessIterator>;
 
-  difference_type n = last - first;
+  const difference_type n = last - first;
 
   thrust::detail::temporary_array<value_type, DerivedPolicy> temp(exec, n);
 
@@ -223,7 +223,7 @@ _CCCL_HOST_DEVICE void iterative_stable_merge_sort_by_key(
   using value_type2     = thrust::detail::it_value_t<RandomAccessIterator2>;
   using difference_type = thrust::detail::it_difference_t<RandomAccessIterator1>;
 
-  difference_type n = keys_last - keys_first;
+  const difference_type n = keys_last - keys_first;
 
   thrust::detail::temporary_array<value_type1, DerivedPolicy> keys_temp(exec, n);
   thrust::detail::temporary_array<value_type2, DerivedPolicy> values_temp(exec, n);

--- a/thrust/thrust/system/detail/sequential/stable_radix_sort.h
+++ b/thrust/thrust/system/detail/sequential/stable_radix_sort.h
@@ -239,7 +239,7 @@ _CCCL_HOST_DEVICE void radix_sort(
 
   const EncodedType BitMask = static_cast<EncodedType>((1 << RadixBits) - 1);
 
-  Encoder encode;
+  const Encoder encode;
 
   // storage for histograms
   size_t histograms[NumHistograms][HistogramSize] = {{0}};
@@ -269,7 +269,7 @@ _CCCL_HOST_DEVICE void radix_sort(
 
     for (unsigned int j = 0; j < HistogramSize; j++)
     {
-      size_t bin = histograms[i][j];
+      const size_t bin = histograms[i][j];
 
       if (bin == N)
       {
@@ -550,7 +550,7 @@ _CCCL_HOST_DEVICE void stable_radix_sort(
 {
   using KeyType = thrust::detail::it_value_t<RandomAccessIterator>;
 
-  size_t N = last - first;
+  const size_t N = last - first;
 
   thrust::detail::temporary_array<KeyType, DerivedPolicy> temp(exec, N);
 
@@ -567,7 +567,7 @@ _CCCL_HOST_DEVICE void stable_radix_sort_by_key(
   using KeyType   = thrust::detail::it_value_t<RandomAccessIterator1>;
   using ValueType = thrust::detail::it_value_t<RandomAccessIterator2>;
 
-  size_t N = last1 - first1;
+  const size_t N = last1 - first1;
 
   thrust::detail::temporary_array<KeyType, DerivedPolicy> temp1(exec, N);
   thrust::detail::temporary_array<ValueType, DerivedPolicy> temp2(exec, N);

--- a/thrust/thrust/system/detail/sequential/unique.h
+++ b/thrust/thrust/system/detail/sequential/unique.h
@@ -39,7 +39,7 @@ _CCCL_HOST_DEVICE OutputIterator unique_copy(
 
     for (++first; first != last; ++first)
     {
-      T temp = *first;
+      const T temp = *first;
 
       if (!binary_pred(prev, temp))
       {
@@ -83,7 +83,7 @@ _CCCL_HOST_DEVICE thrust::detail::it_difference_t<ForwardIterator> unique_count(
 
     for (++first; first != last; ++first)
     {
-      T temp = *first;
+      const T temp = *first;
 
       if (!binary_pred(prev, temp))
       {

--- a/thrust/thrust/system/detail/sequential/unique_by_key.h
+++ b/thrust/thrust/system/detail/sequential/unique_by_key.h
@@ -50,8 +50,8 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_
 
     for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, (void) ++values_first)
     {
-      InputKeyType key      = *keys_first;
-      OutputValueType value = *values_first;
+      const InputKeyType key      = *keys_first;
+      const OutputValueType value = *values_first;
 
       if (!binary_pred(temp_key, key))
       {

--- a/thrust/thrust/system/tbb/detail/copy_if.h
+++ b/thrust/thrust/system/tbb/detail/copy_if.h
@@ -102,7 +102,7 @@ copy_if(tag, InputIterator1 first, InputIterator1 last, InputIterator2 stencil, 
   using Size = thrust::detail::it_difference_t<InputIterator1>;
   using Body = typename copy_if_detail::body<InputIterator1, InputIterator2, OutputIterator, Predicate, Size>;
 
-  Size n = ::cuda::std::distance(first, last);
+  const Size n = ::cuda::std::distance(first, last);
 
   if (n != 0)
   {

--- a/thrust/thrust/system/tbb/detail/merge.h
+++ b/thrust/thrust/system/tbb/detail/merge.h
@@ -61,8 +61,8 @@ struct range
       , grain_size(r.grain_size)
   {
     // we can assume n1 and n2 are not both 0
-    size_t n1 = ::cuda::std::distance(first1, last1);
-    size_t n2 = ::cuda::std::distance(first2, last2);
+    const size_t n1 = ::cuda::std::distance(first1, last1);
+    const size_t n2 = ::cuda::std::distance(first2, last2);
 
     InputIterator1 mid1 = first1;
     InputIterator2 mid2 = first2;
@@ -165,8 +165,8 @@ struct range
       , grain_size(r.grain_size)
   {
     // we can assume n1 and n2 are not both 0
-    size_t n1 = ::cuda::std::distance(keys_first1, keys_last1);
-    size_t n2 = ::cuda::std::distance(keys_first2, keys_last2);
+    const size_t n1 = ::cuda::std::distance(keys_first1, keys_last1);
+    const size_t n2 = ::cuda::std::distance(keys_first2, keys_last2);
 
     InputIterator1 mid1 = keys_first1;
     InputIterator2 mid2 = keys_first2;
@@ -245,8 +245,8 @@ merge(execution_policy<DerivedPolicy>&,
 {
   using Range = typename merge_detail::range<InputIterator1, InputIterator2, OutputIterator, StrictWeakOrdering>;
   using Body  = merge_detail::body;
-  Range range(first1, last1, first2, last2, result, comp);
-  Body body;
+  const Range range(first1, last1, first2, last2, result, comp);
+  const Body body;
 
   ::tbb::parallel_for(range, body);
 
@@ -285,9 +285,9 @@ template <typename DerivedPolicy,
     StrictWeakOrdering>;
   using Body = merge_by_key_detail::body;
 
-  Range range(
+  const Range range(
     keys_first1, keys_last1, keys_first2, keys_last2, values_first3, values_first4, keys_result, values_result, comp);
-  Body body;
+  const Body body;
 
   ::tbb::parallel_for(range, body);
 

--- a/thrust/thrust/system/tbb/detail/reduce.h
+++ b/thrust/thrust/system/tbb/detail/reduce.h
@@ -103,7 +103,7 @@ OutputType reduce(
 {
   using Size = thrust::detail::it_difference_t<InputIterator>;
 
-  Size n = ::cuda::std::distance(begin, end);
+  const Size n = ::cuda::std::distance(begin, end);
 
   if (n == 0)
   {

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.h
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.h
@@ -59,14 +59,14 @@ reduce_last_segment_backward(
   BinaryPredicate binary_pred,
   BinaryFunction binary_op)
 {
-  thrust::detail::it_difference_t<InputIterator1> n = keys_last - keys_first;
+  const thrust::detail::it_difference_t<InputIterator1> n = keys_last - keys_first;
 
   // reverse the ranges and consume from the end
   ::cuda::std::reverse_iterator<InputIterator1> keys_first_r(keys_last);
-  ::cuda::std::reverse_iterator<InputIterator1> keys_last_r(keys_first);
+  const ::cuda::std::reverse_iterator<InputIterator1> keys_last_r(keys_first);
   ::cuda::std::reverse_iterator<InputIterator2> values_first_r(values_first + n);
 
-  thrust::detail::it_value_t<InputIterator1> result_key                        = *keys_first_r;
+  const thrust::detail::it_value_t<InputIterator1> result_key                  = *keys_first_r;
   typename partial_sum_type<InputIterator2, BinaryFunction>::type result_value = *values_first_r;
 
   // consume the entirety of the first key's sequence
@@ -204,7 +204,7 @@ struct serial_reduce_by_key_body
     // store to my_keys_result & my_values_result otherwise
 
     // create tail_flags so we can check for a carry
-    thrust::detail::tail_flags<Iterator1, BinaryPredicate> flags =
+    const thrust::detail::tail_flags<Iterator1, BinaryPredicate> flags =
       thrust::detail::make_tail_flags(keys_first, keys_first + n, binary_pred);
 
     if (interval_has_carry(interval_idx, interval_size, num_intervals, flags.begin()))
@@ -283,8 +283,8 @@ template <typename DerivedPolicy,
   BinaryPredicate binary_pred,
   BinaryFunction binary_op)
 {
-  using difference_type = thrust::detail::it_difference_t<Iterator1>;
-  difference_type n     = keys_last - keys_first;
+  using difference_type   = thrust::detail::it_difference_t<Iterator1>;
+  const difference_type n = keys_last - keys_first;
   if (n == 0)
   {
     return ::cuda::std::make_pair(keys_result, values_result);
@@ -306,16 +306,16 @@ template <typename DerivedPolicy,
   // generate O(P) intervals of sequential work
   // XXX oversubscribing is a tuning opportunity
   const unsigned int subscription_rate = 1;
-  difference_type interval_size        = ::cuda::std::min<difference_type>(
+  const difference_type interval_size  = ::cuda::std::min<difference_type>(
     parallelism_threshold, ::cuda::std::max<difference_type>(n, n / (subscription_rate * p)));
-  difference_type num_intervals = reduce_by_key_detail::divide_ri(n, interval_size);
+  const difference_type num_intervals = reduce_by_key_detail::divide_ri(n, interval_size);
 
   // decompose the input into intervals of size N / num_intervals
   // add one extra element to this vector to store the size of the entire result
   thrust::detail::temporary_array<difference_type, DerivedPolicy> interval_output_offsets(0, exec, num_intervals + 1);
 
   // first count the number of tail flags in each interval
-  thrust::detail::tail_flags<Iterator1, BinaryPredicate> tail_flags =
+  const thrust::detail::tail_flags<Iterator1, BinaryPredicate> tail_flags =
     thrust::detail::make_tail_flags(keys_first, keys_last, binary_pred);
   thrust::system::tbb::detail::reduce_intervals(
     exec,
@@ -355,7 +355,7 @@ template <typename DerivedPolicy,
       binary_op),
     ::tbb::simple_partitioner());
 
-  difference_type size_of_result = interval_output_offsets[num_intervals];
+  const difference_type size_of_result = interval_output_offsets[num_intervals];
 
   // sequentially accumulate the carries
   // note that the last interval does not have a carry
@@ -366,7 +366,7 @@ template <typename DerivedPolicy,
     // if it does not have a carry, then we need to ignore carry_value[i]
     if (reduce_by_key_detail::interval_has_carry(i, interval_size, num_intervals, tail_flags.begin()))
     {
-      difference_type output_idx = interval_output_offsets[i + 1];
+      const difference_type output_idx = interval_output_offsets[i + 1];
 
       values_result[output_idx] = binary_op(values_result[output_idx], carries[i]);
     }

--- a/thrust/thrust/system/tbb/detail/reduce_intervals.h
+++ b/thrust/thrust/system/tbb/detail/reduce_intervals.h
@@ -92,7 +92,7 @@ void reduce_intervals(
   RandomAccessIterator2 result,
   BinaryFunction binary_op)
 {
-  thrust::detail::it_difference_t<RandomAccessIterator1> n = last - first;
+  const thrust::detail::it_difference_t<RandomAccessIterator1> n = last - first;
 
   Size num_intervals = reduce_intervals_detail::divide_ri(n, interval_size);
 

--- a/thrust/thrust/system/tbb/detail/scan.h
+++ b/thrust/thrust/system/tbb/detail/scan.h
@@ -227,8 +227,8 @@ inclusive_scan(tag, InputIterator first, InputIterator last, OutputIterator resu
   // Use the input iterator's value type per https://wg21.link/P0571
   using ValueType = thrust::detail::it_value_t<InputIterator>;
 
-  using Size = thrust::detail::it_difference_t<InputIterator>;
-  Size n     = ::cuda::std::distance(first, last);
+  using Size   = thrust::detail::it_difference_t<InputIterator>;
+  const Size n = ::cuda::std::distance(first, last);
 
   if (n != 0)
   {
@@ -252,8 +252,8 @@ OutputIterator inclusive_scan(
   using ValueType =
     typename ::cuda::std::__accumulator_t<BinaryFunction, thrust::detail::it_value_t<InputIterator>, InitialValueType>;
 
-  using Size = thrust::detail::it_difference_t<InputIterator>;
-  Size n     = ::cuda::std::distance(first, last);
+  using Size   = thrust::detail::it_difference_t<InputIterator>;
+  const Size n = ::cuda::std::distance(first, last);
 
   if (n != 0)
   {
@@ -276,8 +276,8 @@ OutputIterator exclusive_scan(
   // Use the initial value type per https://wg21.link/P0571
   using ValueType = InitialValueType;
 
-  using Size = thrust::detail::it_difference_t<InputIterator>;
-  Size n     = ::cuda::std::distance(first, last);
+  using Size   = thrust::detail::it_difference_t<InputIterator>;
+  const Size n = ::cuda::std::distance(first, last);
 
   if (n != 0)
   {

--- a/thrust/thrust/system/tbb/detail/sort.h
+++ b/thrust/thrust/system/tbb/detail/sort.h
@@ -80,7 +80,7 @@ void merge_sort(execution_policy<DerivedPolicy>& exec,
 {
   using difference_type = thrust::detail::it_difference_t<Iterator1>;
 
-  difference_type n = ::cuda::std::distance(first1, last1);
+  const difference_type n = ::cuda::std::distance(first1, last1);
 
   if (n < threshold)
   {
@@ -196,7 +196,7 @@ void merge_sort_by_key(
 {
   using difference_type = thrust::detail::it_difference_t<Iterator1>;
 
-  difference_type n = ::cuda::std::distance(first1, last1);
+  const difference_type n = ::cuda::std::distance(first1, last1);
 
   Iterator1 mid1  = first1 + (n / 2);
   Iterator2 mid2  = first2 + (n / 2);


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `thrust/thrust/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.