### PR TITLE
[Thrust tests] `misc-const-correctness`

### DIFF
--- a/thrust/examples/bounding_box.cu
+++ b/thrust/examples/bounding_box.cu
@@ -60,10 +60,10 @@ struct bbox_union
   __host__ __device__ bbox operator()(bbox a, bbox b)
   {
     // lower left corner
-    point2d ll(thrust::min(a.lower_left.x, b.lower_left.x), thrust::min(a.lower_left.y, b.lower_left.y));
+    const point2d ll(thrust::min(a.lower_left.x, b.lower_left.x), thrust::min(a.lower_left.y, b.lower_left.y));
 
     // upper right corner
-    point2d ur(thrust::max(a.upper_right.x, b.upper_right.x), thrust::max(a.upper_right.y, b.upper_right.y));
+    const point2d ur(thrust::max(a.upper_right.x, b.upper_right.x), thrust::max(a.upper_right.y, b.upper_right.y));
 
     return bbox(ll, ur);
   }
@@ -81,16 +81,16 @@ int main()
   thrust::uniform_real_distribution<float> u01(0.0f, 1.0f);
   for (size_t i = 0; i < N; i++)
   {
-    float x   = u01(rng);
-    float y   = u01(rng);
-    points[i] = point2d(x, y);
+    const float x = u01(rng);
+    const float y = u01(rng);
+    points[i]     = point2d(x, y);
   }
 
   // initial bounding box contains first point
-  bbox init(points[0], points[0]);
+  const bbox init(points[0], points[0]);
 
   // compute the bounding box for the point set
-  bbox result = thrust::reduce(points.begin(), points.end(), init, bbox_union{});
+  const bbox result = thrust::reduce(points.begin(), points.end(), init, bbox_union{});
 
   // print output
   std::cout << "bounding box " << std::fixed;

--- a/thrust/examples/bucket_sort2d.cu
+++ b/thrust/examples/bucket_sort2d.cu
@@ -17,8 +17,8 @@ vec2 make_random_vec2()
 {
   static thrust::default_random_engine rng;
   static thrust::uniform_real_distribution<float> u01(0.0f, 1.0f);
-  float x = u01(rng);
-  float y = u01(rng);
+  const float x = u01(rng);
+  const float y = u01(rng);
   return vec2(x, y);
 }
 
@@ -37,8 +37,8 @@ struct point_to_bucket_index
   __host__ __device__ unsigned int operator()(const vec2& v) const
   {
     // find the raster indices of p's bucket
-    unsigned int x = static_cast<unsigned int>(cuda::std::get<0>(v) * static_cast<float>(width));
-    unsigned int y = static_cast<unsigned int>(cuda::std::get<1>(v) * static_cast<float>(height));
+    const unsigned int x = static_cast<unsigned int>(cuda::std::get<0>(v) * static_cast<float>(width));
+    const unsigned int y = static_cast<unsigned int>(cuda::std::get<1>(v) * static_cast<float>(height));
 
     // return the bucket's linear index
     return y * width + x;
@@ -58,7 +58,7 @@ int main()
 
   // allocate storage for a 2D grid
   // of dimensions w x h
-  unsigned int w = 200, h = 100;
+  const unsigned int w = 200, h = 100;
 
   // the grid data structure keeps a range per grid bucket:
   // each bucket_begin[i] indexes the first element of bucket i's list of points
@@ -76,7 +76,7 @@ int main()
   thrust::sort_by_key(bucket_indices.begin(), bucket_indices.end(), points.begin());
 
   // find the beginning of each bucket's list of points
-  thrust::counting_iterator<unsigned int> search_begin(0);
+  const thrust::counting_iterator<unsigned int> search_begin(0);
   thrust::lower_bound(
     bucket_indices.begin(),
     bucket_indices.end(),
@@ -93,7 +93,7 @@ int main()
     bucket_end.begin());
 
   // write out bucket (150, 50)'s list of points
-  unsigned int bucket_idx = 50 * w + 150;
+  const unsigned int bucket_idx = 50 * w + 150;
   std::cout << "bucket (150, 50)'s list of points:" << '\n';
   std::cout << std::fixed << std::setprecision(6);
   for (unsigned int point_idx = bucket_begin[bucket_idx]; point_idx != bucket_end[bucket_idx]; ++point_idx)

--- a/thrust/examples/counting_iterator.cu
+++ b/thrust/examples/counting_iterator.cu
@@ -17,13 +17,14 @@ int main()
   thrust::device_vector<int> indices(8);
 
   // counting iterators define a sequence [0, 8)
-  thrust::counting_iterator<int> first(0);
-  thrust::counting_iterator<int> last = first + 8;
+  const thrust::counting_iterator<int> first(0);
+  const thrust::counting_iterator<int> last = first + 8;
 
   // compute indices of nonzero elements
   using IndexIterator = thrust::device_vector<int>::iterator;
 
-  IndexIterator indices_end = thrust::copy_if(first, last, stencil.begin(), indices.begin(), cuda::std::identity{});
+  const IndexIterator indices_end =
+    thrust::copy_if(first, last, stencil.begin(), indices.begin(), cuda::std::identity{});
   // indices now contains [1,2,5,7]
 
   // print result

--- a/thrust/examples/cuda/async_reduce.cu
+++ b/thrust/examples/cuda/async_reduce.cu
@@ -30,7 +30,7 @@ __global__ void reduce_kernel(Iterator first, Iterator last, T init, BinaryOpera
 
 int main()
 {
-  size_t n = 1 << 20;
+  const size_t n = 1 << 20;
   thrust::device_vector<unsigned int> data(n, 1);
   thrust::device_vector<unsigned int> result(1, 0);
 
@@ -60,10 +60,10 @@ int main()
 
   // method 2: use std::async to create asynchrony
   // copy all the algorithm parameters
-  auto begin        = data.begin();
-  auto end          = data.end();
-  unsigned int init = 0;
-  auto binary_op    = cuda::std::plus<unsigned int>();
+  auto begin              = data.begin();
+  auto end                = data.end();
+  const unsigned int init = 0;
+  auto binary_op          = cuda::std::plus<unsigned int>();
 
   // std::async captures the algorithm parameters by value
   // use std::launch::async to ensure the creation of a new thread

--- a/thrust/examples/cuda/custom_temporary_allocation.cu
+++ b/thrust/examples/cuda/custom_temporary_allocation.cu
@@ -125,17 +125,17 @@ private:
 
 int main()
 {
-  std::size_t num_elements = 32768;
+  const std::size_t num_elements = 32768;
 
   thrust::host_vector<int> h_input(num_elements);
 
   // Generate random input.
   thrust::generate(h_input.begin(), h_input.end(), rand);
 
-  thrust::cuda::vector<int> d_input = h_input;
+  const thrust::cuda::vector<int> d_input = h_input;
   thrust::cuda::vector<int> d_result(num_elements);
 
-  std::size_t num_trials = 5;
+  const std::size_t num_trials = 5;
 
   cached_allocator alloc;
 

--- a/thrust/examples/cuda/explicit_cuda_stream.cu
+++ b/thrust/examples/cuda/explicit_cuda_stream.cu
@@ -60,7 +60,7 @@ int main()
   thrust::inclusive_scan(sync_exec_policy, d_vec.cbegin(), d_vec.cend(), d_vec.begin());
 
   // This access is only valid because the stream has been synchronized
-  int sum = d_vec.back();
+  const int sum = d_vec.back();
 
   // Free the stream:
   err = cudaStreamDestroy(custom_stream);

--- a/thrust/examples/cuda/range_view.cu
+++ b/thrust/examples/cuda/range_view.cu
@@ -182,7 +182,7 @@ int main()
   float y[4] = {1.0, 2.0, 3.0, 4.0};
   float z[4] = {0.0};
 
-  thrust::device_vector<float> X(x, x + 4);
+  const thrust::device_vector<float> X(x, x + 4);
   thrust::device_vector<float> Y(y, y + 4);
   thrust::device_vector<float> Z(z, z + 4);
 

--- a/thrust/examples/cuda/unwrap_pointer.cu
+++ b/thrust/examples/cuda/unwrap_pointer.cu
@@ -7,10 +7,10 @@
 
 int main()
 {
-  size_t N = 10;
+  const size_t N = 10;
 
   // create a device_ptr
-  thrust::device_ptr<int> dev_ptr = thrust::device_malloc<int>(N);
+  const thrust::device_ptr<int> dev_ptr = thrust::device_malloc<int>(N);
 
   // extract raw pointer from device_ptr
   int* raw_ptr = thrust::raw_pointer_cast(dev_ptr);

--- a/thrust/examples/cuda/wrap_pointer.cu
+++ b/thrust/examples/cuda/wrap_pointer.cu
@@ -5,14 +5,14 @@
 
 int main()
 {
-  size_t N = 10;
+  const size_t N = 10;
 
   // obtain raw pointer to device memory
   int* raw_ptr;
   cudaMalloc((void**) &raw_ptr, N * sizeof(int));
 
   // wrap raw pointer with a device_ptr
-  thrust::device_ptr<int> dev_ptr = thrust::device_pointer_cast(raw_ptr);
+  const thrust::device_ptr<int> dev_ptr = thrust::device_pointer_cast(raw_ptr);
 
   // use device_ptr in Thrust algorithms
   thrust::fill(dev_ptr, dev_ptr + static_cast<std::ptrdiff_t>(N), (int) 0);

--- a/thrust/examples/device_ptr.cu
+++ b/thrust/examples/device_ptr.cu
@@ -10,11 +10,11 @@
 int main()
 {
   // allocate memory buffer to store 10 integers on the device
-  thrust::device_ptr<int> d_ptr = thrust::device_malloc<int>(10);
+  const thrust::device_ptr<int> d_ptr = thrust::device_malloc<int>(10);
 
   // device_ptr supports pointer arithmetic
-  thrust::device_ptr<int> first = d_ptr;
-  thrust::device_ptr<int> last  = d_ptr + 10;
+  const thrust::device_ptr<int> first = d_ptr;
+  const thrust::device_ptr<int> last  = d_ptr + 10;
   std::cout << "device array contains " << cuda::std::distance(first, last) << " values\n";
 
   // algorithms work as expected
@@ -32,7 +32,7 @@ int main()
   // note: raw_ptr cannot necessarily be accessed by the host!
 
   // conversely, raw pointers can be wrapped
-  [[maybe_unused]] thrust::device_ptr<int> wrapped_ptr = thrust::device_pointer_cast(raw_ptr);
+  [[maybe_unused]] const thrust::device_ptr<int> wrapped_ptr = thrust::device_pointer_cast(raw_ptr);
 
   // back to where we started
   assert(wrapped_ptr == d_ptr);

--- a/thrust/examples/discrete_voronoi.cu
+++ b/thrust/examples/discrete_voronoi.cu
@@ -45,14 +45,14 @@ struct voronoi_site_selector
     }
 
     // coordinates of points p and q
-    int y_q = q / m;
-    int x_q = q - y_q * m;
-    int y_p = p / m;
-    int x_p = p - y_p * m;
+    const int y_q = q / m;
+    const int x_q = q - y_q * m;
+    const int y_p = p / m;
+    const int x_p = p - y_p * m;
 
     // squared distances
-    int d_iq = (x_i - x_q) * (x_i - x_q) + (y_i - y_q) * (y_i - y_q);
-    int d_ip = (x_i - x_p) * (x_i - x_p) + (y_i - y_p) * (y_i - y_p);
+    const int d_iq = (x_i - x_q) * (x_i - x_q) + (y_i - y_q) * (y_i - y_q);
+    const int d_ip = (x_i - x_p) * (x_i - x_p) + (y_i - y_p) * (y_i - y_p);
 
     if (d_iq < d_ip)
     {
@@ -69,12 +69,12 @@ struct voronoi_site_selector
   __host__ __device__ int operator()(const Tuple& t)
   {
     // Current point and site
-    int i = cuda::std::get<9>(t);
-    int v = cuda::std::get<0>(t);
+    const int i = cuda::std::get<9>(t);
+    int v       = cuda::std::get<0>(t);
 
     // Current point coordinates
-    int y = i / m;
-    int x = i - y * m;
+    const int y = i / m;
+    const int x = i - y * m;
 
     if (x >= k)
     {
@@ -142,8 +142,8 @@ void generate_random_sites(thrust::host_vector<int>& t, int Nb, int m, int n)
 
   for (int k = 0; k < Nb; k++)
   {
-    int index = dist(rng);
-    t[index]  = index + 1;
+    const int index = dist(rng);
+    t[index]        = index + 1;
   }
 }
 
@@ -162,7 +162,7 @@ void vector_to_pgm(thrust::host_vector<int>& t, int m, int n, const char* out)
     return (71 * in_value) % 253;
   };
 
-  for (int value : t)
+  for (const int value : t)
   {
     f << to_grey_level(value) << " ";
   }
@@ -210,9 +210,9 @@ void display_time(timer& t)
 
 int main()
 {
-  int m = 2048; // number of rows
-  int n = 2048; // number of columns
-  int s = 1000; // number of sites
+  const int m = 2048; // number of rows
+  const int n = 2048; // number of columns
+  const int s = 1000; // number of sites
 
   timer t;
 

--- a/thrust/examples/dot_products_with_zip.cu
+++ b/thrust/examples/dot_products_with_zip.cu
@@ -79,9 +79,9 @@ int main()
   using Float3Iterator     = thrust::zip_iterator<FloatIteratorTuple>;
 
   // Now we'll create some zip_iterators for A and B
-  Float3Iterator A_first = thrust::make_zip_iterator(A0.begin(), A1.begin(), A2.begin());
-  Float3Iterator A_last  = thrust::make_zip_iterator(A0.end(), A1.end(), A2.end());
-  Float3Iterator B_first = thrust::make_zip_iterator(B0.begin(), B1.begin(), B2.begin());
+  const Float3Iterator A_first = thrust::make_zip_iterator(A0.begin(), A1.begin(), A2.begin());
+  const Float3Iterator A_last  = thrust::make_zip_iterator(A0.end(), A1.end(), A2.end());
+  const Float3Iterator B_first = thrust::make_zip_iterator(B0.begin(), B1.begin(), B2.begin());
 
   // Finally, we pass the zip_iterators into transform() as if they
   // were 'normal' iterators for a device_vector<Float3>.
@@ -107,9 +107,9 @@ int main()
   std::cout << std::fixed;
   for (size_t i = 0; i < 4; i++)
   {
-    Float3 a  = A_first[static_cast<std::ptrdiff_t>(i)];
-    Float3 b  = B_first[static_cast<std::ptrdiff_t>(i)];
-    float dot = result[i];
+    Float3 a        = A_first[static_cast<std::ptrdiff_t>(i)];
+    Float3 b        = B_first[static_cast<std::ptrdiff_t>(i)];
+    const float dot = result[i];
 
     std::cout << "(" << cuda::std::get<0>(a) << "," << cuda::std::get<1>(a) << "," << cuda::std::get<2>(a) << ")";
     std::cout << " * ";

--- a/thrust/examples/expand.cu
+++ b/thrust/examples/expand.cu
@@ -22,8 +22,8 @@ OutputIterator expand(InputIterator1 first1, InputIterator1 last1, InputIterator
 {
   using difference_type = typename cuda::std::iterator_traits<InputIterator1>::difference_type;
 
-  difference_type input_size  = cuda::std::distance(first1, last1);
-  difference_type output_size = thrust::reduce(first1, last1);
+  const difference_type input_size  = cuda::std::distance(first1, last1);
+  const difference_type output_size = thrust::reduce(first1, last1);
 
   // scan the counts to obtain output offsets for each input element
   thrust::device_vector<difference_type> output_offsets(input_size, 0);

--- a/thrust/examples/histogram.cu
+++ b/thrust/examples/histogram.cu
@@ -76,13 +76,13 @@ void dense_histogram(const Vector1& input, Vector2& histogram)
   print_vector("sorted data", data);
 
   // number of histogram bins is equal to the maximum value plus one
-  IndexType num_bins = data.back() + 1;
+  const IndexType num_bins = data.back() + 1;
 
   // resize histogram storage
   histogram.resize(num_bins);
 
   // find the end of each bin of values
-  thrust::counting_iterator<IndexType> search_begin(0);
+  const thrust::counting_iterator<IndexType> search_begin(0);
   thrust::upper_bound(data.begin(), data.end(), search_begin, search_begin + num_bins, histogram.begin());
 
   // print the cumulative histogram
@@ -115,7 +115,7 @@ void sparse_histogram(const Vector1& input, Vector2& histogram_values, Vector3& 
   print_vector("sorted data", data);
 
   // number of histogram bins is equal to number of unique values (assumes data.size() > 0)
-  IndexType num_bins = thrust::inner_product(
+  const IndexType num_bins = thrust::inner_product(
     data.begin(),
     data.end() - 1,
     data.begin() + 1,

--- a/thrust/examples/lambda.cu
+++ b/thrust/examples/lambda.cu
@@ -39,7 +39,7 @@ struct saxpy_functor
 int main()
 {
   // input data
-  float a                             = 2.0f;
+  const float a                       = 2.0f;
   thrust::device_vector<float> x_data = {1, 2, 3, 4};
   thrust::device_vector<float> y_data = {1, 1, 1, 1};
 

--- a/thrust/examples/lexicographical_sort.cu
+++ b/thrust/examples/lexicographical_sort.cu
@@ -51,7 +51,7 @@ thrust::host_vector<int> random_vector(size_t N)
 
 int main()
 {
-  size_t N = 20;
+  const size_t N = 20;
 
   // generate three arrays of random values
   thrust::device_vector<int> upper  = random_vector(N);

--- a/thrust/examples/max_abs_diff.cu
+++ b/thrust/examples/max_abs_diff.cu
@@ -24,13 +24,13 @@ int main()
   thrust::device_vector<float> d_b = {2.0, 4.0, 3.0, 0.0};
 
   // initial value of the reduction
-  float init = 0;
+  const float init = 0;
 
   // binary operations
-  cuda::maximum<float> binary_op1{};
-  abs_diff<float> binary_op2;
+  const cuda::maximum<float> binary_op1{};
+  const abs_diff<float> binary_op2;
 
-  float max_abs_diff = thrust::inner_product(d_a.begin(), d_a.end(), d_b.begin(), init, binary_op1, binary_op2);
+  const float max_abs_diff = thrust::inner_product(d_a.begin(), d_a.end(), d_b.begin(), init, binary_op1, binary_op2);
 
   std::cout << "maximum absolute difference: " << max_abs_diff << '\n';
   return 0;

--- a/thrust/examples/minimal_custom_backend.cu
+++ b/thrust/examples/minimal_custom_backend.cu
@@ -41,7 +41,7 @@ int main()
   thrust::device_vector<int> vec(1);
 
   // create an instance of our system
-  my_system sys;
+  my_system sys; // NOLINT(misc-const-correctness)
 
   // To invoke our version of for_each, pass sys as the first parameter
   thrust::for_each(sys, vec.begin(), vec.end(), cuda::std::negate{});

--- a/thrust/examples/minmax.cu
+++ b/thrust/examples/minmax.cu
@@ -52,7 +52,7 @@ struct minmax_binary_op
 int main()
 {
   // input size
-  size_t N = 10;
+  const size_t N = 10;
 
   // initialize random number generator
   thrust::default_random_engine rng;
@@ -67,14 +67,14 @@ int main()
   thrust::device_vector<int> data = host_data;
 
   // setup arguments
-  minmax_unary_op<int> unary_op;
-  minmax_binary_op<int> binary_op;
+  const minmax_unary_op<int> unary_op;
+  const minmax_binary_op<int> binary_op;
 
   // initialize reduction with the first value
-  minmax_pair<int> init = unary_op(data[0]);
+  const minmax_pair<int> init = unary_op(data[0]);
 
   // compute minimum and maximum values
-  minmax_pair<int> result = thrust::transform_reduce(data.begin(), data.end(), unary_op, init, binary_op);
+  const minmax_pair<int> result = thrust::transform_reduce(data.begin(), data.end(), unary_op, init, binary_op);
 
   // print results
   std::cout << "[ ";

--- a/thrust/examples/mode.cu
+++ b/thrust/examples/mode.cu
@@ -49,7 +49,7 @@ int main()
   std::cout << '\n';
 
   // count number of unique keys
-  size_t num_unique = thrust::unique_count(d_data.begin(), d_data.end());
+  const size_t num_unique = thrust::unique_count(d_data.begin(), d_data.end());
 
   // count multiplicity of each key
   thrust::device_vector<int> d_output_keys(num_unique);
@@ -71,8 +71,8 @@ int main()
   thrust::device_vector<int>::iterator mode_iter;
   mode_iter = thrust::max_element(d_output_counts.begin(), d_output_counts.end());
 
-  int mode        = d_output_keys[cuda::std::distance(d_output_counts.begin(), mode_iter)];
-  int occurrences = *mode_iter;
+  const int mode        = d_output_keys[cuda::std::distance(d_output_counts.begin(), mode_iter)];
+  const int occurrences = *mode_iter;
 
   std::cout << "Modal value " << mode << " occurs " << occurrences << " times " << '\n';
 

--- a/thrust/examples/monte_carlo.cu
+++ b/thrust/examples/monte_carlo.cu
@@ -24,10 +24,10 @@ struct estimate_pi
 {
   __host__ __device__ float operator()(unsigned int thread_id)
   {
-    float sum      = 0;
-    unsigned int N = 10000; // samples per thread
+    float sum            = 0;
+    const unsigned int N = 10000; // samples per thread
 
-    unsigned int seed = hash(thread_id);
+    const unsigned int seed = hash(thread_id);
 
     // seed a random number generator
     thrust::default_random_engine rng(seed);
@@ -39,11 +39,11 @@ struct estimate_pi
     for (unsigned int i = 0; i < N; ++i)
     {
       // draw a sample from the unit square
-      float x = u01(rng);
-      float y = u01(rng);
+      const float x = u01(rng);
+      const float y = u01(rng);
 
       // measure distance from the origin
-      float dist = sqrtf(x * x + y * y);
+      const float dist = sqrtf(x * x + y * y);
 
       // add 1.0f if (u0,u1) is inside the quarter circle
       if (dist <= 1.0f)
@@ -63,7 +63,7 @@ struct estimate_pi
 int main()
 {
   // use 30K independent seeds
-  int M = 30000;
+  const int M = 30000;
 
   float estimate = thrust::transform_reduce(
     thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(M), estimate_pi(), 0.0f, cuda::std::plus<float>());

--- a/thrust/examples/monte_carlo_disjoint_sequences.cu
+++ b/thrust/examples/monte_carlo_disjoint_sequences.cu
@@ -25,8 +25,8 @@ struct estimate_pi
 {
   __host__ __device__ float operator()(unsigned int thread_id)
   {
-    float sum      = 0;
-    unsigned int N = 5000; // samples per stream
+    float sum            = 0;
+    const unsigned int N = 5000; // samples per stream
 
     // note that M * N <= default_random_engine::max,
     // which is also the period of this particular RNG
@@ -46,11 +46,11 @@ struct estimate_pi
     for (unsigned int i = 0; i < N; ++i)
     {
       // draw a sample from the unit square
-      float x = u01(rng);
-      float y = u01(rng);
+      const float x = u01(rng);
+      const float y = u01(rng);
 
       // measure distance from the origin
-      float dist = sqrtf(x * x + y * y);
+      const float dist = sqrtf(x * x + y * y);
 
       // add 1.0f if (u0,u1) is inside the quarter circle
       if (dist <= 1.0f)
@@ -70,7 +70,7 @@ struct estimate_pi
 int main()
 {
   // use 30K subsequences of random numbers
-  int M = 30000;
+  const int M = 30000;
 
   float estimate = thrust::transform_reduce(
     thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(M), estimate_pi(), 0.0f, cuda::std::plus<float>());

--- a/thrust/examples/mr_basic.cu
+++ b/thrust/examples/mr_basic.cu
@@ -31,7 +31,7 @@ int main()
   {
     // no virtual calls will be issued
     using Alloc = thrust::mr::allocator<int, thrust::mr::new_delete_resource>;
-    Alloc alloc(&memres);
+    const Alloc alloc(&memres);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
   }
@@ -40,7 +40,7 @@ int main()
     // virtual calls will be issued - wrapping in a polymorphic wrapper
     thrust::mr::polymorphic_adaptor_resource<void*> adaptor(&memres);
     using Alloc = thrust::mr::polymorphic_allocator<int, void*>;
-    Alloc alloc(&adaptor);
+    const Alloc alloc(&adaptor);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
   }
@@ -51,7 +51,7 @@ int main()
     thrust::mr::polymorphic_adaptor_resource<thrust::device_ptr<void>> adaptor(
       thrust::mr::get_global_resource<Resource>());
     using Alloc = thrust::mr::polymorphic_allocator<int, thrust::device_ptr<void>>;
-    Alloc alloc(&adaptor);
+    const Alloc alloc(&adaptor);
 
     do_stuff_with_vector<thrust::device_vector<int, Alloc>>(alloc);
   }
@@ -60,7 +60,7 @@ int main()
   Pool pool(&memres);
   {
     using Alloc = thrust::mr::allocator<int, Pool>;
-    Alloc alloc(&pool);
+    const Alloc alloc(&pool);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
   }
@@ -70,7 +70,7 @@ int main()
   DisjointPool disjoint_pool(&memres, &memres);
   {
     using Alloc = thrust::mr::allocator<int, DisjointPool>;
-    Alloc alloc(&disjoint_pool);
+    const Alloc alloc(&disjoint_pool);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
   }

--- a/thrust/examples/norm.cu
+++ b/thrust/examples/norm.cu
@@ -33,12 +33,12 @@ int main()
   thrust::device_vector<float> d_x = {1.0, 2.0, 3.0, 4.0};
 
   // setup arguments
-  square<float> unary_op;
-  cuda::std::plus<float> binary_op;
-  float init = 0;
+  const square<float> unary_op;
+  const cuda::std::plus<float> binary_op;
+  const float init = 0;
 
   // compute norm
-  float norm = std::sqrt(thrust::transform_reduce(d_x.begin(), d_x.end(), unary_op, init, binary_op));
+  const float norm = std::sqrt(thrust::transform_reduce(d_x.begin(), d_x.end(), unary_op, init, binary_op));
 
   std::cout << "norm is " << norm << '\n';
 

--- a/thrust/examples/padded_grid_reduction.cu
+++ b/thrust/examples/padded_grid_reduction.cu
@@ -33,7 +33,7 @@ struct transform_tuple
 
   __host__ __device__ OutputTuple operator()(const InputTuple& t) const
   {
-    bool is_valid = (cuda::std::get<0>(t) % N) < n;
+    const bool is_valid = (cuda::std::get<0>(t) % N) < n;
     return OutputTuple(is_valid, cuda::std::get<1>(t), cuda::std::get<1>(t));
   }
 };
@@ -66,9 +66,9 @@ struct reduce_tuple
 
 int main()
 {
-  int M = 10; // number of rows
-  int n = 11; // number of columns excluding padding
-  int N = 16; // number of columns including padding
+  const int M = 10; // number of rows
+  const int n = 11; // number of columns excluding padding
+  const int N = 16; // number of columns including padding
 
   thrust::default_random_engine rng(12345);
   thrust::uniform_real_distribution<float> dist(0.0f, 1.0f);
@@ -102,8 +102,8 @@ int main()
   using result_type = cuda::std::tuple<bool, float, float>;
 
   result_type init(true, FLT_MAX, -FLT_MAX); // initial value
-  transform_tuple<int, float> unary_op(n, N); // transformation operator
-  reduce_tuple<int, float> binary_op; // reduction operator
+  const transform_tuple<int, float> unary_op(n, N); // transformation operator
+  const reduce_tuple<int, float> binary_op; // reduction operator
 
   result_type result = thrust::transform_reduce(
     thrust::make_zip_iterator(thrust::counting_iterator<int>(0), data.begin()),

--- a/thrust/examples/permutation_iterator.cu
+++ b/thrust/examples/permutation_iterator.cu
@@ -17,8 +17,8 @@ int main()
 
   // fuse gather with reduction:
   //   sum = source[map[0]] + source[map[1]] + ...
-  int sum = thrust::reduce(thrust::make_permutation_iterator(source.begin(), map.begin()),
-                           thrust::make_permutation_iterator(source.begin(), map.end()));
+  const int sum = thrust::reduce(thrust::make_permutation_iterator(source.begin(), map.begin()),
+                                 thrust::make_permutation_iterator(source.begin(), map.end()));
 
   // print sum
   std::cout << "sum is " << sum << '\n';

--- a/thrust/examples/print_version.cu
+++ b/thrust/examples/print_version.cu
@@ -4,10 +4,10 @@
 
 int main()
 {
-  int major    = THRUST_MAJOR_VERSION;
-  int minor    = THRUST_MINOR_VERSION;
-  int subminor = THRUST_SUBMINOR_VERSION;
-  int patch    = THRUST_PATCH_NUMBER;
+  const int major    = THRUST_MAJOR_VERSION;
+  const int minor    = THRUST_MINOR_VERSION;
+  const int subminor = THRUST_SUBMINOR_VERSION;
+  const int patch    = THRUST_PATCH_NUMBER;
 
   std::cout << "Thrust v" << major << "." << minor << "." << subminor << "-" << patch << '\n';
 

--- a/thrust/examples/remove_points2d.cu
+++ b/thrust/examples/remove_points2d.cu
@@ -57,7 +57,7 @@ int main()
   std::cout << '\n';
 
   // remove points where x^2 + y^2 > 1 and determine new array sizes
-  size_t new_size =
+  const size_t new_size =
     thrust::remove_if(thrust::make_zip_iterator(x.begin(), y.begin()),
                       thrust::make_zip_iterator(x.end(), y.end()),
                       is_outside_circle<float>())

--- a/thrust/examples/repeated_range.cu
+++ b/thrust/examples/repeated_range.cu
@@ -77,13 +77,13 @@ int main()
   using Iterator = thrust::device_vector<int>::iterator;
 
   // create repeated_range with elements repeated twice
-  repeated_range<Iterator> twice(data.begin(), data.end(), 2);
+  const repeated_range<Iterator> twice(data.begin(), data.end(), 2);
   std::cout << "repeated x2: ";
   thrust::copy(twice.begin(), twice.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << '\n';
 
   // create repeated_range with elements repeated x3
-  repeated_range<Iterator> thrice(data.begin(), data.end(), 3);
+  const repeated_range<Iterator> thrice(data.begin(), data.end(), 3);
   std::cout << "repeated x3: ";
   thrust::copy(thrice.begin(), thrice.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << '\n';

--- a/thrust/examples/run_length_decoding.cu
+++ b/thrust/examples/run_length_decoding.cu
@@ -39,7 +39,7 @@ int main()
   thrust::inclusive_scan(lengths.begin(), lengths.end(), lengths.begin());
 
   // output size is sum of the run lengths
-  int N = lengths.back();
+  const int N = lengths.back();
 
   // compute input index for each output element
   thrust::device_vector<int> indices(N);

--- a/thrust/examples/run_length_encoding.cu
+++ b/thrust/examples/run_length_encoding.cu
@@ -31,7 +31,7 @@ int main()
   std::cout << '\n' << '\n';
 
   // compute run lengths
-  size_t num_runs =
+  const size_t num_runs =
     thrust::reduce_by_key(
       input.begin(),
       input.end(), // input key sequence

--- a/thrust/examples/saxpy.cu
+++ b/thrust/examples/saxpy.cu
@@ -53,8 +53,8 @@ void saxpy_slow(float A, thrust::device_vector<float>& X, thrust::device_vector<
 int main()
 {
   // initialize host arrays
-  thrust::host_vector<float> x{1.0, 1.0, 1.0, 1.0};
-  thrust::host_vector<float> y{1.0, 2.0, 3.0, 4.0};
+  const thrust::host_vector<float> x{1.0, 1.0, 1.0, 1.0};
+  const thrust::host_vector<float> y{1.0, 2.0, 3.0, 4.0};
 
   {
     // transfer to device

--- a/thrust/examples/scan_by_key.cu
+++ b/thrust/examples/scan_by_key.cu
@@ -31,7 +31,7 @@ int main()
   int flags[]  = {1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0}; // segments represented with head flags
   int values[] = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}; // values corresponding to each key
 
-  int N = sizeof(keys) / sizeof(int); // number of elements
+  const int N = sizeof(keys) / sizeof(int); // number of elements
 
   // copy input data to device
   thrust::device_vector<int> d_keys(keys, keys + N);

--- a/thrust/examples/scan_matrix_by_rows.cu
+++ b/thrust/examples/scan_matrix_by_rows.cu
@@ -46,11 +46,11 @@ struct which_row
 __host__ void scan_matrix_by_rows1(thrust::device_vector<int>& u, int n, int m)
 {
   // This `thrust::counting_iterator` represents the index of the element.
-  thrust::counting_iterator<int> c_first(0);
+  const thrust::counting_iterator<int> c_first(0);
 
   // We construct a `thrust::transform_iterator` which applies the `which_row`
   // function object to the index of each element.
-  thrust::transform_iterator<which_row, thrust::counting_iterator<int>> t_first(c_first, which_row(m));
+  const thrust::transform_iterator<which_row, thrust::counting_iterator<int>> t_first(c_first, which_row(m));
 
   // Finally, we use our `thrust::transform_iterator` as the key sequence to
   // `thrust::inclusive_scan_by_key`.

--- a/thrust/examples/set_operations.cu
+++ b/thrust/examples/set_operations.cu
@@ -127,7 +127,7 @@ template <typename Vector>
 void SetIntersectionSize(const Vector& A, const Vector& B)
 {
   // computes the exact size of the intersection without allocating output
-  thrust::discard_iterator<> C_begin, C_end;
+  thrust::discard_iterator<> C_begin, C_end; // NOLINT(misc-const-correctness)
 
   C_end = thrust::set_intersection(A.begin(), A.end(), B.begin(), B.end(), C_begin);
 
@@ -139,8 +139,8 @@ int main()
   int a[] = {0, 2, 4, 5, 6, 8, 9};
   int b[] = {0, 1, 2, 3, 5, 7, 8};
 
-  thrust::device_vector<int> A(a, a + sizeof(a) / sizeof(int));
-  thrust::device_vector<int> B(b, b + sizeof(b) / sizeof(int));
+  const thrust::device_vector<int> A(a, a + sizeof(a) / sizeof(int));
+  const thrust::device_vector<int> B(b, b + sizeof(b) / sizeof(int));
 
   print("Set A", A);
   print("Set B", B);

--- a/thrust/examples/set_operations.cu
+++ b/thrust/examples/set_operations.cu
@@ -127,9 +127,8 @@ template <typename Vector>
 void SetIntersectionSize(const Vector& A, const Vector& B)
 {
   // computes the exact size of the intersection without allocating output
-  thrust::discard_iterator<> C_begin, C_end; // NOLINT(misc-const-correctness)
-
-  C_end = thrust::set_intersection(A.begin(), A.end(), B.begin(), B.end(), C_begin);
+  thrust::discard_iterator<> C_begin;
+  const auto C_end = thrust::set_intersection(A.begin(), A.end(), B.begin(), B.end(), C_begin);
 
   std::cout << "SetIntersectionSize(A,B) " << (C_end - C_begin) << '\n';
 }

--- a/thrust/examples/simple_moving_average.cu
+++ b/thrust/examples/simple_moving_average.cu
@@ -61,10 +61,10 @@ void simple_moving_average(const InputVector& data, size_t w, OutputVector& outp
 int main()
 {
   // length of data series
-  size_t n = 30;
+  const size_t n = 30;
 
   // window size of the moving average
-  size_t w = 4;
+  const size_t w = 4;
 
   // generate random data series
   thrust::host_vector<float> host_data(n);
@@ -74,7 +74,7 @@ int main()
   {
     e = static_cast<float>(dist(rng));
   }
-  thrust::device_vector<float> data = host_data;
+  const thrust::device_vector<float> data = host_data;
 
   // allocate storage for averages
   thrust::device_vector<float> averages(data.size() - (w - 1));

--- a/thrust/examples/sort.cu
+++ b/thrust/examples/sort.cu
@@ -43,9 +43,9 @@ void initialize(thrust::device_vector<cuda::std::pair<int, int>>& v)
   thrust::host_vector<cuda::std::pair<int, int>> host_data(v.size());
   for (auto& e : host_data)
   {
-    int a = dist(rng);
-    int b = dist(rng);
-    e     = cuda::std::make_pair(a, b);
+    const int a = dist(rng);
+    const int b = dist(rng);
+    e           = cuda::std::make_pair(a, b);
   }
   v = host_data;
 }
@@ -85,7 +85,7 @@ void print(const thrust::device_vector<cuda::std::pair<int, int>>& v)
 {
   for (const auto& p : v)
   {
-    cuda::std::pair<int, int> local_p = p;
+    const cuda::std::pair<int, int> local_p = p;
     std::cout << " (" << local_p.first << "," << local_p.second << ")";
   }
   std::cout << "\n";
@@ -123,7 +123,7 @@ struct evens_before_odds
 
 int main()
 {
-  size_t N = 16;
+  const size_t N = 16;
 
   std::cout << "sorting integers\n";
   {

--- a/thrust/examples/sorting_aos_vs_soa.cu
+++ b/thrust/examples/sorting_aos_vs_soa.cu
@@ -61,7 +61,7 @@ void initialize_keys(thrust::device_vector<MyStruct>& structures)
 
 int main()
 {
-  size_t N = 2 * 1024 * 1024;
+  const size_t N = 2 * 1024 * 1024;
 
   // Sort Key-Value pairs using Array of Structures (AoS) storage
   {

--- a/thrust/examples/sparse_vector.cu
+++ b/thrust/examples/sparse_vector.cu
@@ -39,8 +39,8 @@ void sum_sparse_vectors(
   assert(A_index.size() == A_value.size());
   assert(B_index.size() == B_value.size());
 
-  size_t A_size = A_index.size();
-  size_t B_size = B_index.size();
+  const size_t A_size = A_index.size();
+  const size_t B_size = B_index.size();
 
   // allocate storage for the combined contents of sparse vectors A and B
   IndexVector3 temp_index(A_size + B_size);
@@ -58,7 +58,7 @@ void sum_sparse_vectors(
     temp_value.begin());
 
   // compute number of unique indices
-  size_t C_size =
+  const size_t C_size =
     thrust::inner_product(
       temp_index.begin(),
       temp_index.end() - 1,

--- a/thrust/examples/stream_compaction.cu
+++ b/thrust/examples/stream_compaction.cu
@@ -32,7 +32,7 @@ void print_range(const std::string& name, Iterator first, Iterator last)
 int main()
 {
   // input size
-  size_t N = 10;
+  const size_t N = 10;
 
   // define some types
   using Vector   = thrust::device_vector<int>;
@@ -50,13 +50,13 @@ int main()
   Vector output(values.size());
 
   // copy odd numbers to separate array
-  Iterator output_end = thrust::copy_if(values.begin(), values.end(), output.begin(), is_odd<int>());
+  const Iterator output_end = thrust::copy_if(values.begin(), values.end(), output.begin(), is_odd<int>());
 
   print_range("output", output.begin(), output_end);
 
   // another approach is to count the number of values that will
   // be copied, and allocate an array of the right size
-  size_t N_odd = thrust::count_if(values.begin(), values.end(), is_odd<int>());
+  const size_t N_odd = thrust::count_if(values.begin(), values.end(), is_odd<int>());
 
   Vector small_output(N_odd);
 
@@ -65,7 +65,7 @@ int main()
   print_range("small_output", small_output.begin(), small_output.end());
 
   // we can also compact sequences with the remove functions, which do the opposite of copy
-  Iterator values_end = thrust::remove_if(values.begin(), values.end(), is_odd<int>());
+  const Iterator values_end = thrust::remove_if(values.begin(), values.end(), is_odd<int>());
 
   // since the values after values_end are garbage, we'll resize the vector
   values.resize(values_end - values.begin());

--- a/thrust/examples/strided_range.cu
+++ b/thrust/examples/strided_range.cu
@@ -85,11 +85,11 @@ int main()
   using Iterator = thrust::device_vector<int>::iterator;
 
   // create strided_range with indices [0,2,4,6]
-  strided_range<Iterator> evens(data.begin(), data.end(), 2);
+  const strided_range<Iterator> evens(data.begin(), data.end(), 2);
   std::cout << "sum of even indices: " << thrust::reduce(evens.begin(), evens.end()) << '\n';
 
   // create strided_range with indices [1,3,5,7]
-  strided_range<Iterator> odds(data.begin() + 1, data.end(), 2);
+  const strided_range<Iterator> odds(data.begin() + 1, data.end(), 2);
   std::cout << "sum of odd indices:  " << thrust::reduce(odds.begin(), odds.end()) << '\n';
 
   // set odd elements to 0 with fill()

--- a/thrust/examples/sum.cu
+++ b/thrust/examples/sum.cu
@@ -24,13 +24,13 @@ int main()
   thrust::device_vector<int> d_vec = h_vec;
 
   // initial value of the reduction
-  int init = 0;
+  const int init = 0;
 
   // binary operation used to reduce values
-  cuda::std::plus<int> binary_op;
+  const cuda::std::plus<int> binary_op;
 
   // compute sum on the device
-  int sum = thrust::reduce(d_vec.begin(), d_vec.end(), init, binary_op);
+  const int sum = thrust::reduce(d_vec.begin(), d_vec.end(), init, binary_op);
 
   // print the sum
   std::cout << "sum is " << sum << '\n';

--- a/thrust/examples/sum_columns.cu
+++ b/thrust/examples/sum_columns.cu
@@ -45,8 +45,8 @@ int main()
   // Create a transposed view of the multidimensional array.
   auto M_transposed = thrust::make_permutation_iterator(
     M.data_handle(), thrust::make_transform_iterator(cuda::counting_iterator(0), [=] __host__ __device__(int flat) {
-      int i = flat / cols;
-      int j = flat % cols;
+      const int i = flat / cols;
+      const int j = flat % cols;
       return i + j * rows;
     }));
 

--- a/thrust/examples/summary_statistics.cu
+++ b/thrust/examples/summary_statistics.cu
@@ -135,14 +135,14 @@ int main()
   using T = float;
 
   // initialize host array
-  thrust::host_vector<T> h_x{4, 7, 13, 16};
+  const thrust::host_vector<T> h_x{4, 7, 13, 16};
 
   // transfer to device
   thrust::device_vector<T> d_x(h_x);
 
   // setup arguments
-  summary_stats_unary_op<T> unary_op;
-  summary_stats_binary_op<T> binary_op;
+  const summary_stats_unary_op<T> unary_op;
+  const summary_stats_binary_op<T> binary_op;
   summary_stats_data<T> init;
 
   init.initialize();

--- a/thrust/examples/summed_area_table.cu
+++ b/thrust/examples/summed_area_table.cu
@@ -24,8 +24,8 @@ struct transpose_index
 
   __host__ __device__ size_t operator()(size_t linear_index)
   {
-    size_t i = linear_index / n;
-    size_t j = linear_index % n;
+    const size_t i = linear_index / n;
+    const size_t j = linear_index % n;
 
     return m * j + i;
   }
@@ -50,7 +50,7 @@ struct row_index
 template <typename T>
 void transpose(size_t m, size_t n, thrust::device_vector<T>& src, thrust::device_vector<T>& dst)
 {
-  thrust::counting_iterator<size_t> indices(0);
+  const thrust::counting_iterator<size_t> indices(0);
 
   thrust::gather(thrust::make_transform_iterator(indices, transpose_index(n, m)),
                  thrust::make_transform_iterator(indices, transpose_index(n, m)) + dst.size(),
@@ -62,7 +62,7 @@ void transpose(size_t m, size_t n, thrust::device_vector<T>& src, thrust::device
 template <typename T>
 void scan_horizontally(size_t n, thrust::device_vector<T>& d_data)
 {
-  thrust::counting_iterator<size_t> indices(0);
+  const thrust::counting_iterator<size_t> indices(0);
 
   thrust::inclusive_scan_by_key(
     thrust::make_transform_iterator(indices, row_index(n)),
@@ -89,8 +89,8 @@ void print(size_t m, size_t n, thrust::device_vector<T>& d_data)
 
 int main()
 {
-  size_t m = 3; // number of rows
-  size_t n = 4; // number of columns
+  const size_t m = 3; // number of rows
+  const size_t n = 4; // number of columns
 
   // 2d array stored in row-major order [(0,0), (0,1), (0,2) ... ]
   thrust::device_vector<int> data(m * n, 1);

--- a/thrust/examples/tiled_range.cu
+++ b/thrust/examples/tiled_range.cu
@@ -77,13 +77,13 @@ int main()
   using Iterator = thrust::device_vector<int>::iterator;
 
   // create tiled_range with two tiles
-  tiled_range<Iterator> two(data.begin(), data.end(), 2);
+  const tiled_range<Iterator> two(data.begin(), data.end(), 2);
   std::cout << "two tiles:   ";
   thrust::copy(two.begin(), two.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << '\n';
 
   // create tiled_range with three tiles
-  tiled_range<Iterator> three(data.begin(), data.end(), 3);
+  const tiled_range<Iterator> three(data.begin(), data.end(), 3);
   std::cout << "three tiles: ";
   thrust::copy(three.begin(), three.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << '\n';

--- a/thrust/examples/transform_input_output_iterator.cu
+++ b/thrust/examples/transform_input_output_iterator.cu
@@ -26,8 +26,8 @@ public:
 
   __host__ __device__ ScaledInteger rescale(int scale) const
   {
-    int shift  = scale - scale_;
-    int result = shift < 0 ? value_ << (-shift) : value_ >> shift;
+    const int shift  = scale - scale_;
+    const int result = shift < 0 ? value_ << (-shift) : value_ >> shift;
     return ScaledInteger{result, scale};
   }
 
@@ -94,7 +94,7 @@ int main()
 
   thrust::host_vector<int> A_h(A);
   thrust::host_vector<int> B_h(B);
-  thrust::host_vector<int> C_h(C);
+  const thrust::host_vector<int> C_h(C);
 
   std::cout << std::hex;
 

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -59,8 +59,8 @@ void print_range(const std::string& name, Iterator first, Iterator last)
 int main()
 {
   // clamp values to the range [1, 5]
-  int lo = 1;
-  int hi = 5;
+  const int lo = 1;
+  const int hi = 5;
 
   // define some types
   using Vector         = thrust::device_vector<int>;
@@ -84,8 +84,8 @@ int main()
   using ClampedVectorIterator = thrust::transform_iterator<clamp<int>, VectorIterator>;
 
   // create a transform_iterator that applies clamp() to the values array
-  ClampedVectorIterator cv_begin = thrust::make_transform_iterator(values.begin(), clamp<int>(lo, hi));
-  ClampedVectorIterator cv_end   = cv_begin + static_cast<std::ptrdiff_t>(values.size());
+  const ClampedVectorIterator cv_begin = thrust::make_transform_iterator(values.begin(), clamp<int>(lo, hi));
+  const ClampedVectorIterator cv_end   = cv_begin + static_cast<std::ptrdiff_t>(values.size());
 
   // now [clamped_begin, clamped_end) defines a sequence of clamped values
   print_range("clamped values ", cv_begin, cv_end);
@@ -99,13 +99,13 @@ int main()
   using CountingIterator        = thrust::counting_iterator<int>;
   using ClampedCountingIterator = thrust::transform_iterator<clamp<int>, CountingIterator>;
 
-  CountingIterator count_begin(0);
-  CountingIterator count_end(10);
+  const CountingIterator count_begin(0);
+  const CountingIterator count_end(10);
 
   print_range("sequence         ", count_begin, count_end);
 
-  ClampedCountingIterator cs_begin = thrust::make_transform_iterator(count_begin, clamp<int>(lo, hi));
-  ClampedCountingIterator cs_end   = thrust::make_transform_iterator(count_end, clamp<int>(lo, hi));
+  const ClampedCountingIterator cs_begin = thrust::make_transform_iterator(count_begin, clamp<int>(lo, hi));
+  const ClampedCountingIterator cs_end   = thrust::make_transform_iterator(count_end, clamp<int>(lo, hi));
 
   print_range("clamped sequence ", cs_begin, cs_end);
 
@@ -113,8 +113,8 @@ int main()
   // combine transform_iterator with another transform_iterator
   using NegatedClampedCountingIterator = thrust::transform_iterator<cuda::std::negate<int>, ClampedCountingIterator>;
 
-  NegatedClampedCountingIterator ncs_begin = thrust::make_transform_iterator(cs_begin, cuda::std::negate<int>());
-  NegatedClampedCountingIterator ncs_end   = thrust::make_transform_iterator(cs_end, cuda::std::negate<int>());
+  const NegatedClampedCountingIterator ncs_begin = thrust::make_transform_iterator(cs_begin, cuda::std::negate<int>());
+  const NegatedClampedCountingIterator ncs_end   = thrust::make_transform_iterator(cs_end, cuda::std::negate<int>());
 
   print_range("negated sequence ", ncs_begin, ncs_end);
 
@@ -122,8 +122,8 @@ int main()
   // when a functor does not define result_type, a third template argument must be provided
   using NegatedVectorIterator = thrust::transform_iterator<simple_negate<int>, VectorIterator, int>;
 
-  NegatedVectorIterator nv_begin(values.begin(), simple_negate<int>());
-  NegatedVectorIterator nv_end(values.end(), simple_negate<int>());
+  const NegatedVectorIterator nv_begin(values.begin(), simple_negate<int>());
+  const NegatedVectorIterator nv_end(values.end(), simple_negate<int>());
 
   print_range("negated values ", nv_begin, nv_end);
 

--- a/thrust/examples/transform_output_iterator.cu
+++ b/thrust/examples/transform_output_iterator.cu
@@ -19,10 +19,10 @@ struct Functor
 
 int main()
 {
-  thrust::host_vector<float> u{4, 3, 2, 1};
-  thrust::host_vector<float> v{-1, 1, 1, -1};
-  thrust::host_vector<int> idx{3, 0, 1};
-  thrust::host_vector<float> w{0, 0, 0};
+  const thrust::host_vector<float> u{4, 3, 2, 1};
+  const thrust::host_vector<float> v{-1, 1, 1, -1};
+  const thrust::host_vector<int> idx{3, 0, 1};
+  const thrust::host_vector<float> w{0, 0, 0};
 
   thrust::device_vector<float> U(u);
   thrust::device_vector<float> V(v);

--- a/thrust/examples/weld_vertices.cu
+++ b/thrust/examples/weld_vertices.cu
@@ -42,7 +42,7 @@ int main()
   // allocate memory for input mesh representation
   thrust::device_vector<vec2> input(9);
 
-  thrust::host_vector<vec2> h_input{
+  const thrust::host_vector<vec2> h_input{
     vec2(0, 0),
     vec2(1, 0),
     vec2(0, 1), // First Triangle

--- a/thrust/examples/word_count.cu
+++ b/thrust/examples/word_count.cu
@@ -68,10 +68,10 @@ int main()
   std::cout << raw_input << "\n";
 
   // transfer to device
-  thrust::device_vector<char> input(cuda::std::begin(raw_input), cuda::std::end(raw_input));
+  const thrust::device_vector<char> input(cuda::std::begin(raw_input), cuda::std::end(raw_input));
 
   // count words
-  int wc = word_count(input);
+  const int wc = word_count(input);
 
   std::cout << "Text sample contains " << wc << " words\n";
 

--- a/thrust/testing/allocator.cu
+++ b/thrust/testing/allocator.cu
@@ -33,8 +33,8 @@ struct my_allocator_with_custom_construct1 : thrust::device_malloc_allocator<T>
 template <typename T>
 void TestAllocatorCustomDefaultConstruct(size_t n)
 {
-  thrust::device_vector<T> ref(n, 13);
-  thrust::device_vector<T, my_allocator_with_custom_construct1<T>> vec(n);
+  const thrust::device_vector<T> ref(n, 13);
+  const thrust::device_vector<T, my_allocator_with_custom_construct1<T>> vec(n);
 
   ASSERT_EQUAL_QUIET(ref, vec);
 }
@@ -55,9 +55,9 @@ struct my_allocator_with_custom_construct2 : thrust::device_malloc_allocator<T>
 template <typename T>
 void TestAllocatorCustomCopyConstruct(size_t n)
 {
-  thrust::device_vector<T> ref(n, 13);
+  const thrust::device_vector<T> ref(n, 13);
   thrust::device_vector<T> copy_from(n, 7);
-  thrust::device_vector<T, my_allocator_with_custom_construct2<T>> vec(copy_from.begin(), copy_from.end());
+  const thrust::device_vector<T, my_allocator_with_custom_construct2<T>> vec(copy_from.begin(), copy_from.end());
 
   ASSERT_EQUAL_QUIET(ref, vec);
 }
@@ -130,7 +130,7 @@ void TestAllocatorCustomDestroy(size_t n)
   my_allocator_with_custom_destroy<T>::g_state = false;
 
   {
-    thrust::cpp::vector<T, my_allocator_with_custom_destroy<T>> vec(n);
+    const thrust::cpp::vector<T, my_allocator_with_custom_destroy<T>> vec(n);
   } // destroy everything
 
   // state should only be true when there are values to destroy:
@@ -176,8 +176,8 @@ void TestAllocatorMinimal(size_t n)
   thrust::cpp::vector<int, my_minimal_allocator<int>> vec(n, 13);
 
   // XXX copy to h_vec because ASSERT_EQUAL doesn't know about cpp::vector
-  thrust::host_vector<int> h_vec(vec.begin(), vec.end());
-  thrust::host_vector<int> ref(n, 13);
+  const thrust::host_vector<int> h_vec(vec.begin(), vec.end());
+  const thrust::host_vector<int> ref(n, 13);
 
   ASSERT_EQUAL(ref, h_vec);
 }

--- a/thrust/testing/allocator_aware_policies.cu
+++ b/thrust/testing/allocator_aware_policies.cu
@@ -77,7 +77,7 @@ struct TestAllocatorAttachment
 
   void operator()()
   {
-    typename PolicyInfo::policy policy;
+    typename PolicyInfo::policy policy; // NOLINT(misc-const-correctness)
 
     // test correctness of attachment
     assert_correct<test_allocator_t<int>>(policy(test_allocator_t<int>()));

--- a/thrust/testing/binary_search_vector.cu
+++ b/thrust/testing/binary_search_vector.cu
@@ -36,12 +36,12 @@ void TestVectorLowerBoundSimple()
   IntVector integral_output(10);
   thrust::lower_bound(vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin());
 
-  typename IntVector::iterator output_end =
+  const typename IntVector::iterator output_end =
     thrust::lower_bound(vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin());
 
   ASSERT_EQUAL((output_end - integral_output.begin()), 10);
 
-  IntVector ref{0, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+  const IntVector ref{0, 1, 1, 2, 2, 2, 3, 3, 4, 5};
   ASSERT_EQUAL(integral_output, ref);
 
   //    // test with iterator output type
@@ -74,7 +74,7 @@ void TestVectorLowerBoundDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::lower_bound(sys, vec.begin(), vec.end(), vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -116,12 +116,12 @@ void TestVectorUpperBoundSimple()
 
   // test with integral output type
   IntVector integral_output(10);
-  typename IntVector::iterator output_end =
+  const typename IntVector::iterator output_end =
     thrust::upper_bound(vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin());
 
   ASSERT_EQUAL((output_end - integral_output.begin()), 10);
 
-  IntVector ref{1, 1, 2, 2, 2, 3, 3, 4, 5, 5};
+  const IntVector ref{1, 1, 2, 2, 2, 3, 3, 4, 5, 5};
   ASSERT_EQUAL(integral_output, ref);
 
   //    // test with iterator output type
@@ -154,7 +154,7 @@ void TestVectorUpperBoundDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::upper_bound(sys, vec.begin(), vec.end(), vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -197,22 +197,22 @@ void TestVectorBinarySearchSimple()
 
   // test with boolean output type
   BoolVector bool_output(10);
-  typename BoolVector::iterator bool_output_end =
+  const typename BoolVector::iterator bool_output_end =
     thrust::binary_search(vec.begin(), vec.end(), input.begin(), input.end(), bool_output.begin());
 
   ASSERT_EQUAL((bool_output_end - bool_output.begin()), 10);
 
-  BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
+  const BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
   ASSERT_EQUAL(bool_output, bool_ref);
 
   // test with integral output type
   IntVector integral_output(10, 2);
-  typename IntVector::iterator int_output_end =
+  const typename IntVector::iterator int_output_end =
     thrust::binary_search(vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin());
 
   ASSERT_EQUAL((int_output_end - integral_output.begin()), 10);
 
-  IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
+  const IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
   ASSERT_EQUAL(integral_output, int_ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorBinarySearchSimple);
@@ -229,7 +229,7 @@ void TestVectorBinarySearchDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::binary_search(sys, vec.begin(), vec.end(), vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -343,12 +343,12 @@ struct TestVectorLowerBoundDiscardIterator
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::lower_bound(h_vec.begin(), h_vec.end(), h_input.begin(), h_input.end(), thrust::make_discard_iterator());
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::lower_bound(d_vec.begin(), d_vec.end(), d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
 
     ASSERT_EQUAL_QUIET(reference, h_result);
     ASSERT_EQUAL_QUIET(reference, d_result);
@@ -368,12 +368,12 @@ struct TestVectorUpperBoundDiscardIterator
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::upper_bound(h_vec.begin(), h_vec.end(), h_input.begin(), h_input.end(), thrust::make_discard_iterator());
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::upper_bound(d_vec.begin(), d_vec.end(), d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
 
     ASSERT_EQUAL_QUIET(reference, h_result);
     ASSERT_EQUAL_QUIET(reference, d_result);
@@ -393,12 +393,12 @@ struct TestVectorBinarySearchDiscardIterator
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> h_result = thrust::binary_search(
+    const thrust::discard_iterator<> h_result = thrust::binary_search(
       h_vec.begin(), h_vec.end(), h_input.begin(), h_input.end(), thrust::make_discard_iterator());
-    thrust::discard_iterator<> d_result = thrust::binary_search(
+    const thrust::discard_iterator<> d_result = thrust::binary_search(
       d_vec.begin(), d_vec.end(), d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
 
     ASSERT_EQUAL_QUIET(reference, h_result);
     ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/binary_search_vector_descending.cu
+++ b/thrust/testing/binary_search_vector_descending.cu
@@ -35,12 +35,12 @@ void TestVectorLowerBoundDescendingSimple()
 
   // test with integral output type
   IntVector integral_output(10);
-  typename IntVector::iterator output_end = thrust::lower_bound(
+  const typename IntVector::iterator output_end = thrust::lower_bound(
     vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(integral_output.end(), output_end);
 
-  IntVector ref{4, 4, 3, 3, 3, 2, 2, 1, 0, 0};
+  const IntVector ref{4, 4, 3, 3, 3, 2, 2, 1, 0, 0};
   ASSERT_EQUAL(ref, integral_output);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorLowerBoundDescendingSimple);
@@ -59,12 +59,12 @@ void TestVectorUpperBoundDescendingSimple()
 
   // test with integral output type
   IntVector integral_output(10);
-  typename IntVector::iterator output_end = thrust::upper_bound(
+  const typename IntVector::iterator output_end = thrust::upper_bound(
     vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(output_end, integral_output.end());
 
-  IntVector ref{5, 4, 4, 3, 3, 3, 2, 2, 1, 0};
+  const IntVector ref{5, 4, 4, 3, 3, 3, 2, 2, 1, 0};
   ASSERT_EQUAL(ref, integral_output);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorUpperBoundDescendingSimple);
@@ -84,22 +84,22 @@ void TestVectorBinarySearchDescendingSimple()
 
   // test with boolean output type
   BoolVector bool_output(10);
-  typename BoolVector::iterator bool_output_end = thrust::binary_search(
+  const typename BoolVector::iterator bool_output_end = thrust::binary_search(
     vec.begin(), vec.end(), input.begin(), input.end(), bool_output.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(bool_output_end, bool_output.end());
 
-  BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
+  const BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
   ASSERT_EQUAL(bool_ref, bool_output);
 
   // test with integral output type
   IntVector integral_output(10, 2);
-  typename IntVector::iterator int_output_end = thrust::binary_search(
+  const typename IntVector::iterator int_output_end = thrust::binary_search(
     vec.begin(), vec.end(), input.begin(), input.end(), integral_output.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(int_output_end, integral_output.end());
 
-  IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
+  const IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
 
   ASSERT_EQUAL(int_ref, integral_output);
 }

--- a/thrust/testing/caching_allocator.cu
+++ b/thrust/testing/caching_allocator.cu
@@ -10,10 +10,10 @@ void test_implementation(Allocator alloc)
   using Traits = typename cuda::std::allocator_traits<Allocator>;
   using Ptr    = typename Allocator::pointer;
 
-  Ptr p = Traits::allocate(alloc, 123);
+  const Ptr p = Traits::allocate(alloc, 123);
   Traits::deallocate(alloc, p, 123);
 
-  Ptr p2 = Traits::allocate(alloc, 123);
+  const Ptr p2 = Traits::allocate(alloc, 123);
   ASSERT_EQUAL(p, p2);
 }
 

--- a/thrust/testing/catch2_test_adjacent_difference.cu
+++ b/thrust/testing/catch2_test_adjacent_difference.cu
@@ -112,12 +112,12 @@ TEMPLATE_LIST_TEST_CASE("AdjacentDifferenceDiscardIterator", "[adjacent_differen
     thrust::host_vector<T> h_input   = unittest::random_samples<T>(n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::adjacent_difference(h_input.begin(), h_input.end(), thrust::make_discard_iterator());
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::adjacent_difference(d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     CHECK((reference == h_result));
     CHECK((reference == d_result));
@@ -135,7 +135,7 @@ TEST_CASE("AdjacentDifferenceDispatchExplicit", "[adjacent_difference]")
 {
   thrust::device_vector<int> d_input(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::adjacent_difference(sys, d_input.begin(), d_input.end(), d_input.begin());
 
   CHECK(sys.is_valid());

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -45,7 +45,7 @@ TEST_CASE("ScalarLowerBoundDispatchExplicit", "[binary_search]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::lower_bound(sys, vec.begin(), vec.end(), 0);
 
   CHECK(sys.is_valid());
@@ -122,7 +122,7 @@ TEST_CASE("ScalarUpperBoundDispatchExplicit", "[binary_search]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::upper_bound(sys, vec.begin(), vec.end(), 0);
 
   CHECK(sys.is_valid());
@@ -173,7 +173,7 @@ TEST_CASE("ScalarBinarySearchDispatchExplicit", "[binary_search]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::binary_search(sys, vec.begin(), vec.end(), 0);
 
   CHECK(sys.is_valid());
@@ -235,7 +235,7 @@ TEST_CASE("ScalarEqualRangeDispatchExplicit", "[binary_search]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::equal_range(sys, vec.begin(), vec.end(), 0);
 
   CHECK(sys.is_valid());
@@ -262,8 +262,8 @@ _CCCL_DIAG_POP
 
 void TestBoundsWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   CHECK(::cuda::std::distance(begin, end) == 1ll << magnitude);
 
   ::cuda::std::intmax_t distance_low_value =
@@ -286,7 +286,7 @@ void TestBoundsWithBigIndexesHelper(int magnitude)
 
 TEST_CASE("BoundsWithBigIndexes", "[binary_search]")
 {
-  for (int magnitude : {30, 31, 32, 33})
+  for (const int magnitude : {30, 31, 32, 33})
   {
     TestBoundsWithBigIndexesHelper(magnitude);
   }

--- a/thrust/testing/catch2_test_binary_transform.cu
+++ b/thrust/testing/catch2_test_binary_transform.cu
@@ -54,7 +54,7 @@ TEST_CASE("BinaryDispatchExplicit", "[transform]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   CHECK(sys.is_valid());
@@ -94,7 +94,7 @@ TEMPLATE_LIST_TEST_CASE("BinarySimple", "[transform_if]", vector_list)
   Vector output{1, 2, 3};
   Vector result{5, 2, -3};
 
-  ::cuda::std::identity identity;
+  const ::cuda::std::identity identity;
 
   iter = thrust::transform_if(
     input1.begin(),
@@ -133,7 +133,7 @@ TEST_CASE("BinaryDispatchExplicit", "[transform_if]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_if(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   CHECK(sys.is_valid());
@@ -221,12 +221,12 @@ TEMPLATE_LIST_TEST_CASE("BinaryToDiscardIterator", "[transform]", variable_list)
     thrust::device_vector<T> d_input1 = h_input1;
     thrust::device_vector<T> d_input2 = h_input2;
 
-    thrust::discard_iterator<> h_result = thrust::transform(
+    const thrust::discard_iterator<> h_result = thrust::transform(
       h_input1.begin(), h_input1.end(), h_input2.begin(), thrust::make_discard_iterator(), ::cuda::std::minus<T>());
-    thrust::discard_iterator<> d_result = thrust::transform(
+    const thrust::discard_iterator<> d_result = thrust::transform(
       d_input1.begin(), d_input1.end(), d_input2.begin(), thrust::make_discard_iterator(), ::cuda::std::minus<T>());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     CHECK((reference == h_result));
     CHECK((reference == d_result));
@@ -306,7 +306,7 @@ TEMPLATE_LIST_TEST_CASE("BinaryToDiscardIterator", "[transform_if]", variable_li
     thrust::device_vector<T> d_input2  = h_input2;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    thrust::discard_iterator<> h_result = thrust::transform_if(
+    const thrust::discard_iterator<> h_result = thrust::transform_if(
       h_input1.begin(),
       h_input1.end(),
       h_input2.begin(),
@@ -315,7 +315,7 @@ TEMPLATE_LIST_TEST_CASE("BinaryToDiscardIterator", "[transform_if]", variable_li
       ::cuda::std::minus<T>(),
       is_positive());
 
-    thrust::discard_iterator<> d_result = thrust::transform_if(
+    const thrust::discard_iterator<> d_result = thrust::transform_if(
       d_input1.begin(),
       d_input1.end(),
       d_input2.begin(),
@@ -324,7 +324,7 @@ TEMPLATE_LIST_TEST_CASE("BinaryToDiscardIterator", "[transform_if]", variable_li
       ::cuda::std::minus<T>(),
       is_positive());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     CHECK((reference == h_result));
     CHECK((reference == d_result));
@@ -338,8 +338,8 @@ TEMPLATE_LIST_TEST_CASE("BinaryCountingIterator", "[transform]", generic_list)
 
   CHECK(T(n) <= unittest::truncate_to_max_representable<T>(n));
 
-  thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
-  thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
 
   thrust::host_vector<T> h_result(n);
   thrust::device_vector<T> d_result(n);

--- a/thrust/testing/catch2_test_complex.cu
+++ b/thrust/testing/catch2_test_complex.cu
@@ -103,13 +103,13 @@ TEMPLATE_LIST_TEST_CASE("ComplexConstructionAndAssignment", "[complex]", Floatin
 
   {
     const thrust::complex<T> expected(real, imag);
-    thrust::complex<T> construct_from_copy(expected);
+    const thrust::complex<T> construct_from_copy(expected);
     CHECK(expected.real() == construct_from_copy.real());
     CHECK(expected.imag() == construct_from_copy.imag());
   }
 
   {
-    thrust::complex<T> construct_from_move(thrust::complex<T>(real, imag));
+    const thrust::complex<T> construct_from_move(thrust::complex<T>(real, imag));
     CHECK(real == construct_from_move.real());
     CHECK(imag == construct_from_move.imag());
   }
@@ -198,13 +198,13 @@ TEMPLATE_LIST_TEST_CASE("ComplexConstructionAndAssignmentWithPromoting", "[compl
 
   {
     const thrust::complex<T1> expected(real_T1, imag_T1);
-    thrust::complex<T0> construct_from_copy(expected);
+    const thrust::complex<T0> construct_from_copy(expected);
     require_almost_equal(real_T0, construct_from_copy.real());
     require_almost_equal(imag_T0, construct_from_copy.imag());
   }
 
   {
-    thrust::complex<T0> construct_from_move(thrust::complex<T1>(real_T1, imag_T1));
+    const thrust::complex<T0> construct_from_move(thrust::complex<T1>(real_T1, imag_T1));
     require_almost_equal(real_T0, construct_from_move.real());
     require_almost_equal(imag_T0, construct_from_move.imag());
   }

--- a/thrust/testing/catch2_test_cuda_iterators.cu
+++ b/thrust/testing/catch2_test_cuda_iterators.cu
@@ -343,7 +343,7 @@ TEST_CASE("transform_iterator", "[iterators]")
 
 TEST_CASE("zip_iterator", "[iterators]")
 {
-  cuda::zip_function<cuda::std::plus<void>> fun{};
+  const cuda::zip_function<cuda::std::plus<void>> fun{};
   { // device system
     thrust::device_vector<int> vec{-1, -1, -1, -1};
     auto iter = cuda::make_transform_iterator(cuda::make_zip_iterator(vec.begin(), cuda::counting_iterator{4}), fun);

--- a/thrust/testing/catch2_test_iterator_traits.cu
+++ b/thrust/testing/catch2_test_iterator_traits.cu
@@ -135,10 +135,10 @@ using make_it_t          = __type_cartesian_product<make_counting_t, make_transf
 TEMPLATE_LIST_TEST_CASE("iterator system and traversal propagation - any system", "[iterators]", make_it_t)
 {
   using namespace cuda::std;
-  __type_at_c<0, TestType> make_counting_iterator;
-  __type_at_c<1, TestType> make_transform_iterator;
-  __type_at_c<2, TestType> make_zip_iterator;
-  __type_at_c<3, TestType> make_permutation_iterator;
+  const __type_at_c<0, TestType> make_counting_iterator;
+  const __type_at_c<1, TestType> make_transform_iterator;
+  const __type_at_c<2, TestType> make_zip_iterator;
+  const __type_at_c<3, TestType> make_permutation_iterator;
 
   auto counting_it = make_counting_iterator(0);
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
@@ -167,8 +167,8 @@ TEMPLATE_LIST_TEST_CASE("iterator system and traversal propagation - vectors", "
 {
   using namespace cuda::std;
   __type_at_c<0, TestType> vec{};
-  __type_at_c<1, TestType> make_transform_iterator;
-  __type_at_c<2, TestType> make_zip_iterator;
+  const __type_at_c<1, TestType> make_transform_iterator;
+  const __type_at_c<2, TestType> make_zip_iterator;
 
   using tag = decltype(expected_tag(vec));
 
@@ -192,8 +192,8 @@ TEMPLATE_LIST_TEST_CASE(
 {
   using namespace cuda::std;
   __type_at_c<0, TestType> vec{};
-  __type_at_c<1, TestType> make_counting_iterator;
-  __type_at_c<2, TestType> make_zip_iterator;
+  const __type_at_c<1, TestType> make_counting_iterator;
+  const __type_at_c<2, TestType> make_zip_iterator;
 
   using vec_tag = decltype(expected_tag(vec));
 

--- a/thrust/testing/catch2_test_unary_transform.cu
+++ b/thrust/testing/catch2_test_unary_transform.cu
@@ -52,7 +52,7 @@ TEST_CASE("UnaryDispatchExplicit", "[transform]", )
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   CHECK(sys.is_valid());
@@ -105,7 +105,7 @@ TEST_CASE("UnaryNoStencilDispatchExplicit", "[transform_if]")
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_if(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   CHECK(sys.is_valid());
@@ -167,7 +167,7 @@ void TestTransformIfUnaryDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_if(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   CHECK(sys.is_valid());
@@ -220,13 +220,13 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIterator", "[transform]", variable_list)
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::transform(h_input.begin(), h_input.end(), thrust::make_discard_iterator(), ::cuda::std::negate<T>());
 
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::transform(d_input.begin(), d_input.end(), thrust::make_discard_iterator(), ::cuda::std::negate<T>());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     CHECK((reference == h_result));
     CHECK((reference == d_result));
@@ -262,12 +262,12 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIteratorZipped", "[transform]", variable_
     using ZipIterator1 = thrust::zip_iterator<Tuple1>;
     using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
-    ZipIterator1 z1(cuda::std::tuple(h_output.begin(), thrust::make_discard_iterator()));
-    ZipIterator2 z2(cuda::std::tuple(d_output.begin(), thrust::make_discard_iterator()));
+    const ZipIterator1 z1(cuda::std::tuple(h_output.begin(), thrust::make_discard_iterator()));
+    const ZipIterator2 z2(cuda::std::tuple(d_output.begin(), thrust::make_discard_iterator()));
 
-    ZipIterator1 h_result = thrust::transform(h_input.begin(), h_input.end(), z1, repeat2());
+    const ZipIterator1 h_result = thrust::transform(h_input.begin(), h_input.end(), z1, repeat2());
 
-    ZipIterator2 d_result = thrust::transform(d_input.begin(), d_input.end(), z2, repeat2());
+    const ZipIterator2 d_result = thrust::transform(d_input.begin(), d_input.end(), z2, repeat2());
 
     thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
@@ -339,7 +339,7 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIterator", "[transform_if]", variable_lis
     thrust::device_vector<T> d_input   = h_input;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    thrust::discard_iterator<> h_result = thrust::transform_if(
+    const thrust::discard_iterator<> h_result = thrust::transform_if(
       h_input.begin(),
       h_input.end(),
       h_stencil.begin(),
@@ -347,7 +347,7 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIterator", "[transform_if]", variable_lis
       ::cuda::std::negate<T>(),
       is_positive());
 
-    thrust::discard_iterator<> d_result = thrust::transform_if(
+    const thrust::discard_iterator<> d_result = thrust::transform_if(
       d_input.begin(),
       d_input.end(),
       d_stencil.begin(),
@@ -355,7 +355,7 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIterator", "[transform_if]", variable_lis
       ::cuda::std::negate<T>(),
       is_positive());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     CHECK((reference == h_result));
     CHECK((reference == d_result));
@@ -369,8 +369,8 @@ TEMPLATE_LIST_TEST_CASE("UnaryCountingIterator", "[transform]", generic_list)
 
   CHECK(T(n) <= unittest::truncate_to_max_representable<T>(n));
 
-  thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
-  thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
 
   thrust::host_vector<T> h_result(n);
   thrust::device_vector<T> d_result(n);

--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -40,12 +40,12 @@ DECLARE_UNITTEST(TestConstantIteratorTraits);
 
 void TestConstantIteratorConstructFromConvertibleSystem()
 {
-  thrust::constant_iterator<int> default_system(13);
+  const thrust::constant_iterator<int> default_system(13);
 
-  thrust::constant_iterator<int, thrust::use_default, thrust::host_system_tag> host_system = default_system;
+  const thrust::constant_iterator<int, thrust::use_default, thrust::host_system_tag> host_system = default_system;
   ASSERT_EQUAL(*default_system, *host_system);
 
-  thrust::constant_iterator<int, thrust::use_default, thrust::device_system_tag> device_system = default_system;
+  const thrust::constant_iterator<int, thrust::use_default, thrust::device_system_tag> device_system = default_system;
   ASSERT_EQUAL(*default_system, *device_system);
 }
 DECLARE_UNITTEST(TestConstantIteratorConstructFromConvertibleSystem);
@@ -53,7 +53,7 @@ DECLARE_UNITTEST(TestConstantIteratorConstructFromConvertibleSystem);
 void TestConstantIteratorIncrement()
 {
   thrust::constant_iterator<int> lhs(0, 0);
-  thrust::constant_iterator<int> rhs(0, 0);
+  const thrust::constant_iterator<int> rhs(0, 0);
 
   ASSERT_EQUAL(0, lhs - rhs);
 
@@ -80,10 +80,10 @@ static_assert(cuda::std::is_trivially_copyable<thrust::constant_iterator<int>>::
 
 void TestConstantIteratorIncrementBig()
 {
-  long long int n = 10000000000ULL;
+  const long long int n = 10000000000ULL;
 
-  thrust::constant_iterator<long long int> begin(1);
-  thrust::constant_iterator<long long int> end = begin + n;
+  const thrust::constant_iterator<long long int> begin(1);
+  const thrust::constant_iterator<long long int> end = begin + n;
 
   ASSERT_EQUAL(cuda::std::distance(begin, end), n);
 }
@@ -118,18 +118,19 @@ DECLARE_UNITTEST(TestConstantIteratorComparison);
 void TestMakeConstantIterator()
 {
   // test one argument version
-  thrust::constant_iterator<int> iter0 = thrust::make_constant_iterator<int>(13);
+  const thrust::constant_iterator<int> iter0 = thrust::make_constant_iterator<int>(13);
 
   ASSERT_EQUAL(13, *iter0);
 
   // test two argument version
-  thrust::constant_iterator<int, cuda::std::intmax_t> iter1 =
+  const thrust::constant_iterator<int, cuda::std::intmax_t> iter1 =
     thrust::make_constant_iterator<int, cuda::std::intmax_t>(13, 7);
 
   ASSERT_EQUAL(13, *iter1);
   ASSERT_EQUAL(7, iter1 - iter0);
 
   // ensure CTAD words
+  // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
   thrust::constant_iterator deduced_iter{42};
   static_assert(cuda::std::is_same_v<decltype(deduced_iter), thrust::constant_iterator<int>>);
   ASSERT_EQUAL(42, *deduced_iter);
@@ -144,8 +145,8 @@ void TestConstantIteratorCopy()
 
   Vector result(4);
 
-  ConstIter first = thrust::make_constant_iterator<ValueType>(7);
-  ConstIter last  = first + result.size();
+  const ConstIter first = thrust::make_constant_iterator<ValueType>(7);
+  const ConstIter last  = first + result.size();
   thrust::copy(first, last, result.begin());
 
   Vector ref(4, 7);
@@ -161,9 +162,9 @@ void TestConstantIteratorTransform()
 
   Vector result(4);
 
-  ConstIter first1 = thrust::make_constant_iterator<T>(7);
-  ConstIter last1  = first1 + result.size();
-  ConstIter first2 = thrust::make_constant_iterator<T>(3);
+  const ConstIter first1 = thrust::make_constant_iterator<T>(7);
+  const ConstIter last1  = first1 + result.size();
+  const ConstIter first2 = thrust::make_constant_iterator<T>(3);
 
   thrust::transform(first1, last1, result.begin(), cuda::std::negate<T>());
 
@@ -182,10 +183,10 @@ void TestConstantIteratorReduce()
   using T         = int;
   using ConstIter = thrust::constant_iterator<T>;
 
-  ConstIter first = thrust::make_constant_iterator<T>(7);
-  ConstIter last  = first + 4;
+  const ConstIter first = thrust::make_constant_iterator<T>(7);
+  const ConstIter last  = first + 4;
 
-  T sum = thrust::reduce(first, last);
+  const T sum = thrust::reduce(first, last);
 
   ASSERT_EQUAL(sum, 4 * 7);
 };

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -30,21 +30,21 @@ void TestCopyFromConstIterator()
 
   std::vector<T> v{0, 1, 2, 3, 4};
 
-  std::vector<int>::const_iterator begin = v.begin();
-  std::vector<int>::const_iterator end   = v.end();
+  const std::vector<int>::const_iterator begin = v.begin();
+  const std::vector<int>::const_iterator end   = v.end();
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
-  thrust::host_vector<T>::iterator h_result = thrust::copy(begin, end, h.begin());
+  const thrust::host_vector<T>::iterator h_result = thrust::copy(begin, end, h.begin());
 
-  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  const thrust::host_vector<T> href{0, 1, 2, 3, 4};
   ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
-  thrust::device_vector<T>::iterator d_result = thrust::copy(begin, end, d.begin());
-  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  const thrust::device_vector<T>::iterator d_result = thrust::copy(begin, end, d.begin());
+  const thrust::device_vector<T> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -57,13 +57,15 @@ void TestCopyToDiscardIterator()
   thrust::host_vector<T> h_input(5, 1);
   thrust::device_vector<T> d_input = h_input;
 
-  thrust::discard_iterator<> reference(5);
+  const thrust::discard_iterator<> reference(5);
 
   // copy from host_vector
-  thrust::discard_iterator<> h_result = thrust::copy(h_input.begin(), h_input.end(), thrust::make_discard_iterator());
+  const thrust::discard_iterator<> h_result =
+    thrust::copy(h_input.begin(), h_input.end(), thrust::make_discard_iterator());
 
   // copy from device_vector
-  thrust::discard_iterator<> d_result = thrust::copy(d_input.begin(), d_input.end(), thrust::make_discard_iterator());
+  const thrust::discard_iterator<> d_result =
+    thrust::copy(d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -79,7 +81,7 @@ void TestCopyToDiscardIteratorZipped()
 
   thrust::host_vector<T> h_output(5);
   thrust::device_vector<T> d_output(5);
-  thrust::discard_iterator<> reference(5);
+  const thrust::discard_iterator<> reference(5);
 
   using Tuple1 = cuda::std::tuple<thrust::discard_iterator<>, thrust::host_vector<T>::iterator>;
   using Tuple2 = cuda::std::tuple<thrust::discard_iterator<>, thrust::device_vector<T>::iterator>;
@@ -88,13 +90,13 @@ void TestCopyToDiscardIteratorZipped()
   using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
   // copy from host_vector
-  ZipIterator1 h_result = thrust::copy(
+  const ZipIterator1 h_result = thrust::copy(
     thrust::make_zip_iterator(h_input.begin(), h_input.begin()),
     thrust::make_zip_iterator(h_input.end(), h_input.end()),
     thrust::make_zip_iterator(thrust::make_discard_iterator(), h_output.begin()));
 
   // copy from device_vector
-  ZipIterator2 d_result = thrust::copy(
+  const ZipIterator2 d_result = thrust::copy(
     thrust::make_zip_iterator(d_input.begin(), d_input.begin()),
     thrust::make_zip_iterator(d_input.end(), d_input.end()),
     thrust::make_zip_iterator(thrust::make_discard_iterator(), d_output.begin()));
@@ -115,16 +117,16 @@ void TestCopyMatchingTypes()
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
-  typename thrust::host_vector<T>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
-  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  const typename thrust::host_vector<T>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
+  const thrust::host_vector<T> href{0, 1, 2, 3, 4};
   ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
-  typename thrust::device_vector<T>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
+  const typename thrust::device_vector<T>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
 
-  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  const thrust::device_vector<T> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -140,15 +142,15 @@ void TestCopyMixedTypes()
 
   // copy to host_vector with different type
   thrust::host_vector<float> h(5, (float) 10);
-  typename thrust::host_vector<float>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
-  thrust::host_vector<float> href{0, 1, 2, 3, 4};
+  const typename thrust::host_vector<float>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
+  const thrust::host_vector<float> href{0, 1, 2, 3, 4};
   ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector with different type
   thrust::device_vector<float> d(5, (float) 10);
-  typename thrust::device_vector<float>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
-  thrust::device_vector<float> dref{0, 1, 2, 3, 4};
+  const typename thrust::device_vector<float>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
+  const thrust::device_vector<float> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -166,10 +168,10 @@ void TestCopyVectorBool()
   thrust::copy(v.begin(), v.end(), h.begin());
   thrust::copy(v.begin(), v.end(), d.begin());
 
-  thrust::host_vector<bool> href{true, false, true};
+  const thrust::host_vector<bool> href{true, false, true};
   ASSERT_EQUAL(h, href);
 
-  thrust::device_vector<bool> dref{true, false, true};
+  const thrust::device_vector<bool> dref{true, false, true};
   ASSERT_EQUAL(d, dref);
 }
 DECLARE_UNITTEST(TestCopyVectorBool);
@@ -184,7 +186,7 @@ void TestCopyListTo()
 
   Vector v(l.size());
 
-  typename Vector::iterator v_result = thrust::copy(l.begin(), l.end(), v.begin());
+  const typename Vector::iterator v_result = thrust::copy(l.begin(), l.end(), v.begin());
 
   Vector ref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(v, ref);
@@ -246,7 +248,7 @@ void TestCopyIfSimple()
 
   Vector dest(4);
 
-  typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), dest.begin(), is_true<T>());
+  const typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), dest.begin(), is_true<T>());
 
   Vector ref{1, 2, 3, 4};
   ASSERT_EQUAL(ref, dest);
@@ -368,7 +370,7 @@ void TestCopyIfStencilSimple()
 
   Vector dest(3);
 
-  typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), s.begin(), dest.begin(), is_true<T>());
+  const typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), s.begin(), dest.begin(), is_true<T>());
 
   Vector ref{0, 1, 3};
   ASSERT_EQUAL(ref, dest);
@@ -468,7 +470,7 @@ void TestCopyIfNonTrivial()
     object_with_non_trivial_ctor initialized;
     object_with_non_trivial_ctor* uninitialized = reinterpret_cast<object_with_non_trivial_ctor*>(buffer.data());
 
-    object_with_non_trivial_ctor source(42);
+    const object_with_non_trivial_ctor source(42);
     initialized    = source;
     *uninitialized = source;
 
@@ -485,10 +487,10 @@ void TestCopyIfNonTrivial()
 
   for (int i = 0; i < 10; i++)
   {
-    object_with_non_trivial_ctor ha(a[i]);
-    object_with_non_trivial_ctor hb(b[i]);
-    int ia = ha.field;
-    int ib = hb.field;
+    const object_with_non_trivial_ctor ha(a[i]);
+    const object_with_non_trivial_ctor hb(b[i]);
+    const int ia = ha.field;
+    const int ib = hb.field;
 
     ASSERT_EQUAL(ia, ib);
   }
@@ -500,7 +502,7 @@ void TestCopyCountingIterator()
 {
   using T = typename Vector::value_type;
 
-  thrust::counting_iterator<T> iter(1);
+  const thrust::counting_iterator<T> iter(1);
 
   Vector vec(4);
 
@@ -572,7 +574,7 @@ void TestCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::copy(sys, vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -607,7 +609,7 @@ void TestCopyIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::copy_if(sys, vec.begin(), vec.end(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -644,7 +646,7 @@ void TestCopyIfStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::copy_if(sys, vec.begin(), vec.end(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -751,18 +753,18 @@ _CCCL_END_NAMESPACE_CUDA_STD
 
 void TestCopyWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(0);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(0);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
-  *has_executed                         = false;
+  const thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  *has_executed                               = false;
 
-  only_set_when_expected_it out = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_expected_it out = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
 
   thrust::copy(thrust::device, begin, end, out);
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);

--- a/thrust/testing/copy_n.cu
+++ b/thrust/testing/copy_n.cu
@@ -18,19 +18,19 @@ void TestCopyNFromConstIterator()
 
   std::vector<T> v{0, 1, 2, 3, 4};
 
-  std::vector<int>::const_iterator begin = v.begin();
+  const std::vector<int>::const_iterator begin = v.begin();
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
-  thrust::host_vector<T>::iterator h_result = thrust::copy_n(begin, h.size(), h.begin());
+  const thrust::host_vector<T>::iterator h_result = thrust::copy_n(begin, h.size(), h.begin());
 
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
-  thrust::device_vector<T>::iterator d_result = thrust::copy_n(begin, d.size(), d.begin());
+  const thrust::device_vector<T>::iterator d_result = thrust::copy_n(begin, d.size(), d.begin());
 
-  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  const thrust::device_vector<T> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -44,14 +44,14 @@ void TestCopyNToDiscardIterator()
   thrust::device_vector<T> d_input = h_input;
 
   // copy from host_vector
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::copy_n(h_input.begin(), h_input.size(), thrust::make_discard_iterator());
 
   // copy from device_vector
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::copy_n(d_input.begin(), d_input.size(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> reference(5);
+  const thrust::discard_iterator<> reference(5);
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -67,15 +67,15 @@ void TestCopyNMatchingTypes()
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
-  typename thrust::host_vector<T>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
-  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  const typename thrust::host_vector<T>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
+  const thrust::host_vector<T> href{0, 1, 2, 3, 4};
   ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
-  typename thrust::device_vector<T>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
-  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  const typename thrust::device_vector<T>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
+  const thrust::device_vector<T> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -91,16 +91,16 @@ void TestCopyNMixedTypes()
 
   // copy to host_vector with different type
   thrust::host_vector<float> h(5, (float) 10);
-  typename thrust::host_vector<float>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
+  const typename thrust::host_vector<float>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
 
-  thrust::host_vector<float> href{0, 1, 2, 3, 4};
+  const thrust::host_vector<float> href{0, 1, 2, 3, 4};
   ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector with different type
   thrust::device_vector<float> d(5, (float) 10);
-  typename thrust::device_vector<float>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
-  thrust::device_vector<float> dref{0, 1, 2, 3, 4};
+  const typename thrust::device_vector<float>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
+  const thrust::device_vector<float> dref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
@@ -118,10 +118,10 @@ void TestCopyNVectorBool()
   thrust::copy_n(v.begin(), v.size(), h.begin());
   thrust::copy_n(v.begin(), v.size(), d.begin());
 
-  thrust::host_vector<bool> href{true, false, true};
+  const thrust::host_vector<bool> href{true, false, true};
   ASSERT_EQUAL(h, href);
 
-  thrust::device_vector<bool> dref{true, false, true};
+  const thrust::device_vector<bool> dref{true, false, true};
   ASSERT_EQUAL(d, dref);
 
   ASSERT_EQUAL(d, dref);
@@ -138,7 +138,7 @@ void TestCopyNListTo()
 
   Vector v(l.size());
 
-  typename Vector::iterator v_result = thrust::copy_n(l.begin(), l.size(), v.begin());
+  const typename Vector::iterator v_result = thrust::copy_n(l.begin(), l.size(), v.begin());
 
   Vector ref{0, 1, 2, 3, 4};
   ASSERT_EQUAL(v, ref);
@@ -169,7 +169,7 @@ void TestCopyNCountingIterator()
 {
   using T = typename Vector::value_type;
 
-  thrust::counting_iterator<T> iter(1);
+  const thrust::counting_iterator<T> iter(1);
 
   Vector vec(4);
 
@@ -229,7 +229,7 @@ void TestCopyNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::copy_n(sys, vec.begin(), 1, vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/count.cu
+++ b/thrust/testing/count.cu
@@ -20,8 +20,8 @@ void TestCount(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t cpu_result = thrust::count(h_data.begin(), h_data.end(), T(5));
-  size_t gpu_result = thrust::count(d_data.begin(), d_data.end(), T(5));
+  const size_t cpu_result = thrust::count(h_data.begin(), h_data.end(), T(5));
+  const size_t gpu_result = thrust::count(d_data.begin(), d_data.end(), T(5));
 
   ASSERT_EQUAL(cpu_result, gpu_result);
 }
@@ -53,8 +53,8 @@ void TestCountIf(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t cpu_result = thrust::count_if(h_data.begin(), h_data.end(), greater_than_five<T>());
-  size_t gpu_result = thrust::count_if(d_data.begin(), d_data.end(), greater_than_five<T>());
+  const size_t cpu_result = thrust::count_if(h_data.begin(), h_data.end(), greater_than_five<T>());
+  const size_t gpu_result = thrust::count_if(d_data.begin(), d_data.end(), greater_than_five<T>());
 
   ASSERT_EQUAL(cpu_result, gpu_result);
 }
@@ -82,7 +82,7 @@ void TestCountDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::count(sys, vec.begin(), vec.end(), 13);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -107,11 +107,11 @@ DECLARE_UNITTEST(TestCountDispatchImplicit);
 
 void TestCountWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  long long result = thrust::count(thrust::device, begin, end, (1ll << magnitude) - 17);
+  const long long result = thrust::count(thrust::device, begin, end, (1ll << magnitude) - 17);
 
   ASSERT_EQUAL(result, 1);
 }

--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -73,25 +73,25 @@ DECLARE_UNITTEST(TestCountingIteratorTraits);
 template <typename T>
 void TestCountingDefaultConstructor()
 {
-  thrust::counting_iterator<T> iter0;
+  const thrust::counting_iterator<T> iter0;
   ASSERT_EQUAL(*iter0, T{});
 }
 DECLARE_GENERIC_UNITTEST(TestCountingDefaultConstructor);
 
 void TestCountingIteratorCopyConstructor()
 {
-  thrust::counting_iterator<int> iter0(100);
+  const thrust::counting_iterator<int> iter0(100);
 
-  thrust::counting_iterator<int> iter1(iter0);
+  const thrust::counting_iterator<int> iter1(iter0);
 
   ASSERT_EQUAL_QUIET(iter0, iter1);
   ASSERT_EQUAL(*iter0, *iter1);
 
   // construct from related space
-  thrust::counting_iterator<int, thrust::host_system_tag> h_iter = iter0;
+  const thrust::counting_iterator<int, thrust::host_system_tag> h_iter = iter0;
   ASSERT_EQUAL(*iter0, *h_iter);
 
-  thrust::counting_iterator<int, thrust::device_system_tag> d_iter = iter0;
+  const thrust::counting_iterator<int, thrust::device_system_tag> d_iter = iter0;
   ASSERT_EQUAL(*iter0, *d_iter);
 }
 DECLARE_UNITTEST(TestCountingIteratorCopyConstructor);
@@ -232,8 +232,8 @@ DECLARE_UNITTEST(TestCountingIteratorDistance);
 
 void TestCountingIteratorUnsignedType()
 {
-  thrust::counting_iterator<unsigned int> iter0(0);
-  thrust::counting_iterator<unsigned int> iter1(5);
+  const thrust::counting_iterator<unsigned int> iter0(0);
+  const thrust::counting_iterator<unsigned int> iter1(5);
 
   ASSERT_EQUAL(iter1 - iter0, 5);
   ASSERT_EQUAL(iter0 - iter1, -5);
@@ -245,7 +245,7 @@ DECLARE_UNITTEST(TestCountingIteratorUnsignedType);
 
 void TestCountingIteratorLowerBound()
 {
-  size_t n       = 10000;
+  const size_t n = 10000;
   const size_t M = 100;
 
   thrust::host_vector<unsigned int> h_data = unittest::random_integers<unsigned int>(n);
@@ -258,8 +258,8 @@ void TestCountingIteratorLowerBound()
 
   thrust::device_vector<unsigned int> d_data = h_data;
 
-  thrust::counting_iterator<unsigned int> search_begin(0);
-  thrust::counting_iterator<unsigned int> search_end(M);
+  const thrust::counting_iterator<unsigned int> search_begin(0);
+  const thrust::counting_iterator<unsigned int> search_end(M);
 
   thrust::host_vector<unsigned int> h_result(M);
   thrust::device_vector<unsigned int> d_result(M);
@@ -277,10 +277,10 @@ void TestCountingIteratorDifference()
   using Iterator   = thrust::counting_iterator<std::uint64_t>;
   using Difference = thrust::detail::it_difference_t<Iterator>;
 
-  Difference diff = std::numeric_limits<std::uint32_t>::max() + 1; // NOLINT(bugprone-misplaced-widening-cast)
+  const Difference diff = std::numeric_limits<std::uint32_t>::max() + 1; // NOLINT(bugprone-misplaced-widening-cast)
 
-  Iterator first(0);
-  Iterator last = first + diff;
+  const Iterator first(0);
+  const Iterator last = first + diff;
 
   ASSERT_EQUAL(diff, last - first);
 }
@@ -353,8 +353,8 @@ _CCCL_DIAG_POP
 // MSVC C4244 (implicit float-to-integer conversion) without suppression.
 void TestCountingIteratorFloatDistanceTo()
 {
-  thrust::counting_iterator<float> iter1(0);
-  thrust::counting_iterator<float> iter2(5);
+  const thrust::counting_iterator<float> iter1(0);
+  const thrust::counting_iterator<float> iter2(5);
 
   ASSERT_EQUAL(iter2 - iter1, 5);
 }

--- a/thrust/testing/cpp/adjacent_difference.cu
+++ b/thrust/testing/cpp/adjacent_difference.cu
@@ -48,18 +48,18 @@ struct detect_wrong_difference
 
 void TestAdjacentDifferenceWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> all_differences_correct = thrust::device_malloc<bool>(1);
-  *all_differences_correct                         = true;
+  const thrust::device_ptr<bool> all_differences_correct = thrust::device_malloc<bool>(1);
+  *all_differences_correct                               = true;
 
-  detect_wrong_difference out = {thrust::raw_pointer_cast(all_differences_correct)};
+  const detect_wrong_difference out = {thrust::raw_pointer_cast(all_differences_correct)};
 
   thrust::adjacent_difference(thrust::device, begin, end, out);
 
-  bool all_differences_correct_h = *all_differences_correct;
+  const bool all_differences_correct_h = *all_differences_correct;
   thrust::device_free(all_differences_correct);
 
   ASSERT_EQUAL(all_differences_correct_h, true);

--- a/thrust/testing/cuda/adjacent_difference.cu
+++ b/thrust/testing/cuda/adjacent_difference.cu
@@ -85,7 +85,7 @@ void TestAdjacentDifferenceCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  thrust::device_vector<int> ref{1, 3, 2};
+  const thrust::device_vector<int> ref{1, 3, 2};
 
   ASSERT_EQUAL(output, ref);
 
@@ -133,18 +133,18 @@ struct detect_wrong_difference
 
 void TestAdjacentDifferenceWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> all_differences_correct = thrust::device_malloc<bool>(1);
-  *all_differences_correct                         = true;
+  const thrust::device_ptr<bool> all_differences_correct = thrust::device_malloc<bool>(1);
+  *all_differences_correct                               = true;
 
-  detect_wrong_difference out = {thrust::raw_pointer_cast(all_differences_correct)};
+  const detect_wrong_difference out = {thrust::raw_pointer_cast(all_differences_correct)};
 
   thrust::adjacent_difference(thrust::device, begin, end, out);
 
-  bool all_differences_correct_h = *all_differences_correct;
+  const bool all_differences_correct_h = *all_differences_correct;
   thrust::device_free(all_differences_correct);
 
   ASSERT_EQUAL(all_differences_correct_h, true);

--- a/thrust/testing/cuda/binary_search.cu
+++ b/thrust/testing/cuda/binary_search.cu
@@ -15,8 +15,8 @@ void TestEqualRangeOnStream()
 
   vector_t input(10);
   thrust::sequence(thrust::device, input.begin(), input.end(), 0);
-  cudaStream_t stream = nullptr;
-  result_t result     = thrust::equal_range(thrust::cuda::par.on(stream), input.begin(), input.end(), 5);
+  cudaStream_t stream   = nullptr;
+  const result_t result = thrust::equal_range(thrust::cuda::par.on(stream), input.begin(), input.end(), 5);
 
   ASSERT_EQUAL(5, ::cuda::std::distance(input.begin(), result.first));
   ASSERT_EQUAL(6, ::cuda::std::distance(input.begin(), result.second));

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -133,11 +133,11 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), is_even<int>());
+  const Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), is_even<int>());
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());
-  Vector ref{2, 2};
+  const Vector ref{2, 2};
   ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
@@ -265,13 +265,13 @@ void TestCopyIfStencilCudaStreams(ExecutionPolicy policy)
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end =
+  const Vector::iterator end =
     thrust::copy_if(policy.on(s), data.begin(), data.end(), stencil.begin(), result.begin(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(end - result.begin(), 2);
   result.resize(end - result.begin());
 
-  Vector ref{2, 2};
+  const Vector ref{2, 2};
   ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
@@ -294,25 +294,25 @@ void TestCopyIfWithMagnitude(int magnitude)
   using offset_t = std::size_t;
 
   // Prepare input
-  offset_t num_items = offset_t{1ull} << magnitude;
-  thrust::counting_iterator<offset_t> begin(offset_t{0});
+  const offset_t num_items = offset_t{1ull} << magnitude;
+  const thrust::counting_iterator<offset_t> begin(offset_t{0});
   auto end = begin + static_cast<std::ptrdiff_t>(num_items);
   ASSERT_EQUAL(static_cast<offset_t>(::cuda::std::distance(begin, end)), num_items);
 
   // Run algorithm on large number of items
-  offset_t match_every_nth     = 1000000;
-  offset_t expected_num_copied = (num_items + match_every_nth - 1) / match_every_nth;
+  const offset_t match_every_nth     = 1000000;
+  const offset_t expected_num_copied = (num_items + match_every_nth - 1) / match_every_nth;
   thrust::device_vector<offset_t> copied_out(expected_num_copied);
   auto selected_out_end = thrust::copy_if(begin, end, copied_out.begin(), mod_n<offset_t>{match_every_nth});
 
   // Ensure number of selected items are correct
-  offset_t num_selected_out = static_cast<offset_t>(::cuda::std::distance(copied_out.begin(), selected_out_end));
+  const offset_t num_selected_out = static_cast<offset_t>(::cuda::std::distance(copied_out.begin(), selected_out_end));
   ASSERT_EQUAL(num_selected_out, expected_num_copied);
   copied_out.resize(expected_num_copied);
 
   // Ensure selected items are correct
-  auto expected_out_it     = thrust::make_transform_iterator(begin, multiply_n<offset_t>{match_every_nth});
-  bool all_results_correct = thrust::equal(copied_out.begin(), copied_out.end(), expected_out_it);
+  auto expected_out_it           = thrust::make_transform_iterator(begin, multiply_n<offset_t>{match_every_nth});
+  const bool all_results_correct = thrust::equal(copied_out.begin(), copied_out.end(), expected_out_it);
   ASSERT_EQUAL(all_results_correct, true);
 }
 
@@ -330,26 +330,26 @@ void TestCopyIfStencilWithMagnitude(int magnitude)
   using offset_t = std::size_t;
 
   // Prepare input
-  offset_t num_items = offset_t{1ull} << magnitude;
-  thrust::counting_iterator<offset_t> begin(offset_t{0});
+  const offset_t num_items = offset_t{1ull} << magnitude;
+  const thrust::counting_iterator<offset_t> begin(offset_t{0});
   auto end = begin + static_cast<std::ptrdiff_t>(num_items);
-  thrust::counting_iterator<offset_t> stencil(offset_t{0});
+  const thrust::counting_iterator<offset_t> stencil(offset_t{0});
   ASSERT_EQUAL(static_cast<offset_t>(::cuda::std::distance(begin, end)), num_items);
 
   // Run algorithm on large number of items
-  offset_t match_every_nth     = 1000000;
-  offset_t expected_num_copied = (num_items + match_every_nth - 1) / match_every_nth;
+  const offset_t match_every_nth     = 1000000;
+  const offset_t expected_num_copied = (num_items + match_every_nth - 1) / match_every_nth;
   thrust::device_vector<offset_t> copied_out(expected_num_copied);
   auto selected_out_end = thrust::copy_if(begin, end, stencil, copied_out.begin(), mod_n<offset_t>{match_every_nth});
 
   // Ensure number of selected items are correct
-  offset_t num_selected_out = static_cast<offset_t>(::cuda::std::distance(copied_out.begin(), selected_out_end));
+  const offset_t num_selected_out = static_cast<offset_t>(::cuda::std::distance(copied_out.begin(), selected_out_end));
   ASSERT_EQUAL(num_selected_out, expected_num_copied);
   copied_out.resize(expected_num_copied);
 
   // Ensure selected items are correct
-  auto expected_out_it     = thrust::make_transform_iterator(begin, multiply_n<offset_t>{match_every_nth});
-  bool all_results_correct = thrust::equal(copied_out.begin(), copied_out.end(), expected_out_it);
+  auto expected_out_it           = thrust::make_transform_iterator(begin, multiply_n<offset_t>{match_every_nth});
+  const bool all_results_correct = thrust::equal(copied_out.begin(), copied_out.end(), expected_out_it);
   ASSERT_EQUAL(all_results_correct, true);
 }
 

--- a/thrust/testing/cuda/device_buffer_algorithms.cu
+++ b/thrust/testing/cuda/device_buffer_algorithms.cu
@@ -17,7 +17,7 @@
 void TestDeviceBufferShuffleCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto buffer       = cuda::make_device_buffer<int>(stream, device, 5, cuda::no_init);
   const auto policy = thrust::cuda::par_nosync.on(stream.get());
@@ -35,7 +35,7 @@ DECLARE_UNITTEST(TestDeviceBufferShuffleCudaStreams);
 void TestDeviceBufferSortCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto buffer       = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{3, 1, 4, 0, 2});
   const auto policy = thrust::cuda::par_nosync.on(stream.get());

--- a/thrust/testing/cuda/for_each.cu
+++ b/thrust/testing/cuda/for_each.cu
@@ -11,7 +11,7 @@ static const size_t NUM_REGISTERS = 64;
 template <size_t N>
 _CCCL_HOST_DEVICE void f(int* x)
 {
-  int temp = *x;
+  const int temp = *x;
   f<N - 1>(x + 1);
   *x = temp;
 };
@@ -230,7 +230,7 @@ void TestForEachCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  thrust::device_vector<int> ref{0, 0, 1, 1, 1, 0, 1};
+  const thrust::device_vector<int> ref{0, 0, 1, 1, 1, 0, 1};
   ASSERT_EQUAL(output, ref);
 
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -74,7 +74,7 @@ void TestGatherCudaStreams()
   thrust::gather(thrust::cuda::par.on(s), map.begin(), map.end(), src.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  thrust::device_vector<int> ref = {6, 2, 1, 7, 2}; // destination vector
+  const thrust::device_vector<int> ref = {6, 2, 1, 7, 2}; // destination vector
 
   ASSERT_EQUAL(dst, ref);
   cudaStreamDestroy(s);
@@ -194,7 +194,7 @@ void TestGatherIfCudaStreams()
   thrust::gather_if(thrust::cuda::par.on(s), map.begin(), map.end(), flg.begin(), src.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  thrust::device_vector<int> ref{0, 2, 0, 7, 0}; // destination vector
+  const thrust::device_vector<int> ref{0, 2, 0, 7, 0}; // destination vector
 
   ASSERT_EQUAL(dst, ref);
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/generate.cu
+++ b/thrust/testing/cuda/generate.cu
@@ -65,9 +65,9 @@ void TestGenerateCudaStreams()
 {
   thrust::device_vector<int> result(5);
 
-  int value = 13;
+  const int value = 13;
 
-  return_value<int> f(value);
+  const return_value<int> f(value);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -131,9 +131,9 @@ void TestGenerateNCudaStreams()
 {
   thrust::device_vector<int> result(5);
 
-  int value = 13;
+  const int value = 13;
 
-  return_value<int> f(value);
+  const return_value<int> f(value);
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/inner_product.cu
+++ b/thrust/testing/cuda/inner_product.cu
@@ -58,8 +58,8 @@ void TestInnerProductCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  int init   = 3;
-  int result = thrust::inner_product(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin(), init);
+  const int init   = 3;
+  const int result = thrust::inner_product(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin(), init);
   ASSERT_EQUAL(result, 7);
 
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/max_element.cu
+++ b/thrust/testing/cuda/max_element.cu
@@ -123,8 +123,8 @@ void TestMaxElementDevicePointer()
   data[4] = 5;
   data[5] = 1;
 
-  T* raw_ptr = thrust::raw_pointer_cast(data.data());
-  size_t n   = data.size();
+  T* raw_ptr     = thrust::raw_pointer_cast(data.data());
+  const size_t n = data.size();
   ASSERT_EQUAL(thrust::max_element(thrust::device, raw_ptr, raw_ptr + n) - raw_ptr, 1);
   ASSERT_EQUAL(thrust::max_element(thrust::device, raw_ptr, raw_ptr + n, ::cuda::std::greater<T>()) - raw_ptr, 2);
 }

--- a/thrust/testing/cuda/memory.cu
+++ b/thrust/testing/cuda/memory.cu
@@ -24,10 +24,11 @@ void TestSelectSystemCudaToCpp()
 
   thrust::cuda::tag cuda_tag;
   thrust::cpp::tag cpp_tag;
+  // NOLINTNEXTLINE(misc-const-correctness)
   thrust::cuda_cub::cross_system<thrust::cuda::tag, thrust::cpp::tag> cuda_to_cpp(cuda_tag, cpp_tag);
 
   // select_system(cuda::tag, thrust::host_system_tag) should return cuda_to_cpp
-  bool is_cuda_to_cpp = are_same_type(cuda_to_cpp, select_system(cuda_tag, cpp_tag));
+  const bool is_cuda_to_cpp = are_same_type(cuda_to_cpp, select_system(cuda_tag, cpp_tag));
   ASSERT_EQUAL(true, is_cuda_to_cpp);
 }
 DECLARE_UNITTEST(TestSelectSystemCudaToCpp);

--- a/thrust/testing/cuda/merge.cu
+++ b/thrust/testing/cuda/merge.cu
@@ -76,7 +76,7 @@ DECLARE_UNITTEST(TestMergeDeviceDevice);
 void TestMergeCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, {0, 2, 4});
   auto b      = cuda::make_device_buffer<int>(stream, device, {0, 3, 3, 4});

--- a/thrust/testing/cuda/merge_by_key.cu
+++ b/thrust/testing/cuda/merge_by_key.cu
@@ -89,7 +89,7 @@ DECLARE_UNITTEST(TestMergeByKeyDeviceDevice);
 void TestMergeByKeyCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a_key = cuda::make_device_buffer<int>(stream, device, {0, 2, 4});
   auto a_val = cuda::make_device_buffer<int>(stream, device, {13, 7, 42});

--- a/thrust/testing/cuda/min_element.cu
+++ b/thrust/testing/cuda/min_element.cu
@@ -104,8 +104,8 @@ void TestMinElementDevicePointer()
   data[4] = 5;
   data[5] = 1;
 
-  T* raw_ptr = thrust::raw_pointer_cast(data.data());
-  size_t n   = data.size();
+  T* raw_ptr     = thrust::raw_pointer_cast(data.data());
+  const size_t n = data.size();
   ASSERT_EQUAL(thrust::min_element(thrust::device, raw_ptr, raw_ptr + n) - raw_ptr, 2);
   ASSERT_EQUAL(thrust::min_element(thrust::device, raw_ptr, raw_ptr + n, ::cuda::std::greater<T>()) - raw_ptr, 1);
 }

--- a/thrust/testing/cuda/minmax_element.cu
+++ b/thrust/testing/cuda/minmax_element.cu
@@ -112,8 +112,8 @@ void TestMinMaxElementDevicePointer()
   data[4] = 5;
   data[5] = 1;
 
-  T* raw_ptr = thrust::raw_pointer_cast(data.data());
-  size_t n   = data.size();
+  T* raw_ptr     = thrust::raw_pointer_cast(data.data());
+  const size_t n = data.size();
   ASSERT_EQUAL(thrust::minmax_element(thrust::device, raw_ptr, raw_ptr + n).first - raw_ptr, 2);
   ASSERT_EQUAL(thrust::minmax_element(thrust::device, raw_ptr, raw_ptr + n).second - raw_ptr, 1);
 }

--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -117,8 +117,8 @@ __global__ void TestOffsetIteratorDevice(thrust::offset_iterator<device_only_ite
 void TestOffsetIteratorWithDeviceOnlyIterator()
 {
   thrust::device_vector<int> v{1, 2, 3, 4, 5};
-  device_only_iterator base(thrust::raw_pointer_cast(v.data()));
-  thrust::offset_iterator iter(base);
+  const device_only_iterator base(thrust::raw_pointer_cast(v.data()));
+  const thrust::offset_iterator iter(base);
   TestOffsetIteratorBoth(iter);
   TestOffsetIteratorDevice<<<1, 1>>>(iter);
 }

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -706,7 +706,7 @@ void TestPartitionCudaStreams(ExecutionPolicy policy)
 
   auto streampolicy = policy.on(s);
 
-  Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), is_even<T>());
+  const Iterator iter = thrust::partition(streampolicy, data.begin(), data.end(), is_even<T>());
 
   Vector ref(5);
   ref[0] = 2;

--- a/thrust/testing/cuda/partition_point.cu
+++ b/thrust/testing/cuda/partition_point.cu
@@ -63,7 +63,7 @@ void TestPartitionPointCudaStreams()
   v[2] = 1;
   v[3] = 0;
 
-  Iterator first = v.begin();
+  const Iterator first = v.begin();
 
   Iterator last = v.begin() + 4;
   Iterator ref  = first + 3;

--- a/thrust/testing/cuda/reduce.cu
+++ b/thrust/testing/cuda/reduce.cu
@@ -105,7 +105,7 @@ void TestReduceLargeInput()
   using OffsetT           = std::size_t;
   const OffsetT num_items = 1ull << 32;
 
-  cuda::constant_iterator<T> d_data(T{1});
+  const cuda::constant_iterator<T> d_data(T{1});
   thrust::device_vector<T> d_result(1);
 
   reduce_kernel<<<1, 1>>>(thrust::device, d_data, d_data + num_items, T{}, d_result.begin());

--- a/thrust/testing/cuda/reduce_by_key.cu
+++ b/thrust/testing/cuda/reduce_by_key.cu
@@ -442,14 +442,14 @@ void TestReduceByKeyWithBigIndexesHelper(int magnitude)
   using transform_key_it = thrust::transform_iterator<div_op, counting_it>;
   using transform_val_it = thrust::transform_iterator<mod_op, counting_it>;
 
-  counting_it count_begin(0ll);
-  counting_it count_end = count_begin + num_items;
+  const counting_it count_begin(0ll);
+  const counting_it count_end = count_begin + num_items;
   ASSERT_EQUAL(static_cast<std::int64_t>(::cuda::std::distance(count_begin, count_end)), num_items);
 
-  transform_key_it keys_begin(count_begin, div_op{key_size});
-  transform_key_it keys_end(count_end, div_op{key_size});
+  const transform_key_it keys_begin(count_begin, div_op{key_size});
+  const transform_key_it keys_end(count_end, div_op{key_size});
 
-  transform_val_it values_begin(count_begin, mod_op{key_size});
+  const transform_val_it values_begin(count_begin, mod_op{key_size});
 
   thrust::device_vector<std::int64_t> output_keys(num_unique_keys);
   thrust::device_vector<std::int64_t> output_values(num_unique_keys);
@@ -519,11 +519,11 @@ void TestReduceByKeyWithCustomEqualityOp()
   ASSERT_EQUAL(error_counter[0], cuda::std::uint32_t{0});
 
   // Verify that unique keys are correct
-  bool all_keys_correct = thrust::equal(unique_out.cbegin(), unique_out.cend(), keys);
+  const bool all_keys_correct = thrust::equal(unique_out.cbegin(), unique_out.cend(), keys);
   ASSERT_EQUAL(all_keys_correct, true);
 
   // Verify that the aggregates are correct
-  bool all_values_correct = thrust::equal(aggregates_out.cbegin(), aggregates_out.cend(), values);
+  const bool all_values_correct = thrust::equal(aggregates_out.cbegin(), aggregates_out.cend(), values);
   ASSERT_EQUAL(all_values_correct, true);
 }
 

--- a/thrust/testing/cuda/reduce_into.cu
+++ b/thrust/testing/cuda/reduce_into.cu
@@ -111,7 +111,7 @@ void TestReduceIntoLargeInput()
   using OffsetT           = std::size_t;
   const OffsetT num_items = 1ull << 32;
 
-  cuda::constant_iterator<T> d_data(T{1});
+  const cuda::constant_iterator<T> d_data(T{1});
   thrust::device_vector<T> d_result(1);
 
   reduce_into_kernel<<<1, 1>>>(thrust::device, d_data, d_data + num_items, d_result.begin(), T{});

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -334,12 +334,12 @@ void TestRemoveCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove(thrust::cuda::par.on(s), data.begin(), data.end(), (T) 2);
+  const Vector::iterator end = thrust::remove(thrust::cuda::par.on(s), data.begin(), data.end(), (T) 2);
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.erase(end, data.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
@@ -358,12 +358,13 @@ void TestRemoveCopyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove_copy(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), (T) 2);
+  const Vector::iterator end =
+    thrust::remove_copy(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), (T) 2);
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.erase(end, result.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
@@ -380,12 +381,12 @@ void TestRemoveIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), is_even<T>());
+  const Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), is_even<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.erase(end, data.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
@@ -404,13 +405,13 @@ void TestRemoveIfStencilCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end =
+  const Vector::iterator end =
     thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), stencil.begin(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.erase(end, data.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
@@ -429,13 +430,13 @@ void TestRemoveCopyIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end =
+  const Vector::iterator end =
     thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), is_even<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.erase(end, result.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
@@ -456,13 +457,13 @@ void TestRemoveCopyIfStencilCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Vector::iterator end = thrust::remove_copy_if(
+  const Vector::iterator end = thrust::remove_copy_if(
     thrust::cuda::par.on(s), data.begin(), data.end(), stencil.begin(), result.begin(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.erase(end, result.end());
 
-  Vector ref{1, 1, 3};
+  const Vector ref{1, 1, 3};
   ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/replace.cu
+++ b/thrust/testing/cuda/replace.cu
@@ -274,7 +274,7 @@ void TestReplaceCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector result{4, 5, 4, 3, 5};
+  const Vector result{4, 5, 4, 3, 5};
 
   ASSERT_EQUAL(data, result);
 

--- a/thrust/testing/cuda/reverse.cu
+++ b/thrust/testing/cuda/reverse.cu
@@ -88,7 +88,7 @@ void TestReverseCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector ref{5, 4, 3, 2, 1};
+  const Vector ref{5, 4, 3, 2, 1};
 
   ASSERT_EQUAL(ref, data);
 
@@ -110,7 +110,7 @@ void TestReverseCopyCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector ref{5, 4, 3, 2, 1};
+  const Vector ref{5, 4, 3, 2, 1};
 
   ASSERT_EQUAL(ref, result);
 

--- a/thrust/testing/cuda/scan.cu
+++ b/thrust/testing/cuda/scan.cu
@@ -141,7 +141,7 @@ void TestScanCudaStreams()
   Vector result{1, 4, 2, 6, 1};
   Vector output(5);
 
-  Vector input_copy(input);
+  const Vector input_copy(input);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -259,7 +259,7 @@ static void TestInclusiveScanWithConstAccumulator()
   thrust::inclusive_scan(
     data.begin(), data.end(), data.begin(), const_ref_plus_mod3<int>(thrust::raw_pointer_cast(&table[0])));
 
-  thrust::device_vector<int> ref{0, 1, 0, 1, 0, 0, 1};
+  const thrust::device_vector<int> ref{0, 1, 0, 1, 0, 0, 1};
   ASSERT_EQUAL(data, ref);
 }
 DECLARE_UNITTEST(TestInclusiveScanWithConstAccumulator);

--- a/thrust/testing/cuda/scan_by_key.cu
+++ b/thrust/testing/cuda/scan_by_key.cu
@@ -143,7 +143,7 @@ void TestInclusiveScanByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Iterator iter =
+  const Iterator iter =
     thrust::inclusive_scan_by_key(thrust::cuda::par.on(s), keys.begin(), keys.end(), vals.begin(), output.begin());
   cudaStreamSynchronize(s);
 
@@ -190,7 +190,7 @@ void TestExclusiveScanByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  Iterator iter =
+  const Iterator iter =
     thrust::exclusive_scan_by_key(thrust::cuda::par.on(s), keys.begin(), keys.end(), vals.begin(), output.begin());
   cudaStreamSynchronize(s);
 

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -148,7 +148,7 @@ void TestScatterCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector ref{0, 2, 4, 1, 0, 0, 0, 3};
+  const Vector ref{0, 2, 4, 1, 0, 0, 0, 3};
   ASSERT_EQUAL(dst, ref);
 
   cudaStreamDestroy(s);
@@ -170,7 +170,7 @@ void TestScatterIfCudaStreams()
   thrust::scatter_if(thrust::cuda::par.on(s), src.begin(), src.end(), map.begin(), flg.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  Vector ref{0, 0, 0, 1, 0, 0, 0, 3};
+  const Vector ref{0, 0, 0, 1, 0, 0, 0, 3};
   ASSERT_EQUAL(dst, ref);
 
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/set_difference.cu
+++ b/thrust/testing/cuda/set_difference.cu
@@ -52,7 +52,7 @@ DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
 void TestSetDifferenceCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
   auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -90,7 +90,7 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
 void TestSetDifferenceByKeyCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 5});
   auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 6});

--- a/thrust/testing/cuda/set_intersection.cu
+++ b/thrust/testing/cuda/set_intersection.cu
@@ -58,7 +58,7 @@ template <typename ExecutionPolicy>
 void TestSetIntersectionCudaStreams(ExecutionPolicy policy)
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, {0, 2, 4});
   auto b      = cuda::make_device_buffer<int>(stream, device, {0, 3, 3, 4});

--- a/thrust/testing/cuda/set_intersection_by_key.cu
+++ b/thrust/testing/cuda/set_intersection_by_key.cu
@@ -86,7 +86,7 @@ template <typename ExecutionPolicy>
 void TestSetIntersectionByKeyCudaStreams(ExecutionPolicy policy)
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, {0, 2, 4});
   auto b_key      = cuda::make_device_buffer<int>(stream, device, {0, 3, 3, 4});

--- a/thrust/testing/cuda/set_symmetric_difference.cu
+++ b/thrust/testing/cuda/set_symmetric_difference.cu
@@ -52,7 +52,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
 void TestSetSymmetricDifferenceCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
   auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -89,7 +89,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
 void TestSetSymmetricDifferenceByKeyCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4, 6});
   auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4, 7});

--- a/thrust/testing/cuda/set_union.cu
+++ b/thrust/testing/cuda/set_union.cu
@@ -52,7 +52,7 @@ DECLARE_UNITTEST(TestSetUnionDeviceDevice);
 void TestSetUnionCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
   auto b      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -89,7 +89,7 @@ DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
 void TestSetUnionByKeyCudaStreams()
 {
   const auto device = test_runtime::current_test_device();
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   auto a_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 2, 4});
   auto b_key      = cuda::make_device_buffer<int>(stream, device, cuda::std::initializer_list<int>{0, 3, 3, 4});

--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -244,7 +244,7 @@ public:
   {
     // The first (num_remainder_items * remainder_item_count) are items that appear once more often than the items that
     // follow remainder_items_offset
-    std::size_t remainder_items_offset = num_remainder_items * remainder_item_count;
+    const std::size_t remainder_items_offset = num_remainder_items * remainder_item_count;
 
     UnsignedIntegralKeyT target_item_index =
       (index <= remainder_items_offset)

--- a/thrust/testing/cuda/swap_ranges.cu
+++ b/thrust/testing/cuda/swap_ranges.cu
@@ -47,8 +47,8 @@ void TestSwapRangesCudaStreams()
 
   Vector v1{0, 1, 2, 3, 4};
   Vector v2{5, 6, 7, 8, 9};
-  Vector v1_ref(v2);
-  Vector v2_ref(v1);
+  const Vector v1_ref(v2);
+  const Vector v2_ref(v1);
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/transform.cu
+++ b/thrust/testing/cuda/transform.cu
@@ -313,7 +313,7 @@ void TestTransformUnaryCudaStreams()
 
   Vector input{1, -2, 3};
   Vector output(3);
-  Vector result{-1, 2, -3};
+  const Vector result{-1, 2, -3};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -339,7 +339,7 @@ void TestTransformBinaryCudaStreams()
   Vector input1{1, -2, 3};
   Vector input2{-4, 5, 6};
   Vector output(3);
-  Vector result{5, -7, -3};
+  const Vector result{5, -7, -3};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -410,7 +410,7 @@ void TestTransformThrustZipIteratorUnwrapping()
     thrust::transform(z, z + num_items, result.begin(), thrust::make_zip_function(sum_five{}));
 
     // compute reference and verify
-    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    const thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
     ASSERT_EQUAL(reference, result);
   }
   // SECTION("trice")
@@ -423,7 +423,7 @@ void TestTransformThrustZipIteratorUnwrapping()
                       thrust::make_zip_function(thrust::make_zip_function(thrust::make_zip_function(sum_five{}))));
 
     // compute reference and verify
-    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    const thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
     ASSERT_EQUAL(reference, result);
   }
 }
@@ -481,7 +481,7 @@ void TestTransformCudaZipIteratorUnwrapping()
     thrust::transform(z, z + num_items, result.begin(), cuda::zip_function(sum_five{}));
 
     // compute reference and verify
-    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    const thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
     ASSERT_EQUAL(reference, result);
   }
   // SECTION("trice")
@@ -492,7 +492,7 @@ void TestTransformCudaZipIteratorUnwrapping()
       z, z + num_items, result.begin(), cuda::zip_function<cuda::zip_function<cuda::zip_function<sum_five>>>{});
 
     // compute reference and verify
-    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    const thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
     ASSERT_EQUAL(reference, result);
   }
 }

--- a/thrust/testing/cuda/transform_reduce.cu
+++ b/thrust/testing/cuda/transform_reduce.cu
@@ -49,12 +49,12 @@ void TestTransformReduceCudaStreams()
   using T      = Vector::value_type;
 
   Vector data{1, -2, 3};
-  T init = 10;
+  const T init = 10;
 
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  T result = thrust::transform_reduce(
+  const T result = thrust::transform_reduce(
     thrust::cuda::par.on(s), data.begin(), data.end(), ::cuda::std::negate<T>(), init, ::cuda::std::plus<T>());
   cudaStreamSynchronize(s);
 

--- a/thrust/testing/cuda/transform_scan.cu
+++ b/thrust/testing/cuda/transform_scan.cu
@@ -240,7 +240,7 @@ void TestTransformScanCudaStreams()
   Vector result{-1, -4, -2, -6, -1};
   Vector output(5);
 
-  Vector input_copy(input);
+  const Vector input_copy(input);
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/trivial_copy_memcpy_default.cu
+++ b/thrust/testing/cuda/trivial_copy_memcpy_default.cu
@@ -17,7 +17,7 @@ void TestTrivialCopyFromDevice_HostSource()
   int src[]  = {0, 10, 20, 30, 40};
   int dst[5] = {};
 
-  cudaError_t status = thrust::cuda_cub::trivial_copy_from_device(dst, src, 5, cudaStreamDefault);
+  const cudaError_t status = thrust::cuda_cub::trivial_copy_from_device(dst, src, 5, cudaStreamDefault);
 
   ASSERT_EQUAL(status, cudaSuccess);
   for (int i = 0; i < 5; i++)
@@ -32,7 +32,7 @@ void TestTrivialCopyToDevice_HostDest()
   int src[]  = {0, 100, 200, 300, 400};
   int dst[5] = {};
 
-  cudaError_t status = thrust::cuda_cub::trivial_copy_to_device(dst, src, 5, cudaStreamDefault);
+  const cudaError_t status = thrust::cuda_cub::trivial_copy_to_device(dst, src, 5, cudaStreamDefault);
 
   ASSERT_EQUAL(status, cudaSuccess);
   for (int i = 0; i < 5; i++)

--- a/thrust/testing/cuda/uninitialized_fill.cu
+++ b/thrust/testing/cuda/uninitialized_fill.cu
@@ -81,7 +81,7 @@ void TestUninitializedFillCudaStreams()
   using T      = Vector::value_type;
 
   Vector v{0, 1, 2, 3, 4};
-  T sub(7);
+  const T sub(7);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -89,7 +89,7 @@ void TestUninitializedFillCudaStreams()
   thrust::uninitialized_fill(thrust::cuda::par.on(s), v.begin(), v.end(), sub);
   cudaStreamSynchronize(s);
 
-  Vector ref(v.size(), sub);
+  const Vector ref(v.size(), sub);
   ASSERT_EQUAL(v, ref);
 
   cudaStreamDestroy(s);
@@ -189,7 +189,7 @@ void TestUninitializedFillNCudaStreams()
   using T      = Vector::value_type;
 
   Vector v{0, 1, 2, 3, 4};
-  T sub(7);
+  const T sub(7);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -197,7 +197,7 @@ void TestUninitializedFillNCudaStreams()
   thrust::uninitialized_fill_n(thrust::cuda::par.on(s), v.begin(), v.size(), sub);
   cudaStreamSynchronize(s);
 
-  Vector ref(5, sub);
+  const Vector ref(5, sub);
   ASSERT_EQUAL(v, ref);
 
   cudaStreamDestroy(s);

--- a/thrust/testing/cuda/unique.cu
+++ b/thrust/testing/cuda/unique.cu
@@ -123,7 +123,7 @@ void TestUniqueCudaStreams(ExecutionPolicy policy)
 
   Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
-  thrust::device_vector<Vector::iterator> new_last_vec(1);
+  const thrust::device_vector<Vector::iterator> new_last_vec(1);
   Vector::iterator new_last;
 
   cudaStream_t s;
@@ -247,7 +247,7 @@ void TestUniqueCopyCudaStreams(ExecutionPolicy policy)
 
   Vector output(10, -1);
 
-  thrust::device_vector<Vector::iterator> new_last_vec(1);
+  const thrust::device_vector<Vector::iterator> new_last_vec(1);
   Vector::iterator new_last;
 
   cudaStream_t s;
@@ -389,34 +389,34 @@ void TestUniqueWithMagnitude(int magnitude)
   using offset_t      = std::int64_t;
   using equality_op_t = div_n_equality_op<offset_t>;
 
-  offset_t run_length_of_equal_items = offset_t{10};
-  equality_op_t equality_op          = equality_op_t{run_length_of_equal_items};
+  const offset_t run_length_of_equal_items = offset_t{10};
+  const equality_op_t equality_op          = equality_op_t{run_length_of_equal_items};
 
   // Prepare input
-  offset_t num_items = offset_t{1ull} << magnitude;
-  thrust::counting_iterator<offset_t> begin(offset_t{0});
+  const offset_t num_items = offset_t{1ull} << magnitude;
+  const thrust::counting_iterator<offset_t> begin(offset_t{0});
   auto end = begin + num_items;
   ASSERT_EQUAL(static_cast<offset_t>(cuda::std::distance(begin, end)), num_items);
 
-  offset_t expected_num_unique = ::cuda::ceil_div(num_items, offset_t{10});
+  const offset_t expected_num_unique = ::cuda::ceil_div(num_items, offset_t{10});
   thrust::device_vector<offset_t> unique_out(expected_num_unique);
   auto unique_out_end = thrust::unique_copy(begin, end, unique_out.begin(), equality_op);
 
   // Ensure number of selected items are correct
-  offset_t num_selected_out = static_cast<offset_t>(cuda::std::distance(unique_out.begin(), unique_out_end));
+  const offset_t num_selected_out = static_cast<offset_t>(cuda::std::distance(unique_out.begin(), unique_out_end));
   ASSERT_EQUAL(num_selected_out, expected_num_unique);
   unique_out.resize(expected_num_unique);
 
   // Ensure selected items are correct
-  auto expected_out_it     = thrust::make_transform_iterator(begin, multiply_n<offset_t>{run_length_of_equal_items});
-  bool all_results_correct = thrust::equal(unique_out.begin(), unique_out.end(), expected_out_it);
+  auto expected_out_it = thrust::make_transform_iterator(begin, multiply_n<offset_t>{run_length_of_equal_items});
+  const bool all_results_correct = thrust::equal(unique_out.begin(), unique_out.end(), expected_out_it);
   ASSERT_EQUAL(all_results_correct, true);
 }
 
 void TestUniqueWithLargeNumberOfItems()
 try
 {
-  for (int mag : {30, 31, 32, 33})
+  for (const int mag : {30, 31, 32, 33})
   {
     TestUniqueWithMagnitude(mag);
   }
@@ -446,7 +446,7 @@ void TestUniqueWithCustomEqualityOp()
   auto num_selected_out = cuda::std::distance(unique_out.begin(), unique_out_end);
   ASSERT_EQUAL(num_selected_out, num_items);
   ASSERT_EQUAL(error_counter[0], ::cuda::std::uint32_t{0});
-  bool all_results_correct = thrust::equal(unique_out.cbegin(), unique_out.cend(), data);
+  const bool all_results_correct = thrust::equal(unique_out.cbegin(), unique_out.cend(), data);
   ASSERT_EQUAL(all_results_correct, true);
 }
 

--- a/thrust/testing/decompose.cu
+++ b/thrust/testing/decompose.cu
@@ -7,7 +7,7 @@ using thrust::system::detail::internal::uniform_decomposition;
 void TestUniformDecomposition()
 {
   {
-    uniform_decomposition<int> ud(10, 10, 1);
+    const uniform_decomposition<int> ud(10, 10, 1);
 
     // [0,10)
     ASSERT_EQUAL(ud.size(), 1);
@@ -17,7 +17,7 @@ void TestUniformDecomposition()
   }
 
   {
-    uniform_decomposition<int> ud(10, 20, 1);
+    const uniform_decomposition<int> ud(10, 20, 1);
 
     // [0,10)
     ASSERT_EQUAL(ud.size(), 1);
@@ -27,7 +27,7 @@ void TestUniformDecomposition()
   }
 
   {
-    uniform_decomposition<int> ud(8, 5, 2);
+    const uniform_decomposition<int> ud(8, 5, 2);
 
     // [0,5)[5,8)
     ASSERT_EQUAL(ud.size(), 2);
@@ -40,7 +40,7 @@ void TestUniformDecomposition()
   }
 
   {
-    uniform_decomposition<int> ud(8, 5, 3);
+    const uniform_decomposition<int> ud(8, 5, 3);
 
     // [0,5)[5,8)
     ASSERT_EQUAL(ud.size(), 2);
@@ -53,7 +53,7 @@ void TestUniformDecomposition()
   }
 
   {
-    uniform_decomposition<int> ud(10, 1, 2);
+    const uniform_decomposition<int> ud(10, 1, 2);
 
     // [0,5)[5,10)
     ASSERT_EQUAL(ud.size(), 2);
@@ -67,7 +67,7 @@ void TestUniformDecomposition()
 
   {
     // [0,4)[4,8)[8,10)
-    uniform_decomposition<int> ud(10, 2, 3);
+    const uniform_decomposition<int> ud(10, 2, 3);
 
     ASSERT_EQUAL(ud.size(), 3);
     ASSERT_EQUAL(ud[0].begin(), 0);

--- a/thrust/testing/dereference.cu
+++ b/thrust/testing/dereference.cu
@@ -47,9 +47,9 @@ void TestDeviceDereferenceDevicePtr()
   thrust::device_vector<int> input = unittest::random_integers<int>(100);
   thrust::device_vector<int> output(input.size(), 0);
 
-  thrust::device_ptr<int> _first1 = &input[0];
-  thrust::device_ptr<int> _last1  = _first1 + static_cast<std::ptrdiff_t>(input.size());
-  thrust::device_ptr<int> _first2 = &output[0];
+  const thrust::device_ptr<int> _first1 = &input[0];
+  const thrust::device_ptr<int> _last1  = _first1 + static_cast<std::ptrdiff_t>(input.size());
+  const thrust::device_ptr<int> _first2 = &output[0];
 
   simple_copy(_first1, _last1, _first2);
 
@@ -98,22 +98,22 @@ DECLARE_UNITTEST(TestDeviceDereferenceTransformIteratorOutputConversion);
 
 void TestDeviceDereferenceCountingIterator()
 {
-  thrust::counting_iterator<int> first(1);
-  thrust::counting_iterator<int> last(6);
+  const thrust::counting_iterator<int> first(1);
+  const thrust::counting_iterator<int> last(6);
 
   thrust::device_vector<int> output(5);
 
   simple_copy(first, last, output.begin());
 
-  thrust::device_vector<int> ref{1, 2, 3, 4, 5};
+  const thrust::device_vector<int> ref{1, 2, 3, 4, 5};
   ASSERT_EQUAL(output, ref);
 }
 DECLARE_UNITTEST(TestDeviceDereferenceCountingIterator);
 
 void TestDeviceDereferenceTransformedCountingIterator()
 {
-  thrust::counting_iterator<int> first(1);
-  thrust::counting_iterator<int> last(6);
+  const thrust::counting_iterator<int> first(1);
+  const thrust::counting_iterator<int> last(6);
 
   thrust::device_vector<int> output(5);
 
@@ -121,7 +121,7 @@ void TestDeviceDereferenceTransformedCountingIterator()
               thrust::make_transform_iterator(last, ::cuda::std::negate<int>()),
               output.begin());
 
-  thrust::device_vector<int> ref{-1, -2, -3, -4, -5};
+  const thrust::device_vector<int> ref{-1, -2, -3, -4, -5};
   ASSERT_EQUAL(output, ref);
 }
 DECLARE_UNITTEST(TestDeviceDereferenceTransformedCountingIterator);

--- a/thrust/testing/device_delete.cu
+++ b/thrust/testing/device_delete.cu
@@ -27,7 +27,7 @@ struct Foo
 
 void TestDeviceDeleteDestructorInvocation()
 {
-  thrust::device_ptr<Foo> foo_ptr = thrust::device_new<Foo>();
+  const thrust::device_ptr<Foo> foo_ptr = thrust::device_new<Foo>();
 
   thrust::device_vector<bool> destructor_flag(1, false);
   *thrust::device_ptr<bool*>(&foo_ptr.get()->destroyed) = destructor_flag.data().get();
@@ -73,13 +73,13 @@ struct derived : base
 void TestDeviceDeleteVirtualDestructorInvocation()
 {
   {
-    thrust::device_ptr<derived> ptr = thrust::device_new<derived>();
+    const thrust::device_ptr<derived> ptr = thrust::device_new<derived>();
 
     thrust::device_vector<bool> destructor_flags(2, false);
     *thrust::device_ptr<bool*>(&ptr.get()->base_destroyed)    = destructor_flags.data().get() + 0;
     *thrust::device_ptr<bool*>(&ptr.get()->derived_destroyed) = destructor_flags.data().get() + 1;
 
-    thrust::device_ptr<derived> base_ptr = ptr;
+    const thrust::device_ptr<derived> base_ptr = ptr;
 
     ASSERT_EQUAL(false, destructor_flags[0]);
     ASSERT_EQUAL(false, destructor_flags[1]);

--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -17,7 +17,7 @@ void TestDevicePointerManipulation()
   thrust::device_vector<int> data(5);
 
   thrust::device_ptr<int> begin(&data[0]);
-  thrust::device_ptr<int> end(&data[0] + 5);
+  const thrust::device_ptr<int> end(&data[0] + 5);
 
   ASSERT_EQUAL(end - begin, 5);
 
@@ -64,11 +64,11 @@ void TestMakeDevicePointer()
 
   T* raw_ptr = nullptr;
 
-  thrust::device_ptr<T> p0 = thrust::device_pointer_cast(raw_ptr);
+  const thrust::device_ptr<T> p0 = thrust::device_pointer_cast(raw_ptr);
 
   ASSERT_EQUAL(thrust::raw_pointer_cast(p0), raw_ptr);
 
-  thrust::device_ptr<T> p1 = thrust::device_pointer_cast(p0);
+  const thrust::device_ptr<T> p1 = thrust::device_pointer_cast(p0);
 
   ASSERT_EQUAL(p0, p1);
 }
@@ -117,7 +117,7 @@ DECLARE_GENERIC_UNITTEST(TestDevicePointerNullptrCompatibility);
 template <typename T>
 void TestDevicePointerBoolConversion()
 {
-  thrust::device_ptr<T> p0(nullptr);
+  const thrust::device_ptr<T> p0(nullptr);
   auto const b = bool(p0);
 
   ASSERT_EQUAL_QUIET(false, b);
@@ -133,8 +133,8 @@ void TestDevicePointerCompare()
   { // test same element type
     using device_ptr = thrust::device_ptr<T1>;
 
-    device_ptr ptr1 = v1.data();
-    device_ptr ptr2 = ptr1 + 1;
+    const device_ptr ptr1 = v1.data();
+    const device_ptr ptr2 = ptr1 + 1;
 
     // Equality
     ASSERT_EQUAL(true, (ptr1 == ptr1));
@@ -171,8 +171,8 @@ void TestDevicePointerCompare()
       thrust::pointer<T1, thrust::device_system_tag, thrust::tagged_reference<T1, thrust::device_system_tag>>;
     static_assert(!::cuda::std::is_same_v<device_ptr, other_ptr>);
 
-    device_ptr ptr1 = v1.data();
-    other_ptr ptr2{other_ptr{thrust::raw_pointer_cast(ptr1 + 1)}};
+    const device_ptr ptr1 = v1.data();
+    const other_ptr ptr2{other_ptr{thrust::raw_pointer_cast(ptr1 + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ptr1 == ptr1));

--- a/thrust/testing/device_reference.cu
+++ b/thrust/testing/device_reference.cu
@@ -8,7 +8,7 @@ void TestDeviceReferenceConstructorFromDeviceReference()
   using T = int;
 
   thrust::device_vector<T> v(1, 0);
-  thrust::device_reference<T> ref = v[0];
+  const thrust::device_reference<T> ref = v[0];
 
   // ref equals the object at v[0]
   ASSERT_EQUAL(v[0], ref);
@@ -33,8 +33,8 @@ void TestDeviceReferenceConstructorFromDevicePointer()
   using T = int;
 
   thrust::device_vector<T> v(1, 0);
-  thrust::device_ptr<T> ptr = &v[0];
-  thrust::device_reference<T> ref(ptr);
+  const thrust::device_ptr<T> ptr = &v[0];
+  const thrust::device_reference<T> ref(ptr);
 
   // ref equals the object pointed to by ptr
   ASSERT_EQUAL(*ptr, ref);
@@ -59,8 +59,8 @@ void TestDeviceReferenceAssignmentFromDeviceReference()
   // test same types
   using T0 = int;
   thrust::device_vector<T0> v0{0, 0};
-  thrust::device_reference<T0> ref0 = v0[0];
-  thrust::device_reference<T0> ref1 = v0[1];
+  const thrust::device_reference<T0> ref0 = v0[0];
+  const thrust::device_reference<T0> ref1 = v0[1];
 
   ref0 = 13;
   ref1 = ref0;
@@ -92,7 +92,7 @@ void TestDeviceReferenceAssignmentFromDeviceReference()
   // test different types
   using T1 = float;
   thrust::device_vector<T1> v1{0.0f};
-  thrust::device_reference<T1> ref2 = v1[0];
+  const thrust::device_reference<T1> ref2 = v1[0];
 
   ref2 = ref0;
 
@@ -107,7 +107,7 @@ void TestDeviceReferenceManipulation()
   using T1 = int;
 
   thrust::device_vector<T1> v(1, 0);
-  thrust::device_ptr<T1> ptr = &v[0];
+  const thrust::device_ptr<T1> ptr = &v[0];
   thrust::device_reference<T1> ref(ptr);
 
   // reset
@@ -123,7 +123,7 @@ void TestDeviceReferenceManipulation()
   ref = 0;
 
   // test postfix increment
-  T1 x1 = ref++;
+  const T1 x1 = ref++;
   ASSERT_EQUAL(0, x1);
   ASSERT_EQUAL(1, ref);
   ASSERT_EQUAL(1, *ptr);
@@ -220,7 +220,7 @@ void TestDeviceReferenceManipulation()
   ASSERT_EQUAL(0, v[0]);
 
   // test equality of const references
-  thrust::device_reference<const T1> ref1 = v[0];
+  const thrust::device_reference<const T1> ref1 = v[0];
   ASSERT_EQUAL(true, ref1 == ref);
 }
 DECLARE_UNITTEST(TestDeviceReferenceManipulation);
@@ -230,8 +230,8 @@ void TestDeviceReferenceSwap()
   using T = int;
 
   thrust::device_vector<T> v(2);
-  thrust::device_reference<T> ref1 = v.front();
-  thrust::device_reference<T> ref2 = v.back();
+  thrust::device_reference<T> ref1       = v.front();
+  const thrust::device_reference<T> ref2 = v.back();
 
   ref1 = 7;
   ref2 = 13;
@@ -258,8 +258,8 @@ void TestDeviceReferenceCompare()
   { // test same element type
     using device_ref = thrust::device_reference<T1>;
 
-    device_ref ref1 = v1.front();
-    device_ref ref2 = v1.back();
+    const device_ref ref1 = v1.front();
+    const device_ref ref2 = v1.back();
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -286,8 +286,8 @@ void TestDeviceReferenceCompare()
     using device_ref = thrust::device_reference<T1>;
     using other_ref  = thrust::device_reference<T2>;
 
-    device_ref ref1 = v1.front();
-    other_ref ref2  = v2.back();
+    const device_ref ref1 = v1.front();
+    const other_ref ref2  = v2.back();
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -314,8 +314,8 @@ void TestDeviceReferenceCompare()
     using other_pointer = typename other_ref::pointer;
     static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
 
-    device_ref ref1 = v1.front();
-    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
+    const device_ref ref1 = v1.front();
+    const other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -342,8 +342,8 @@ void TestDeviceReferenceCompare()
     using other_pointer = typename other_ref::pointer;
     static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
 
-    device_ref ref1 = v1.front();
-    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
+    const device_ref ref1 = v1.front();
+    const other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -413,8 +413,8 @@ void TestTaggedReferenceCompare()
     using tagged_ref = thrust::tagged_reference<T1, thrust::device_system_tag>;
     using tagged_ptr = typename tagged_ref::pointer;
 
-    tagged_ref ref1{tagged_ptr{thrust::raw_pointer_cast(v1.data())}};
-    tagged_ref ref2{tagged_ptr{thrust::raw_pointer_cast(v1.data() + 1)}};
+    const tagged_ref ref1{tagged_ptr{thrust::raw_pointer_cast(v1.data())}};
+    const tagged_ref ref2{tagged_ptr{thrust::raw_pointer_cast(v1.data() + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -441,8 +441,8 @@ void TestTaggedReferenceCompare()
     using tagged_ref = thrust::device_reference<T1>;
     using other_ref  = thrust::device_reference<T2>;
 
-    tagged_ref ref1 = v1.front();
-    other_ref ref2  = v2.back();
+    const tagged_ref ref1 = v1.front();
+    const other_ref ref2  = v2.back();
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -469,8 +469,8 @@ void TestTaggedReferenceCompare()
     using other_pointer = typename other_ref::pointer;
     static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
 
-    tagged_ref ref1 = v1.front();
-    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
+    const tagged_ref ref1 = v1.front();
+    const other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));
@@ -497,8 +497,8 @@ void TestTaggedReferenceCompare()
     using other_pointer = typename other_ref::pointer;
     static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
 
-    tagged_ref ref1 = v1.front();
-    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
+    const tagged_ref ref1 = v1.front();
+    const other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
 
     // Equality
     ASSERT_EQUAL(true, (ref1 == ref1));

--- a/thrust/testing/discard_iterator.cu
+++ b/thrust/testing/discard_iterator.cu
@@ -36,7 +36,7 @@ DECLARE_UNITTEST(TestDiscardIteratorTraits);
 void TestDiscardIteratorIncrement()
 {
   thrust::discard_iterator<> lhs(0);
-  thrust::discard_iterator<> rhs(0);
+  const thrust::discard_iterator<> rhs(0);
 
   ASSERT_EQUAL(0, lhs - rhs);
 
@@ -89,11 +89,11 @@ DECLARE_UNITTEST(TestDiscardIteratorComparison);
 
 void TestMakeDiscardIterator()
 {
-  thrust::discard_iterator<> iter0 = thrust::make_discard_iterator(13);
+  const thrust::discard_iterator<> iter0 = thrust::make_discard_iterator(13);
 
   *iter0 = 7;
 
-  thrust::discard_iterator<> iter1 = thrust::make_discard_iterator(7);
+  const thrust::discard_iterator<> iter1 = thrust::make_discard_iterator(7);
 
   *iter1 = 13;
 
@@ -106,10 +106,10 @@ void TestZippedDiscardIterator()
   using IteratorTuple1 = cuda::std::tuple<thrust::discard_iterator<>>;
   using ZipIterator1   = thrust::zip_iterator<IteratorTuple1>;
 
-  IteratorTuple1 t = cuda::std::tuple(thrust::make_discard_iterator());
+  const IteratorTuple1 t = cuda::std::tuple(thrust::make_discard_iterator());
 
-  ZipIterator1 z_iter1_first = thrust::make_zip_iterator(t);
-  ZipIterator1 z_iter1_last  = z_iter1_first + 10;
+  ZipIterator1 z_iter1_first      = thrust::make_zip_iterator(t);
+  const ZipIterator1 z_iter1_last = z_iter1_first + 10;
   for (; z_iter1_first != z_iter1_last; ++z_iter1_first)
   {
     ;
@@ -120,8 +120,8 @@ void TestZippedDiscardIterator()
   using IteratorTuple2 = cuda::std::tuple<int*, thrust::discard_iterator<>>;
   using ZipIterator2   = thrust::zip_iterator<IteratorTuple2>;
 
-  ZipIterator2 z_iter_first = thrust::make_zip_iterator((int*) nullptr, thrust::make_discard_iterator());
-  ZipIterator2 z_iter_last  = z_iter_first + 10;
+  ZipIterator2 z_iter_first      = thrust::make_zip_iterator((int*) nullptr, thrust::make_discard_iterator());
+  const ZipIterator2 z_iter_last = z_iter_first + 10;
 
   for (; z_iter_first != z_iter_last; ++z_iter_first)
   {

--- a/thrust/testing/equal.cu
+++ b/thrust/testing/equal.cu
@@ -77,7 +77,7 @@ void TestEqualDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::equal(sys, vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -120,18 +120,18 @@ struct only_set_when_both_expected
 
 void TestEqualWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
-  *has_executed                         = false;
+  const thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  *has_executed                               = false;
 
-  only_set_when_both_expected fn = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_both_expected fn = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
 
   ASSERT_EQUAL(thrust::equal(thrust::device, begin, end, begin, fn), true);
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);

--- a/thrust/testing/fill.cu
+++ b/thrust/testing/fill.cu
@@ -139,13 +139,13 @@ DECLARE_VECTOR_UNITTEST(TestFillNSimple);
 
 void TestFillNDiscardIterator()
 {
-  thrust::discard_iterator<thrust::host_system_tag> h_result =
+  const thrust::discard_iterator<thrust::host_system_tag> h_result =
     thrust::fill_n(thrust::discard_iterator<thrust::host_system_tag>(), 10, 13);
 
-  thrust::discard_iterator<thrust::device_system_tag> d_result =
+  const thrust::discard_iterator<thrust::device_system_tag> d_result =
     thrust::fill_n(thrust::discard_iterator<thrust::device_system_tag>(), 10, 13);
 
-  thrust::discard_iterator<> reference(10);
+  const thrust::discard_iterator<> reference(10);
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -346,7 +346,7 @@ void TestFillDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::fill(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -380,7 +380,7 @@ void TestFillNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::fill_n(sys, vec.begin(), vec.size(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/find.cu
+++ b/thrust/testing/find.cu
@@ -32,7 +32,7 @@ void TestFindDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::find(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -84,7 +84,7 @@ void TestFindIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::find_if(sys, vec.begin(), vec.end(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -136,7 +136,7 @@ void TestFindIfNotDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::find_if_not(sys, vec.begin(), vec.end(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -242,8 +242,8 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(TestFindIfNot, SignedIntegralTypes);
 
 void TestFindWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
   cuda::std::intmax_t distance_low_value = ::cuda::std::distance(begin, thrust::find(thrust::device, begin, end, 17));

--- a/thrust/testing/for_each.cu
+++ b/thrust/testing/for_each.cu
@@ -34,7 +34,7 @@ void TestForEachSimple()
   mark_present_for_each<T> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
-  typename Vector::iterator result = thrust::for_each(input.begin(), input.end(), f);
+  const typename Vector::iterator result = thrust::for_each(input.begin(), input.end(), f);
 
   Vector ref{0, 0, 1, 1, 1, 0, 1};
   ASSERT_EQUAL(output, ref);
@@ -53,7 +53,7 @@ void TestForEachDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::for_each(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -88,7 +88,7 @@ void TestForEachNSimple()
   mark_present_for_each<T> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
-  typename Vector::iterator result = thrust::for_each_n(input.begin(), input.size(), f);
+  const typename Vector::iterator result = thrust::for_each_n(input.begin(), input.size(), f);
 
   Vector ref{0, 0, 1, 1, 1, 0, 1};
   ASSERT_EQUAL(output, ref);
@@ -107,7 +107,7 @@ void TestForEachNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::for_each_n(sys, vec.begin(), vec.size(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -138,10 +138,10 @@ void TestForEachSimpleAnySystem()
   mark_present_for_each<int> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
-  thrust::counting_iterator<int> result =
+  const thrust::counting_iterator<int> result =
     thrust::for_each(thrust::make_counting_iterator(0), thrust::make_counting_iterator(5), f);
 
-  thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
+  const thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
   ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, thrust::make_counting_iterator(5));
 }
@@ -154,9 +154,9 @@ void TestForEachNSimpleAnySystem()
   mark_present_for_each<int> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
-  thrust::counting_iterator<int> result = thrust::for_each_n(thrust::make_counting_iterator(0), 5, f);
+  const thrust::counting_iterator<int> result = thrust::for_each_n(thrust::make_counting_iterator(0), 5, f);
 
-  thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
+  const thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
   ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, thrust::make_counting_iterator(5));
 }
@@ -184,9 +184,9 @@ void TestForEach(const size_t n)
   h_f.ptr = &h_output[0];
   d_f.ptr = (&d_output[0]).get();
 
-  typename thrust::host_vector<T>::iterator h_result = thrust::for_each(h_input.begin(), h_input.end(), h_f);
+  const typename thrust::host_vector<T>::iterator h_result = thrust::for_each(h_input.begin(), h_input.end(), h_f);
 
-  typename thrust::device_vector<T>::iterator d_result = thrust::for_each(d_input.begin(), d_input.end(), d_f);
+  const typename thrust::device_vector<T>::iterator d_result = thrust::for_each(d_input.begin(), d_input.end(), d_f);
 
   ASSERT_EQUAL(h_output, d_output);
   ASSERT_EQUAL_QUIET(h_result, h_input.end());
@@ -216,9 +216,9 @@ void TestForEachN(const size_t n)
   h_f.ptr = &h_output[0];
   d_f.ptr = (&d_output[0]).get();
 
-  typename thrust::host_vector<T>::iterator h_result = thrust::for_each_n(h_input.begin(), h_input.size(), h_f);
+  const typename thrust::host_vector<T>::iterator h_result = thrust::for_each_n(h_input.begin(), h_input.size(), h_f);
 
-  typename thrust::device_vector<T>::iterator d_result = thrust::for_each_n(d_input.begin(), d_input.size(), d_f);
+  const typename thrust::device_vector<T>::iterator d_result = thrust::for_each_n(d_input.begin(), d_input.size(), d_f);
 
   ASSERT_EQUAL(h_output, d_output);
   ASSERT_EQUAL_QUIET(h_result, h_input.end());
@@ -244,7 +244,7 @@ struct SetFixedVectorToConstant
 template <typename T, unsigned int N>
 void _TestForEachWithLargeTypes()
 {
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<FixedVector<T, N>> h_data(n);
 
@@ -255,7 +255,7 @@ void _TestForEachWithLargeTypes()
 
   thrust::device_vector<FixedVector<T, N>> d_data = h_data;
 
-  SetFixedVectorToConstant<T, N> func(123);
+  const SetFixedVectorToConstant<T, N> func(123);
 
   thrust::for_each(h_data.begin(), h_data.end(), func);
   thrust::for_each(d_data.begin(), d_data.end(), func);
@@ -285,7 +285,7 @@ DECLARE_UNITTEST(TestForEachWithLargeTypes);
 template <typename T, unsigned int N>
 void _TestForEachNWithLargeTypes()
 {
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<FixedVector<T, N>> h_data(n);
 
@@ -296,7 +296,7 @@ void _TestForEachNWithLargeTypes()
 
   thrust::device_vector<FixedVector<T, N>> d_data = h_data;
 
-  SetFixedVectorToConstant<T, N> func(123);
+  const SetFixedVectorToConstant<T, N> func(123);
 
   thrust::for_each_n(h_data.begin(), h_data.size(), func);
   thrust::for_each_n(d_data.begin(), d_data.size(), func);
@@ -341,18 +341,18 @@ struct only_set_when_expected
 
 void TestForEachWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<unsigned long long> begin(0);
-  thrust::counting_iterator<unsigned long long> end = begin + static_cast<std::ptrdiff_t>(1ull << magnitude);
+  const thrust::counting_iterator<unsigned long long> begin(0);
+  const thrust::counting_iterator<unsigned long long> end = begin + static_cast<std::ptrdiff_t>(1ull << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
-  *has_executed                         = false;
+  const thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  *has_executed                               = false;
 
-  only_set_when_expected fn = {(1ull << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_expected fn = {(1ull << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
 
   thrust::for_each(thrust::device, begin, end, fn);
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);

--- a/thrust/testing/functional_placeholders_miscellaneous.cu
+++ b/thrust/testing/functional_placeholders_miscellaneous.cu
@@ -26,7 +26,7 @@ struct TestFunctionalPlaceholdersValue
     const size_t n = 10000;
     using T        = typename Vector::value_type;
 
-    T a(13);
+    const T a(13);
 
     Vector x = unittest::random_integers<T>(n);
     Vector y = unittest::random_integers<T>(n);
@@ -61,7 +61,7 @@ struct TestFunctionalPlaceholdersTransformIterator
     const size_t n = 10000;
     using T        = typename Vector::value_type;
 
-    T a(13);
+    const T a(13);
 
     Vector x = unittest::random_integers<T>(n);
     Vector y = unittest::random_integers<T>(n);
@@ -109,9 +109,10 @@ void TestFunctionalPlaceholdersSemiRegular()
 {
   using namespace thrust::placeholders;
   using Expr = decltype(_1 * _1 + _2 * _2);
+  // NOLINTNEXTLINE(misc-const-correctness)
   Expr expr; // default-constructible
   ASSERT_EQUAL(expr(2, 3), 13);
-  Expr expr2 = expr; // copy-constructible
+  const Expr expr2 = expr; // copy-constructible
   ASSERT_EQUAL(expr2(2, 3), 13);
   Expr expr3;
   expr3 = expr; // copy-assignable

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -45,7 +45,7 @@ void TestGatherDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::gather(sys, vec.begin(), vec.end(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -121,13 +121,13 @@ void TestGatherToDiscardIterator(const size_t n)
 
   thrust::device_vector<unsigned int> d_map = h_map;
 
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::gather(h_map.begin(), h_map.end(), h_source.begin(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::gather(d_map.begin(), d_map.end(), d_source.begin(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -175,7 +175,7 @@ void TestGatherIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::gather_if(sys, vec.begin(), vec.end(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -291,7 +291,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
 
   thrust::device_vector<unsigned int> d_stencil = h_stencil;
 
-  thrust::discard_iterator<> h_result = thrust::gather_if(
+  const thrust::discard_iterator<> h_result = thrust::gather_if(
     h_map.begin(),
     h_map.end(),
     h_stencil.begin(),
@@ -299,7 +299,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     thrust::make_discard_iterator(),
     is_even_gather_if<unsigned int>());
 
-  thrust::discard_iterator<> d_result = thrust::gather_if(
+  const thrust::discard_iterator<> d_result = thrust::gather_if(
     d_map.begin(),
     d_map.end(),
     d_stencil.begin(),
@@ -307,7 +307,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
     thrust::make_discard_iterator(),
     is_even_gather_if<unsigned int>());
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/generate.cu
+++ b/thrust/testing/generate.cu
@@ -30,9 +30,9 @@ void TestGenerateSimple()
 
   Vector result(5);
 
-  T value = 13;
+  const T value = 13;
 
-  return_value<T> f(value);
+  const return_value<T> f(value);
 
   thrust::generate(result.begin(), result.end(), f);
 
@@ -51,7 +51,7 @@ void TestGenerateDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::generate(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -81,7 +81,7 @@ void TestGenerate(const size_t n)
   thrust::device_vector<T> d_result(n);
 
   T value = 13;
-  return_value<T> f(value);
+  const return_value<T> f(value);
 
   thrust::generate(h_result.begin(), h_result.end(), f);
   thrust::generate(d_result.begin(), d_result.end(), f);
@@ -94,12 +94,12 @@ template <typename T>
 void TestGenerateToDiscardIterator(const size_t)
 {
   T value = 13;
-  return_value<T> f(value);
+  const return_value<T> f(value);
 
-  thrust::discard_iterator<thrust::host_system_tag> h_first;
+  thrust::discard_iterator<thrust::host_system_tag> h_first; // NOLINT(misc-const-correctness)
   thrust::generate(h_first, h_first + 10, f);
 
-  thrust::discard_iterator<thrust::device_system_tag> d_first;
+  thrust::discard_iterator<thrust::device_system_tag> d_first; // NOLINT(misc-const-correctness)
   thrust::generate(d_first, d_first + 10, f);
 
   // there's nothing to actually check except that it compiles
@@ -113,9 +113,9 @@ void TestGenerateNSimple()
 
   Vector result(5);
 
-  T value = 13;
+  const T value = 13;
 
-  return_value<T> f(value);
+  const return_value<T> f(value);
 
   thrust::generate_n(result.begin(), result.size(), f);
 
@@ -135,7 +135,7 @@ void TestGenerateNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::generate_n(sys, vec.begin(), vec.size(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -163,15 +163,15 @@ template <typename T>
 void TestGenerateNToDiscardIterator(const size_t n)
 {
   T value = 13;
-  return_value<T> f(value);
+  const return_value<T> f(value);
 
-  thrust::discard_iterator<thrust::host_system_tag> h_result =
+  const thrust::discard_iterator<thrust::host_system_tag> h_result =
     thrust::generate_n(thrust::discard_iterator<thrust::host_system_tag>(), n, f);
 
-  thrust::discard_iterator<thrust::device_system_tag> d_result =
+  const thrust::discard_iterator<thrust::device_system_tag> d_result =
     thrust::generate_n(thrust::discard_iterator<thrust::device_system_tag>(), n, f);
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/inner_product.cu
+++ b/thrust/testing/inner_product.cu
@@ -15,8 +15,8 @@ void TestInnerProductSimple()
   Vector v1{1, -2, 3};
   Vector v2{-4, 5, 6};
 
-  T init   = 3;
-  T result = thrust::inner_product(v1.begin(), v1.end(), v2.begin(), init);
+  const T init   = 3;
+  const T result = thrust::inner_product(v1.begin(), v1.end(), v2.begin(), init);
   ASSERT_EQUAL(result, 7);
 }
 DECLARE_VECTOR_UNITTEST(TestInnerProductSimple);
@@ -32,7 +32,7 @@ void TestInnerProductDispatchExplicit()
 {
   thrust::device_vector<int> vec;
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::inner_product(sys, vec.begin(), vec.end(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -49,7 +49,7 @@ void TestInnerProductDispatchImplicit()
 {
   thrust::device_vector<int> vec;
 
-  int result = thrust::inner_product(
+  const int result = thrust::inner_product(
     thrust::retag<my_tag>(vec.begin()), thrust::retag<my_tag>(vec.end()), thrust::retag<my_tag>(vec.begin()), 0);
 
   ASSERT_EQUAL(13, result);
@@ -65,8 +65,8 @@ void TestInnerProductWithOperator()
   Vector v2{-1, 3, 6};
 
   // compute (v1 - v2) and perform a multiplies reduction
-  T init   = 3;
-  T result = thrust::inner_product(
+  const T init   = 3;
+  const T result = thrust::inner_product(
     v1.begin(), v1.end(), v2.begin(), init, ::cuda::std::multiplies<T>(), ::cuda::std::minus<T>());
   ASSERT_EQUAL(result, 90);
 }
@@ -111,19 +111,19 @@ struct only_set_when_both_expected
 
 void TestInnerProductWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
-  *has_executed                         = false;
+  const thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  *has_executed                               = false;
 
-  only_set_when_both_expected fn = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_both_expected fn = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
 
   ASSERT_EQUAL(thrust::inner_product(thrust::device, begin, end, begin, 0ll, ::cuda::std::plus<long long>(), fn),
                (1ll << magnitude));
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -71,7 +71,7 @@ void TestIsPartitionedDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::is_partitioned(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/is_sorted.cu
+++ b/thrust/testing/is_sorted.cu
@@ -73,7 +73,7 @@ void TestIsSortedDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::is_sorted(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/is_sorted_until.cu
+++ b/thrust/testing/is_sorted_until.cu
@@ -96,7 +96,7 @@ void TestIsSortedUntilExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::is_sorted_until(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/logical.cu
+++ b/thrust/testing/logical.cu
@@ -35,7 +35,7 @@ void TestAllOfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::all_of(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -90,7 +90,7 @@ void TestAnyOfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::any_of(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -145,7 +145,7 @@ void TestNoneOfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::none_of(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/max_element.cu
+++ b/thrust/testing/max_element.cu
@@ -45,14 +45,14 @@ void TestMaxElement(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  typename thrust::host_vector<T>::iterator h_max   = thrust::max_element(h_data.begin(), h_data.end());
-  typename thrust::device_vector<T>::iterator d_max = thrust::max_element(d_data.begin(), d_data.end());
+  const typename thrust::host_vector<T>::iterator h_max   = thrust::max_element(h_data.begin(), h_data.end());
+  const typename thrust::device_vector<T>::iterator d_max = thrust::max_element(d_data.begin(), d_data.end());
 
   ASSERT_EQUAL(h_max - h_data.begin(), d_max - d_data.begin());
 
-  typename thrust::host_vector<T>::iterator h_min =
+  const typename thrust::host_vector<T>::iterator h_min =
     thrust::max_element(h_data.begin(), h_data.end(), ::cuda::std::greater<T>());
-  typename thrust::device_vector<T>::iterator d_min =
+  const typename thrust::device_vector<T>::iterator d_min =
     thrust::max_element(d_data.begin(), d_data.end(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL(h_min - h_data.begin(), d_min - d_data.begin());
@@ -70,7 +70,7 @@ void TestMaxElementDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::max_element(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -96,8 +96,8 @@ DECLARE_UNITTEST(TestMaxElementDispatchImplicit);
 
 void TestMaxElementWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
   ASSERT_EQUAL(*thrust::max_element(thrust::device, begin, end), (1ll << magnitude));

--- a/thrust/testing/memory.cu
+++ b/thrust/testing/memory.cu
@@ -145,15 +145,15 @@ void TestSelectSystemSameTypes()
   thrust::host_system_tag host_sys;
 
   // select_system(host_system_tag, host_system_tag) should return host_system_tag
-  bool is_host_system_tag = are_same(host_sys, select_system(host_sys, host_sys));
+  const bool is_host_system_tag = are_same(host_sys, select_system(host_sys, host_sys));
   ASSERT_EQUAL(true, is_host_system_tag);
 
   // select_system(device_system_tag, device_system_tag) should return device_system_tag
-  bool is_device_system_tag = are_same(device_sys, select_system(device_sys, device_sys));
+  const bool is_device_system_tag = are_same(device_sys, select_system(device_sys, device_sys));
   ASSERT_EQUAL(true, is_device_system_tag);
 
   // select_system(my_system, my_system) should return my_system
-  bool is_my_system = are_same(my_sys, select_system(my_sys, my_sys));
+  const bool is_my_system = are_same(my_sys, select_system(my_sys, my_sys));
   ASSERT_EQUAL(true, is_my_system);
 }
 DECLARE_UNITTEST(TestSelectSystemSameTypes);
@@ -162,14 +162,14 @@ void TestGetTemporaryBuffer()
 {
   const std::ptrdiff_t n = 9001;
 
-  thrust::device_system_tag dev_tag;
-  using pointer                                       = thrust::pointer<int, thrust::device_system_tag>;
-  cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(dev_tag, n);
+  const thrust::device_system_tag dev_tag;
+  using pointer                                             = thrust::pointer<int, thrust::device_system_tag>;
+  const cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(dev_tag, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
 
   const int ref_val = 13;
-  thrust::device_vector<int> ref(n, ref_val);
+  const thrust::device_vector<int> ref(n, ref_val);
 
   thrust::fill_n(ptr_and_sz.first, n, ref_val);
 
@@ -183,12 +183,12 @@ void TestMalloc()
 {
   const std::ptrdiff_t n = 9001;
 
-  thrust::device_system_tag dev_tag;
-  using pointer = thrust::pointer<int, thrust::device_system_tag>;
-  pointer ptr   = pointer(static_cast<int*>(thrust::malloc(dev_tag, sizeof(int) * n).get()));
+  const thrust::device_system_tag dev_tag;
+  using pointer     = thrust::pointer<int, thrust::device_system_tag>;
+  const pointer ptr = pointer(static_cast<int*>(thrust::malloc(dev_tag, sizeof(int) * n).get()));
 
   const int ref_val = 13;
-  thrust::device_vector<int> ref(n, ref_val);
+  const thrust::device_vector<int> ref(n, ref_val);
 
   thrust::fill_n(ptr, n, ref_val);
 
@@ -224,7 +224,7 @@ void free(my_memory_system& system, Pointer)
 
 void TestFreeDispatchExplicit()
 {
-  thrust::pointer<my_memory_system, void> ptr{};
+  const thrust::pointer<my_memory_system, void> ptr{};
 
   my_memory_system sys(0);
   thrust::free(sys, ptr);
@@ -239,8 +239,8 @@ get_temporary_buffer(my_memory_system& system, std::ptrdiff_t n)
 {
   system.validate_dispatch();
 
-  thrust::device_system_tag device_sys;
-  cuda::std::pair<thrust::pointer<T, thrust::device_system_tag>, std::ptrdiff_t> result =
+  const thrust::device_system_tag device_sys;
+  const cuda::std::pair<thrust::pointer<T, thrust::device_system_tag>, std::ptrdiff_t> result =
     thrust::get_temporary_buffer<T>(device_sys, n);
   return cuda::std::make_pair(thrust::pointer<T, my_memory_system>(result.first.get()), result.second);
 }
@@ -250,14 +250,14 @@ void TestGetTemporaryBufferDispatchExplicit()
   const std::ptrdiff_t n = 9001;
 
   my_memory_system sys(0);
-  using pointer                                       = thrust::pointer<int, thrust::device_system_tag>;
-  cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(sys, n);
+  using pointer                                             = thrust::pointer<int, thrust::device_system_tag>;
+  const cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(sys, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
   ASSERT_EQUAL(true, sys.is_valid());
 
   const int ref_val = 13;
-  thrust::device_vector<int> ref(n, ref_val);
+  const thrust::device_vector<int> ref(n, ref_val);
 
   thrust::fill_n(ptr_and_sz.first, n, ref_val);
 
@@ -300,10 +300,10 @@ void TestTemporaryBufferOldCustomization()
   using pointer          = thrust::pointer<int, system>;
   using pointer_and_size = cuda::std::pair<pointer, std::ptrdiff_t>;
 
-  system sys;
+  const system sys;
 
   {
-    pointer_and_size ps = thrust::get_temporary_buffer<int>(sys, 0);
+    const pointer_and_size ps = thrust::get_temporary_buffer<int>(sys, 0);
 
     // The magic values are defined in `my_old_namespace` above.
     ASSERT_EQUAL(ps.first.get(), reinterpret_cast<int*>(4217));
@@ -320,10 +320,10 @@ void TestTemporaryBufferNewCustomization()
   using pointer          = thrust::pointer<int, system>;
   using pointer_and_size = cuda::std::pair<pointer, std::ptrdiff_t>;
 
-  system sys;
+  const system sys;
 
   {
-    pointer_and_size ps = thrust::get_temporary_buffer<int>(sys, 0);
+    const pointer_and_size ps = thrust::get_temporary_buffer<int>(sys, 0);
 
     // The magic values are defined in `my_new_namespace` above.
     ASSERT_EQUAL(ps.first.get(), reinterpret_cast<int*>(1742));

--- a/thrust/testing/merge.cu
+++ b/thrust/testing/merge.cu
@@ -34,7 +34,7 @@ void TestMergeDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::merge(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -111,7 +111,7 @@ void TestMergeToDiscardIterator(size_t n)
   const auto h_result = thrust::merge(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), thrust::make_discard_iterator());
   const auto d_result = thrust::merge(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(2 * n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/merge_by_key.cu
+++ b/thrust/testing/merge_by_key.cu
@@ -60,7 +60,7 @@ void TestMergeByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::merge_by_key(
     sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 

--- a/thrust/testing/min_and_max.cu
+++ b/thrust/testing/min_and_max.cu
@@ -19,8 +19,8 @@ struct TestMin
     ASSERT_EQUAL(three, ::cuda::std::min(three, two, ::cuda::std::greater<T>()));
 
     using KV = key_value<T, T>;
-    KV two_and_two(two, two);
-    KV two_and_three(two, three);
+    const KV two_and_two(two, two);
+    const KV two_and_three(two, three);
 
     // the first element breaks ties
     ASSERT_EQUAL_QUIET(two_and_two, ::cuda::std::min(two_and_two, two_and_three));
@@ -52,8 +52,8 @@ struct TestMax
     ASSERT_EQUAL(two, ::cuda::std::max(three, two, ::cuda::std::greater<T>()));
 
     using KV = key_value<T, T>;
-    KV two_and_two(two, two);
-    KV two_and_three(two, three);
+    const KV two_and_two(two, two);
+    const KV two_and_three(two, three);
 
     // the first element breaks ties
     ASSERT_EQUAL_QUIET(two_and_two, ::cuda::std::max(two_and_two, two_and_three));

--- a/thrust/testing/min_element.cu
+++ b/thrust/testing/min_element.cu
@@ -43,14 +43,14 @@ void TestMinElement(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  typename thrust::host_vector<T>::iterator h_min   = thrust::min_element(h_data.begin(), h_data.end());
-  typename thrust::device_vector<T>::iterator d_min = thrust::min_element(d_data.begin(), d_data.end());
+  const typename thrust::host_vector<T>::iterator h_min   = thrust::min_element(h_data.begin(), h_data.end());
+  const typename thrust::device_vector<T>::iterator d_min = thrust::min_element(d_data.begin(), d_data.end());
 
   ASSERT_EQUAL(h_min - h_data.begin(), d_min - d_data.begin());
 
-  typename thrust::host_vector<T>::iterator h_max =
+  const typename thrust::host_vector<T>::iterator h_max =
     thrust::min_element(h_data.begin(), h_data.end(), ::cuda::std::greater<T>());
-  typename thrust::device_vector<T>::iterator d_max =
+  const typename thrust::device_vector<T>::iterator d_max =
     thrust::min_element(d_data.begin(), d_data.end(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL(h_max - h_data.begin(), d_max - d_data.begin());
@@ -68,7 +68,7 @@ void TestMinElementDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::min_element(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -94,8 +94,8 @@ DECLARE_UNITTEST(TestMinElementDispatchImplicit);
 
 void TestMinElementWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(1);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(1);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
   ASSERT_EQUAL(*thrust::min_element(thrust::device, begin, end, ::cuda::std::greater<long long>()), (1ll << magnitude));

--- a/thrust/testing/minmax_element.cu
+++ b/thrust/testing/minmax_element.cu
@@ -76,7 +76,7 @@ void TestMinMaxElementDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::minmax_element(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -103,8 +103,8 @@ DECLARE_UNITTEST(TestMinMaxElementDispatchImplicit);
 void TestMinMaxElementWithBigIndexesHelper(int magnitude)
 {
   using Iter = thrust::counting_iterator<long long>;
-  Iter begin(1);
-  Iter end = begin + (1ll << magnitude);
+  const Iter begin(1);
+  const Iter end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
   cuda::std::pair<Iter, Iter> result = thrust::minmax_element(thrust::device, begin, end);

--- a/thrust/testing/mismatch.cu
+++ b/thrust/testing/mismatch.cu
@@ -122,7 +122,7 @@ void TestMismatchDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::mismatch(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/mr_disjoint_pool.cu
+++ b/thrust/testing/mr_disjoint_pool.cu
@@ -140,16 +140,16 @@ void TestDisjointPool()
   upstream.id_to_allocate = 1;
 
   // first allocation
-  alloc_id a1 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
+  const alloc_id a1 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a1.id, 1u);
 
   // due to chunking, the above allocation should be enough for the next one too
-  alloc_id a2 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
+  const alloc_id a2 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a2.id, 1u);
 
   // deallocating and allocating back should give the same resource back
   pool->do_deallocate(a1, 12, THRUST_MR_DEFAULT_ALIGNMENT);
-  alloc_id a3 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
+  const alloc_id a3 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a1.id, a3.id);
   ASSERT_EQUAL(a1.size, a3.size);
   ASSERT_EQUAL(a1.alignment, a3.alignment);
@@ -157,7 +157,7 @@ void TestDisjointPool()
 
   // allocating over-aligned memory should give non-cached results
   upstream.id_to_allocate = 2;
-  alloc_id a4             = pool->do_allocate(32, THRUST_MR_DEFAULT_ALIGNMENT * 2);
+  const alloc_id a4       = pool->do_allocate(32, THRUST_MR_DEFAULT_ALIGNMENT * 2);
   ASSERT_EQUAL(a4.id, 2u);
   ASSERT_EQUAL(a4.size, 32u);
   ASSERT_EQUAL(a4.alignment, (std::size_t) THRUST_MR_DEFAULT_ALIGNMENT * 2);
@@ -174,7 +174,7 @@ void TestDisjointPool()
 
   // and does the same for oversized/overaligned memory
   upstream.id_to_allocate = 3;
-  alloc_id a5             = pool->do_allocate(1024, THRUST_MR_DEFAULT_ALIGNMENT * 2);
+  const alloc_id a5       = pool->do_allocate(1024, THRUST_MR_DEFAULT_ALIGNMENT * 2);
   ASSERT_EQUAL(upstream.id_to_allocate, 0u);
   ASSERT_EQUAL(a5.id, 3u);
 
@@ -185,7 +185,7 @@ void TestDisjointPool()
   // and after that, the formerly cached memory isn't used anymore,
   // so new memory from upstream is returned back
   upstream.id_to_allocate = 4;
-  alloc_id a6             = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
+  const alloc_id a6       = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(upstream.id_to_allocate, 0u);
   ASSERT_EQUAL(a6.id, 4u);
 
@@ -225,21 +225,21 @@ void TestDisjointPoolCachingOversized()
   Pool pool(&upstream, &bookkeeper, opts);
 
   upstream.id_to_allocate = 1;
-  alloc_id a1             = pool.do_allocate(2048, 32);
+  const alloc_id a1       = pool.do_allocate(2048, 32);
   ASSERT_EQUAL(a1.id, 1u);
 
   upstream.id_to_allocate = 2;
-  alloc_id a2             = pool.do_allocate(64, 32);
+  const alloc_id a2       = pool.do_allocate(64, 32);
   ASSERT_EQUAL(a2.id, 2u);
 
   pool.do_deallocate(a2, 64, 32);
   pool.do_deallocate(a1, 2048, 32);
 
   // make sure a good fit is used from the cache
-  alloc_id a3 = pool.do_allocate(32, 32);
+  const alloc_id a3 = pool.do_allocate(32, 32);
   ASSERT_EQUAL(a3.id, 2u);
 
-  alloc_id a4 = pool.do_allocate(1024, 32);
+  const alloc_id a4 = pool.do_allocate(1024, 32);
   ASSERT_EQUAL(a4.id, 1u);
 
   pool.do_deallocate(a4, 1024, 32);
@@ -247,18 +247,18 @@ void TestDisjointPoolCachingOversized()
   // make sure that a new block is allocated when there's nothing cached with
   // the required alignment
   upstream.id_to_allocate = 3;
-  alloc_id a5             = pool.do_allocate(32, 64);
+  const alloc_id a5       = pool.do_allocate(32, 64);
   ASSERT_EQUAL(a5.id, 3u);
 
   pool.release();
 
   // make sure that release actually clears caches
   upstream.id_to_allocate = 4;
-  alloc_id a6             = pool.do_allocate(32, 64);
+  const alloc_id a6       = pool.do_allocate(32, 64);
   ASSERT_EQUAL(a6.id, 4u);
 
   upstream.id_to_allocate = 5;
-  alloc_id a7             = pool.do_allocate(2048, 1024);
+  const alloc_id a7       = pool.do_allocate(2048, 1024);
   ASSERT_EQUAL(a7.id, 5u);
 
   pool.do_deallocate(a7, 2048, 1024);
@@ -266,13 +266,13 @@ void TestDisjointPoolCachingOversized()
   // make sure that the 'ridiculousness' factor for size (options.cached_size_cutoff_factor)
   // is respected
   upstream.id_to_allocate = 6;
-  alloc_id a8             = pool.do_allocate(24, 1024);
+  const alloc_id a8       = pool.do_allocate(24, 1024);
   ASSERT_EQUAL(a8.id, 6u);
 
   // make sure that the 'ridiculousness' factor for alignment (options.cached_alignment_cutoff_factor)
   // is respected
   upstream.id_to_allocate = 7;
-  alloc_id a9             = pool.do_allocate(2048, 32);
+  const alloc_id a9       = pool.do_allocate(2048, 32);
   ASSERT_EQUAL(a9.id, 7u);
 }
 
@@ -343,23 +343,23 @@ void TestDisjointPoolSqueeze()
   {
     // Allocate several blocks from different pools + oversized:
     upstream.id_to_allocate = 1u;
-    alloc_id a1             = pool->do_allocate(small_block);
+    const alloc_id a1       = pool->do_allocate(small_block);
     ASSERT_EQUAL(a1.id, 1u);
     ASSERT_EQUAL(upstream.id_to_allocate, 0u);
 
     upstream.id_to_allocate = 2u;
-    alloc_id a2             = pool->do_allocate(large_block);
+    const alloc_id a2       = pool->do_allocate(large_block);
     ASSERT_EQUAL(a2.id, 2u);
     ASSERT_EQUAL(upstream.id_to_allocate, 0u);
 
     upstream.id_to_allocate = 3u;
-    alloc_id a3             = pool->do_allocate(oversized_block);
+    const alloc_id a3       = pool->do_allocate(oversized_block);
     ASSERT_EQUAL(a3.id, 3u);
     ASSERT_EQUAL(upstream.id_to_allocate, 0u);
 
     // Simulate OOM, ensure that the allocations are still in place:
-    std::size_t old_free_bytes = upstream.free_bytes;
-    upstream.free_bytes        = not_enough_bytes;
+    const std::size_t old_free_bytes = upstream.free_bytes;
+    upstream.free_bytes              = not_enough_bytes;
     ASSERT_THROWS([[maybe_unused]] auto _ = pool->do_allocate(medium_block), thrust::system::detail::bad_alloc);
     ASSERT_THROWS([[maybe_unused]] auto _ = pool->do_allocate(oversized_block), thrust::system::detail::bad_alloc);
     ASSERT_EQUAL(upstream.free_bytes, not_enough_bytes);
@@ -417,7 +417,7 @@ void TestDisjointPoolSqueeze()
     // in-use allocations exist:
     upstream.free_bytes     = not_enough_bytes;
     upstream.id_to_allocate = 4u;
-    alloc_id a4             = pool->do_allocate(extra_large_block);
+    const alloc_id a4       = pool->do_allocate(extra_large_block);
     ASSERT_EQUAL(a4.id, 4u);
     ASSERT_EQUAL(upstream.id_to_allocate, 0u);
     ASSERT_EQUAL(upstream.allocation_ids.size(), 4u);
@@ -478,7 +478,7 @@ void TestDisjointPoolSqueeze()
     // in-use allocation exist:
     upstream.free_bytes     = not_enough_bytes;
     upstream.id_to_allocate = 1u;
-    alloc_id a5             = pool->do_allocate(extra_large_block);
+    const alloc_id a5       = pool->do_allocate(extra_large_block);
     ASSERT_EQUAL(a5.id, 1u);
     ASSERT_EQUAL(upstream.id_to_allocate, 0u);
     ASSERT_EQUAL(upstream.allocation_ids.size(), 1u);

--- a/thrust/testing/mr_pool.cu
+++ b/thrust/testing/mr_pool.cu
@@ -167,16 +167,16 @@ void TestPool()
   upstream.id_to_allocate = 1;
 
   // first allocation
-  tracked_pointer<void> a1 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
+  const tracked_pointer<void> a1 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a1.id, 1u);
 
   // due to chunking, the above allocation should be enough for the next one too
-  tracked_pointer<void> a2 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
+  const tracked_pointer<void> a2 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a2.id, 1u);
 
   // deallocating and allocating back should give the same resource back
   pool->do_deallocate(a1, 12, THRUST_MR_DEFAULT_ALIGNMENT);
-  tracked_pointer<void> a3 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
+  const tracked_pointer<void> a3 = pool->do_allocate(12, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a1.id, a3.id);
   ASSERT_EQUAL(a1.size, a3.size);
   ASSERT_EQUAL(a1.alignment, a3.alignment);
@@ -184,8 +184,8 @@ void TestPool()
 
   // allocating over-aligned memory should give non-cached results
   // unlike with the disjoint version, nothing sensible can be said about the chunk size
-  upstream.id_to_allocate  = 2;
-  tracked_pointer<void> a4 = pool->do_allocate(32, THRUST_MR_DEFAULT_ALIGNMENT * 2);
+  upstream.id_to_allocate        = 2;
+  const tracked_pointer<void> a4 = pool->do_allocate(32, THRUST_MR_DEFAULT_ALIGNMENT * 2);
   ASSERT_EQUAL(a4.id, 2u);
   ASSERT_EQUAL(a4.alignment, (std::size_t) THRUST_MR_DEFAULT_ALIGNMENT * 2);
 
@@ -200,8 +200,8 @@ void TestPool()
   ASSERT_EQUAL(upstream.id_to_deallocate, 0u);
 
   // and does the same for oversized/overaligned memory
-  upstream.id_to_allocate  = 3;
-  tracked_pointer<void> a5 = pool->do_allocate(1024, THRUST_MR_DEFAULT_ALIGNMENT * 2);
+  upstream.id_to_allocate        = 3;
+  const tracked_pointer<void> a5 = pool->do_allocate(1024, THRUST_MR_DEFAULT_ALIGNMENT * 2);
   ASSERT_EQUAL(upstream.id_to_allocate, 0u);
   ASSERT_EQUAL(a5.id, 3u);
 
@@ -211,8 +211,8 @@ void TestPool()
 
   // and after that, the formerly cached memory isn't used anymore,
   // so new memory from upstream is returned back
-  upstream.id_to_allocate  = 4;
-  tracked_pointer<void> a6 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
+  upstream.id_to_allocate        = 4;
+  const tracked_pointer<void> a6 = pool->do_allocate(16, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(upstream.id_to_allocate, 0u);
   ASSERT_EQUAL(a6.id, 4u);
 
@@ -252,63 +252,63 @@ void TestPoolCachingOversized()
 
   Pool pool(&upstream, opts);
 
-  upstream.id_to_allocate  = 1;
-  tracked_pointer<void> a1 = pool.do_allocate(2048, 32);
+  upstream.id_to_allocate        = 1;
+  const tracked_pointer<void> a1 = pool.do_allocate(2048, 32);
   ASSERT_EQUAL(a1.id, 1u);
 
-  upstream.id_to_allocate  = 2;
-  tracked_pointer<void> a2 = pool.do_allocate(64, 32);
+  upstream.id_to_allocate        = 2;
+  const tracked_pointer<void> a2 = pool.do_allocate(64, 32);
   ASSERT_EQUAL(a2.id, 2u);
 
   pool.do_deallocate(a2, 64, 32);
   pool.do_deallocate(a1, 2048, 32);
 
   // make sure a good fit is used from the cache
-  tracked_pointer<void> a3 = pool.do_allocate(32, 32);
+  const tracked_pointer<void> a3 = pool.do_allocate(32, 32);
   ASSERT_EQUAL(a3.id, 2u);
 
-  tracked_pointer<void> a4 = pool.do_allocate(1024, 32);
+  const tracked_pointer<void> a4 = pool.do_allocate(1024, 32);
   ASSERT_EQUAL(a4.id, 1u);
 
   pool.do_deallocate(a4, 1024, 32);
 
   // make sure that a new block is allocated when there's nothing cached with
   // the required alignment
-  upstream.id_to_allocate  = 3;
-  tracked_pointer<void> a5 = pool.do_allocate(32, 64);
+  upstream.id_to_allocate        = 3;
+  const tracked_pointer<void> a5 = pool.do_allocate(32, 64);
   ASSERT_EQUAL(a5.id, 3u);
 
   pool.release();
 
   // make sure that release actually clears caches
-  upstream.id_to_allocate  = 4;
-  tracked_pointer<void> a6 = pool.do_allocate(32, 64);
+  upstream.id_to_allocate        = 4;
+  const tracked_pointer<void> a6 = pool.do_allocate(32, 64);
   ASSERT_EQUAL(a6.id, 4u);
 
-  upstream.id_to_allocate  = 5;
-  tracked_pointer<void> a7 = pool.do_allocate(2048, 1024);
+  upstream.id_to_allocate        = 5;
+  const tracked_pointer<void> a7 = pool.do_allocate(2048, 1024);
   ASSERT_EQUAL(a7.id, 5u);
 
   pool.do_deallocate(a7, 2048, 1024);
 
   // make sure that the 'ridiculousness' factor for size (options.cached_size_cutoff_factor)
   // is respected
-  upstream.id_to_allocate  = 6;
-  tracked_pointer<void> a8 = pool.do_allocate(24, 1024);
+  upstream.id_to_allocate        = 6;
+  const tracked_pointer<void> a8 = pool.do_allocate(24, 1024);
   ASSERT_EQUAL(a8.id, 6u);
 
   // make sure that the 'ridiculousness' factor for alignment (options.cached_alignment_cutoff_factor)
   // is respected
-  upstream.id_to_allocate  = 7;
-  tracked_pointer<void> a9 = pool.do_allocate(2048, 32);
+  upstream.id_to_allocate        = 7;
+  const tracked_pointer<void> a9 = pool.do_allocate(2048, 32);
   ASSERT_EQUAL(a9.id, 7u);
 
   // make sure that reusing a larger oversized block for a smaller allocation works
   // this is NVIDIA/cccl#585
-  upstream.id_to_allocate   = 8;
-  tracked_pointer<void> a10 = pool.do_allocate(2048 + 16, THRUST_MR_DEFAULT_ALIGNMENT);
+  upstream.id_to_allocate         = 8;
+  const tracked_pointer<void> a10 = pool.do_allocate(2048 + 16, THRUST_MR_DEFAULT_ALIGNMENT);
   pool.do_deallocate(a10, 2048 + 16, THRUST_MR_DEFAULT_ALIGNMENT);
-  tracked_pointer<void> a11 = pool.do_allocate(2048, THRUST_MR_DEFAULT_ALIGNMENT);
+  const tracked_pointer<void> a11 = pool.do_allocate(2048, THRUST_MR_DEFAULT_ALIGNMENT);
   ASSERT_EQUAL(a11.ptr, a10.ptr);
   pool.do_deallocate(a11, 2048, THRUST_MR_DEFAULT_ALIGNMENT);
 

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -66,11 +66,11 @@ void TestOffsetIteratorCopyConstructorAndAssignment()
 
   // value offset
   {
-    thrust::offset_iterator iter0(v.begin());
+    const thrust::offset_iterator iter0(v.begin());
 #if _CCCL_COMPILER(MSVC) // MSVC cannot deduce the template arguments from the copy ctor
     decltype(iter0) iter1(iter0);
 #else // _CCCL_COMPILER(MSVC)
-    thrust::offset_iterator iter1(iter0);
+    const thrust::offset_iterator iter1(iter0);
 #endif // _CCCL_COMPILER(MSVC)
     ASSERT_EQUAL(iter0 == iter1, true);
     ASSERT_EQUAL(*iter0 == *iter1, true);
@@ -87,12 +87,12 @@ void TestOffsetIteratorCopyConstructorAndAssignment()
   // indirect offset
   {
     const typename Vector::iterator::difference_type offset = 0;
-    thrust::offset_iterator iter0(v.begin(), &offset);
+    const thrust::offset_iterator iter0(v.begin(), &offset);
 
 #if _CCCL_COMPILER(MSVC) // MSVC cannot deduce the template arguments from the copy ctor
     decltype(iter0) iter1(iter0);
 #else // _CCCL_COMPILER(MSVC)
-    thrust::offset_iterator iter1(iter0);
+    const thrust::offset_iterator iter1(iter0);
 #endif // _CCCL_COMPILER(MSVC)
     ASSERT_EQUAL(iter0 == iter1, true);
     ASSERT_EQUAL(*iter0 == *iter1, true);
@@ -200,7 +200,7 @@ void TestOffsetIteratorLateValue()
 {
   typename Vector::difference_type offset;
   Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::offset_iterator iter(v.begin(), &offset);
+  const thrust::offset_iterator iter(v.begin(), &offset);
   offset = 2; // we provide the offset value **after** constructing the iterator
   ASSERT_EQUAL(*iter, 2);
 }
@@ -214,7 +214,7 @@ void TestOffsetIteratorIndirectValueFancyIterator()
   Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
   thrust::device_vector<typename Vector::difference_type> offsets{2};
   auto it = thrust::make_transform_iterator(offsets.begin(), _1 * 3);
-  thrust::offset_iterator iter(v.begin(), it);
+  const thrust::offset_iterator iter(v.begin(), it);
   ASSERT_EQUAL(*iter, 6);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValueFancyIterator);

--- a/thrust/testing/out_of_memory_recovery.cu
+++ b/thrust/testing/out_of_memory_recovery.cu
@@ -26,9 +26,9 @@ void test_out_of_memory_recovery()
 {
   try
   {
-    thrust::device_vector<non_trivial> x(1);
+    const thrust::device_vector<non_trivial> x(1);
 
-    thrust::device_vector<std::uint32_t> y(0x00ffffffffffffff);
+    const thrust::device_vector<std::uint32_t> y(0x00ffffffffffffff);
   }
   catch (...)
   {

--- a/thrust/testing/pair.cu
+++ b/thrust/testing/pair.cu
@@ -33,7 +33,7 @@ struct TestPairManipulation
     ASSERT_EQUAL(p1.second, sp.second);
 
     // test initialization
-    P p3 = p2; // NOLINT(performance-unnecessary-copy-initialization)
+    const P p3 = p2; // NOLINT(performance-unnecessary-copy-initialization)
     ASSERT_EQUAL(p2.first, p3.first);
     ASSERT_EQUAL(p2.second, p3.second);
 
@@ -277,11 +277,11 @@ DECLARE_UNITTEST(TestPairTupleElement);
 
 void TestPairSwap()
 {
-  int x = 7;
-  int y = 13;
+  const int x = 7;
+  const int y = 13;
 
-  int z = 42;
-  int w = 0;
+  const int z = 42;
+  const int w = 0;
 
   thrust::pair<int, int> a(x, y);
   thrust::pair<int, int> b(z, w);
@@ -302,7 +302,7 @@ void TestPairSwap()
   thrust::swap_ranges(h_v1.begin(), h_v1.end(), h_v2.begin());
   thrust::swap_ranges(d_v1.begin(), d_v1.end(), d_v2.begin());
 
-  swappable_pair ref(user_swappable(true), user_swappable(true));
+  const swappable_pair ref(user_swappable(true), user_swappable(true));
 
   ASSERT_EQUAL_QUIET(ref, h_v1[0]);
   ASSERT_EQUAL_QUIET(ref, h_v1[0]);

--- a/thrust/testing/pair_reduce.cu
+++ b/thrust/testing/pair_reduce.cu
@@ -40,17 +40,17 @@ struct TestPairReduce
     // zip up pairs on the host
     thrust::transform(h_p1.begin(), h_p1.end(), h_p2.begin(), h_pairs.begin(), make_pair_functor());
 
-    thrust::device_vector<T> d_p1    = h_p1;
-    thrust::device_vector<T> d_p2    = h_p2;
-    thrust::device_vector<P> d_pairs = h_pairs;
+    const thrust::device_vector<T> d_p1 = h_p1;
+    const thrust::device_vector<T> d_p2 = h_p2;
+    thrust::device_vector<P> d_pairs    = h_pairs;
 
     P init = cuda::std::make_pair(T{13}, T{13});
 
     // reduce on the host
-    P h_result = thrust::reduce(h_pairs.begin(), h_pairs.end(), init, add_pairs());
+    const P h_result = thrust::reduce(h_pairs.begin(), h_pairs.end(), init, add_pairs());
 
     // reduce on the device
-    P d_result = thrust::reduce(d_pairs.begin(), d_pairs.end(), init, add_pairs());
+    const P d_result = thrust::reduce(d_pairs.begin(), d_pairs.end(), init, add_pairs());
 
     ASSERT_EQUAL_QUIET(h_result, d_result);
   }

--- a/thrust/testing/pair_scan.cu
+++ b/thrust/testing/pair_scan.cu
@@ -42,9 +42,9 @@ struct TestPairScan
     // zip up pairs on the host
     thrust::transform(h_p1.begin(), h_p1.end(), h_p2.begin(), h_pairs.begin(), make_pair_functor());
 
-    thrust::device_vector<T> d_p1    = h_p1;
-    thrust::device_vector<T> d_p2    = h_p2;
-    thrust::device_vector<P> d_pairs = h_pairs;
+    const thrust::device_vector<T> d_p1 = h_p1;
+    const thrust::device_vector<T> d_p2 = h_p2;
+    thrust::device_vector<P> d_pairs    = h_pairs;
     thrust::device_vector<P> d_output(n);
 
     P init = cuda::std::make_pair(13, 13);

--- a/thrust/testing/pair_scan_by_key.cu
+++ b/thrust/testing/pair_scan_by_key.cu
@@ -40,9 +40,9 @@ struct TestPairScanByKey
     // zip up pairs on the host
     thrust::transform(h_p1.begin(), h_p1.end(), h_p2.begin(), h_pairs.begin(), make_pair_functor());
 
-    thrust::device_vector<T> d_p1    = h_p1;
-    thrust::device_vector<T> d_p2    = h_p2;
-    thrust::device_vector<P> d_pairs = h_pairs;
+    const thrust::device_vector<T> d_p1 = h_p1;
+    const thrust::device_vector<T> d_p2 = h_p2;
+    thrust::device_vector<P> d_pairs    = h_pairs;
 
     thrust::host_vector<T> h_keys   = unittest::random_integers<bool>(n);
     thrust::device_vector<T> d_keys = h_keys;

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -41,7 +41,7 @@ void TestPartitionSimple()
 
   Vector data{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), is_even<T>());
+  const Iterator iter = thrust::partition(data.begin(), data.end(), is_even<T>());
 
   Vector ref{2, 2, 1, 1, 1};
 
@@ -60,7 +60,7 @@ void TestPartitionStencilSimple()
 
   Vector stencil{1, 2, 1, 1, 2};
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), is_even<T>());
+  const Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), is_even<T>());
 
   Vector ref{1, 1, 0, 0, 0};
 
@@ -79,7 +79,7 @@ void TestPartitionCopySimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
+  const cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 2);
@@ -105,7 +105,7 @@ void TestPartitionCopyStencilSimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
+  const cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 1);
@@ -127,7 +127,7 @@ void TestStablePartitionSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  Iterator iter = thrust::stable_partition(data.begin(), data.end(), is_even<T>());
+  const Iterator iter = thrust::stable_partition(data.begin(), data.end(), is_even<T>());
 
   Vector ref{2, 2, 1, 1, 3};
 
@@ -145,7 +145,7 @@ void TestStablePartitionStencilSimple()
 
   Vector stencil{0, 1, 0, 0, 1};
 
-  Iterator iter = thrust::stable_partition(data.begin(), data.end(), stencil.begin(), ::cuda::std::identity{});
+  const Iterator iter = thrust::stable_partition(data.begin(), data.end(), stencil.begin(), ::cuda::std::identity{});
 
   Vector ref{2, 2, 1, 1, 3};
 
@@ -164,7 +164,7 @@ void TestStablePartitionCopySimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
+  const cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 2);
@@ -187,7 +187,7 @@ void TestStablePartitionCopyStencilSimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
+  const cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), ::cuda::std::identity{});
 
   Vector true_ref(2, 2);
@@ -210,8 +210,10 @@ struct TestPartition
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    typename thrust::host_vector<T>::iterator h_iter   = thrust::partition(h_data.begin(), h_data.end(), is_even<T>());
-    typename thrust::device_vector<T>::iterator d_iter = thrust::partition(d_data.begin(), d_data.end(), is_even<T>());
+    const typename thrust::host_vector<T>::iterator h_iter =
+      thrust::partition(h_data.begin(), h_data.end(), is_even<T>());
+    const typename thrust::device_vector<T>::iterator d_iter =
+      thrust::partition(d_data.begin(), d_data.end(), is_even<T>());
 
     thrust::sort(h_data.begin(), h_iter);
     thrust::sort(h_iter, h_data.end());
@@ -246,9 +248,9 @@ struct TestPartitionStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    typename thrust::host_vector<T>::iterator h_iter =
+    const typename thrust::host_vector<T>::iterator h_iter =
       thrust::partition(h_data.begin(), h_data.end(), h_stencil.begin(), is_even<T>());
-    typename thrust::device_vector<T>::iterator d_iter =
+    const typename thrust::device_vector<T>::iterator d_iter =
       thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), is_even<T>());
 
     thrust::sort(h_data.begin(), h_iter);
@@ -271,8 +273,8 @@ struct TestPartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
     thrust::host_vector<T> h_true_results(n_true, 0);
@@ -280,12 +282,12 @@ struct TestPartitionCopy
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
-      thrust::partition_copy(
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>
+      d_ends = thrust::partition_copy(
         d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
     // check true output
@@ -316,8 +318,8 @@ struct TestPartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
     thrust::host_vector<T> h_true_results(n_true, 0);
@@ -325,12 +327,12 @@ struct TestPartitionCopyStencil
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
-      thrust::partition_copy(
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>
+      d_ends = thrust::partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
     // check true output
@@ -361,8 +363,8 @@ struct TestStablePartitionCopyStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
     thrust::host_vector<T> h_true_results(n_true, 0);
@@ -370,12 +372,12 @@ struct TestStablePartitionCopyStencil
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
-      thrust::stable_partition_copy(
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>
+      d_ends = thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
     // check true output
@@ -404,17 +406,17 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
       h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
@@ -424,18 +426,18 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
       cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
@@ -446,18 +448,18 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
@@ -478,11 +480,11 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
       h_data.begin(),
       h_data.end(),
       h_stencil.begin(),
@@ -490,7 +492,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(),
       d_data.end(),
       d_stencil.begin(),
@@ -498,7 +500,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
@@ -508,18 +510,18 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
       cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
@@ -530,7 +532,7 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
         h_data.begin(),
         h_data.end(),
@@ -539,7 +541,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         h_falses.begin(),
         is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
         d_data.begin(),
         d_data.end(),
@@ -548,10 +550,10 @@ struct TestPartitionCopyStencilToDiscardIterator
         d_falses.begin(),
         is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
@@ -573,9 +575,9 @@ struct TestStablePartition
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    typename thrust::host_vector<T>::iterator h_iter =
+    const typename thrust::host_vector<T>::iterator h_iter =
       thrust::stable_partition(h_data.begin(), h_data.end(), is_even<T>());
-    typename thrust::device_vector<T>::iterator d_iter =
+    const typename thrust::device_vector<T>::iterator d_iter =
       thrust::stable_partition(d_data.begin(), d_data.end(), is_even<T>());
 
     ASSERT_EQUAL(h_data, d_data);
@@ -600,9 +602,9 @@ struct TestStablePartitionStencil
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    typename thrust::host_vector<T>::iterator h_iter =
+    const typename thrust::host_vector<T>::iterator h_iter =
       thrust::stable_partition(h_data.begin(), h_data.end(), h_stencil.begin(), is_even<T>());
-    typename thrust::device_vector<T>::iterator d_iter =
+    const typename thrust::device_vector<T>::iterator d_iter =
       thrust::stable_partition(d_data.begin(), d_data.end(), d_stencil.begin(), is_even<T>());
 
     ASSERT_EQUAL(h_data, d_data);
@@ -622,8 +624,8 @@ struct TestStablePartitionCopy
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // setup output ranges
     thrust::host_vector<T> h_true_results(n_true, 0);
@@ -631,12 +633,12 @@ struct TestStablePartitionCopy
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
-      thrust::stable_partition_copy(
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>
+      d_ends = thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
     // check true output
@@ -661,17 +663,19 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
-      h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 =
+      thrust::stable_partition_copy(
+        h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
-      d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 =
+      thrust::stable_partition_copy(
+        d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
@@ -681,18 +685,18 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
       cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
@@ -703,18 +707,18 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
@@ -735,27 +739,29 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::device_vector<T> d_data    = h_data;
     thrust::device_vector<T> d_stencil = h_stencil;
 
-    std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
-    std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
+    const std::ptrdiff_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
+    const std::ptrdiff_t n_false = static_cast<std::ptrdiff_t>(n - n_true);
 
     // mask both ranges
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
-      h_data.begin(),
-      h_data.end(),
-      h_stencil.begin(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      is_even<T>());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 =
+      thrust::stable_partition_copy(
+        h_data.begin(),
+        h_data.end(),
+        h_stencil.begin(),
+        thrust::make_discard_iterator(),
+        thrust::make_discard_iterator(),
+        is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
-      d_data.begin(),
-      d_data.end(),
-      d_stencil.begin(),
-      thrust::make_discard_iterator(),
-      thrust::make_discard_iterator(),
-      is_even<T>());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 =
+      thrust::stable_partition_copy(
+        d_data.begin(),
+        d_data.end(),
+        d_stencil.begin(),
+        thrust::make_discard_iterator(),
+        thrust::make_discard_iterator(),
+        is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
@@ -765,18 +771,18 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+    const cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+    const cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
       cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
@@ -787,7 +793,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
         h_data.begin(),
         h_data.end(),
@@ -796,7 +802,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         h_falses.begin(),
         is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
         d_data.begin(),
         d_data.end(),
@@ -805,10 +811,10 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         d_falses.begin(),
         is_even<T>());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
@@ -837,10 +843,10 @@ void TestPartitionZipIterator()
   using IteratorTuple = cuda::std::tuple<Iterator, Iterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator begin = thrust::make_zip_iterator(data1.begin(), data2.begin());
-  ZipIterator end   = thrust::make_zip_iterator(data1.end(), data2.end());
+  const ZipIterator begin = thrust::make_zip_iterator(data1.begin(), data2.begin());
+  const ZipIterator end   = thrust::make_zip_iterator(data1.end(), data2.end());
 
-  ZipIterator iter = thrust::partition(begin, end, is_ordered());
+  const ZipIterator iter = thrust::partition(begin, end, is_ordered());
 
   Vector ref1{1, 1, 1, 2, 2};
   Vector ref2{2, 2, 2, 1, 1};
@@ -863,9 +869,9 @@ void TestPartitionStencilZipIterator()
   using IteratorTuple = cuda::std::tuple<Iterator, Iterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator stencil_begin = thrust::make_zip_iterator(stencil1.begin(), stencil2.begin());
+  const ZipIterator stencil_begin = thrust::make_zip_iterator(stencil1.begin(), stencil2.begin());
 
-  Iterator iter = thrust::partition(data.begin(), data.end(), stencil_begin, is_ordered());
+  const Iterator iter = thrust::partition(data.begin(), data.end(), stencil_begin, is_ordered());
 
   Vector ref{1, 1, 1, 0, 0};
 
@@ -884,10 +890,10 @@ void TestStablePartitionZipIterator()
   using IteratorTuple = cuda::std::tuple<Iterator, Iterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator begin = thrust::make_zip_iterator(data1.begin(), data2.begin());
-  ZipIterator end   = thrust::make_zip_iterator(data1.end(), data2.end());
+  const ZipIterator begin = thrust::make_zip_iterator(data1.begin(), data2.begin());
+  const ZipIterator end   = thrust::make_zip_iterator(data1.end(), data2.end());
 
-  ZipIterator iter = thrust::stable_partition(begin, end, is_ordered());
+  const ZipIterator iter = thrust::stable_partition(begin, end, is_ordered());
 
   Vector ref1{1, 1, 1, 2, 2};
   Vector ref2{2, 3, 2, 0, 1};
@@ -910,9 +916,9 @@ void TestStablePartitionStencilZipIterator()
   using IteratorTuple = cuda::std::tuple<Iterator, Iterator>;
   using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
-  ZipIterator stencil_begin = thrust::make_zip_iterator(stencil1.begin(), stencil2.begin());
+  const ZipIterator stencil_begin = thrust::make_zip_iterator(stencil1.begin(), stencil2.begin());
 
-  Iterator mid = thrust::stable_partition(data.begin(), data.end(), stencil_begin, is_ordered());
+  const Iterator mid = thrust::stable_partition(data.begin(), data.end(), stencil_begin, is_ordered());
 
   Vector ref{1, 1, 1, 0, 0};
 
@@ -932,7 +938,7 @@ void TestPartitionDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::partition(sys, vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -950,7 +956,7 @@ void TestPartitionStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::partition(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1004,7 +1010,7 @@ void TestPartitionCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::partition_copy(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1033,7 +1039,7 @@ void TestPartitionCopyStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::partition_copy(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1108,7 +1114,7 @@ void TestStablePartitionDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_partition(sys, vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1126,7 +1132,7 @@ void TestStablePartitionStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_partition(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1180,7 +1186,7 @@ void TestStablePartitionCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_partition_copy(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -1209,7 +1215,7 @@ void TestStablePartitionCopyStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_partition_copy(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -20,7 +20,7 @@ void TestPartitionPointSimple()
 
   Vector v{1, 1, 1, 0};
 
-  Iterator first = v.begin();
+  const Iterator first = v.begin();
 
   Iterator last = v.begin() + 4;
   Iterator ref  = first + 3;
@@ -42,7 +42,7 @@ void TestPartitionPoint()
 
   Vector v = unittest::random_integers<T>(n);
 
-  Iterator ref = thrust::stable_partition(v.begin(), v.end(), is_even<T>());
+  const Iterator ref = thrust::stable_partition(v.begin(), v.end(), is_even<T>());
 
   ASSERT_EQUAL(ref - v.begin(), thrust::partition_point(v.begin(), v.end(), is_even<T>()) - v.begin());
 }
@@ -59,7 +59,7 @@ void TestPartitionPointDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::partition_point(sys, vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -95,11 +95,11 @@ struct test_less_than
 
 void TestPartitionPointWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(0);
-  thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin(0);
+  const thrust::counting_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  test_less_than fn = {(1ll << magnitude) - 17};
+  const test_less_than fn = {(1ll << magnitude) - 17};
 
   ASSERT_EQUAL(::cuda::std::distance(begin, thrust::partition_point(thrust::device, begin, end, fn)),
                (1ll << magnitude) - 17);

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -93,7 +93,7 @@ void TestPermutationIteratorGather()
   // initialize input
   thrust::sequence(source.begin(), source.end(), 1);
 
-  thrust::permutation_iterator<Iterator, Iterator> p_source(source.begin(), indices.begin());
+  const thrust::permutation_iterator<Iterator, Iterator> p_source(source.begin(), indices.begin());
 
   thrust::copy(p_source, p_source + 4, output.begin());
 
@@ -115,7 +115,7 @@ void TestPermutationIteratorScatter()
   thrust::sequence(output.begin(), output.end(), 1);
 
   // construct transform_iterator
-  thrust::permutation_iterator<Iterator, Iterator> p_output(output.begin(), indices.begin());
+  const thrust::permutation_iterator<Iterator, Iterator> p_output(output.begin(), indices.begin());
 
   thrust::copy(source.begin(), source.end(), p_output);
 
@@ -157,14 +157,14 @@ void TestPermutationIteratorReduce()
   thrust::sequence(source.begin(), source.end(), 1);
 
   // construct transform_iterator
-  thrust::permutation_iterator<Iterator, Iterator> iter(source.begin(), indices.begin());
+  const thrust::permutation_iterator<Iterator, Iterator> iter(source.begin(), indices.begin());
 
-  T result1 = thrust::reduce(thrust::make_permutation_iterator(source.begin(), indices.begin()),
-                             thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4);
+  const T result1 = thrust::reduce(thrust::make_permutation_iterator(source.begin(), indices.begin()),
+                                   thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4);
 
   ASSERT_EQUAL(result1, 19);
 
-  T result2 = thrust::transform_reduce(
+  const T result2 = thrust::transform_reduce(
     thrust::make_permutation_iterator(source.begin(), indices.begin()),
     thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4,
     ::cuda::std::negate<T>(),
@@ -194,19 +194,19 @@ void TestPermutationIteratorHostDeviceGather()
   thrust::sequence(h_source.begin(), h_source.end(), 1);
   thrust::sequence(d_source.begin(), d_source.end(), 1);
 
-  thrust::permutation_iterator<HostIterator, HostIterator> p_h_source(h_source.begin(), h_indices.begin());
-  thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_source(d_source.begin(), d_indices.begin());
+  const thrust::permutation_iterator<HostIterator, HostIterator> p_h_source(h_source.begin(), h_indices.begin());
+  const thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_source(d_source.begin(), d_indices.begin());
 
   // gather host->device
   thrust::copy(p_h_source, p_h_source + 4, d_output.begin());
 
-  DeviceVector dref{4, 1, 6, 8};
+  const DeviceVector dref{4, 1, 6, 8};
   ASSERT_EQUAL(d_output, dref);
 
   // gather device->host
   thrust::copy(p_d_source, p_d_source + 4, h_output.begin());
 
-  HostVector href{4, 1, 6, 8};
+  const HostVector href{4, 1, 6, 8};
   ASSERT_EQUAL(h_output, href);
 }
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceGather);
@@ -231,19 +231,19 @@ void TestPermutationIteratorHostDeviceScatter()
   thrust::sequence(h_output.begin(), h_output.end(), 1);
   thrust::sequence(d_output.begin(), d_output.end(), 1);
 
-  thrust::permutation_iterator<HostIterator, HostIterator> p_h_output(h_output.begin(), h_indices.begin());
-  thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_output(d_output.begin(), d_indices.begin());
+  const thrust::permutation_iterator<HostIterator, HostIterator> p_h_output(h_output.begin(), h_indices.begin());
+  const thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_output(d_output.begin(), d_indices.begin());
 
   // scatter host->device
   thrust::copy(h_source.begin(), h_source.end(), p_d_output);
 
-  DeviceVector dref{10, 2, 3, 10, 5, 10, 7, 10};
+  const DeviceVector dref{10, 2, 3, 10, 5, 10, 7, 10};
   ASSERT_EQUAL(d_output, dref);
 
   // scatter device->host
   thrust::copy(d_source.begin(), d_source.end(), p_h_output);
 
-  HostVector href = dref;
+  const HostVector href = dref;
   ASSERT_EQUAL(h_output, href);
 }
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceScatter);
@@ -254,7 +254,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestPermutationIteratorWithCountingIte
   using T      = typename Vector::value_type;
   using diff_t = typename thrust::counting_iterator<T>::difference_type;
 
-  thrust::counting_iterator<T> input(0), index(0);
+  const thrust::counting_iterator<T> input(0), index(0);
 
   // test copy()
   {

--- a/thrust/testing/random.cu
+++ b/thrust/testing/random.cu
@@ -295,7 +295,7 @@ void TestEngineSaveRestore()
 template <typename Engine>
 void TestEngineEqual()
 {
-  ValidateEngineEqual<Engine> f;
+  const ValidateEngineEqual<Engine> f;
 
   // test host
   thrust::host_vector<bool> h(1);
@@ -313,7 +313,7 @@ void TestEngineEqual()
 template <typename Engine>
 void TestEngineUnequal()
 {
-  ValidateEngineUnequal<Engine> f;
+  const ValidateEngineUnequal<Engine> f;
 
   // test host
   thrust::host_vector<bool> h(1);
@@ -706,9 +706,9 @@ void ValidateDistributionCharacteristic()
     // test Distribution with smaller range than engine
 
     // test host
-    typename Distribution::result_type engine_range = (engine_traits::max) () - (engine_traits::min) ();
-    typename Distribution::result_type smaller_min  = engine_range / 3;
-    typename Distribution::result_type smaller_max  = engine_range - smaller_min;
+    const typename Distribution::result_type engine_range = (engine_traits::max) () - (engine_traits::min) ();
+    const typename Distribution::result_type smaller_min  = engine_range / 3;
+    const typename Distribution::result_type smaller_max  = engine_range - smaller_min;
 
     thrust::generate(h.begin(), h.end(), Validator(Distribution(smaller_min, smaller_max)));
 

--- a/thrust/testing/raw_reference_cast.cu
+++ b/thrust/testing/raw_reference_cast.cu
@@ -15,6 +15,7 @@ void TestRawReferenceCast()
   using ::cuda::std::is_same_v;
 
   {
+    // NOLINTNEXTLINE(misc-const-correctness): the non-const overload is under test
     [[maybe_unused]] int i        = 42;
     [[maybe_unused]] const int ci = 42;
     static_assert(is_same_v<decltype(thrust::raw_reference_cast(i)), int&>);
@@ -53,7 +54,7 @@ void TestRawReferenceCast()
 
   // proxy references
   {
-    [[maybe_unused]] std::vector<bool> vb;
+    [[maybe_unused]] std::vector<bool> vb; // NOLINT(misc-const-correctness)
     static_assert(is_same_v<decltype(thrust::raw_reference_cast(vb[0])), std::vector<bool>::reference>);
   }
 }

--- a/thrust/testing/reduce.cu
+++ b/thrust/testing/reduce.cu
@@ -43,7 +43,7 @@ void TestReduceDispatchExplicit()
 {
   thrust::device_vector<int> vec;
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::reduce(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -60,7 +60,7 @@ void TestReduceDispatchImplicit()
 {
   thrust::device_vector<int> vec;
 
-  int result = thrust::reduce(thrust::retag<my_tag>(vec.begin()), thrust::retag<my_tag>(vec.end()));
+  const int result = thrust::reduce(thrust::retag<my_tag>(vec.begin()), thrust::retag<my_tag>(vec.end()));
 
   ASSERT_EQUAL(13, result);
 }
@@ -152,7 +152,7 @@ void TestReduceWithIndirection()
 
   Vector table{0, 1, 2, 0, 1, 2};
 
-  T result = thrust::reduce(data.begin(), data.end(), T(0), plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
+  const T result = thrust::reduce(data.begin(), data.end(), T(0), plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
 
   ASSERT_EQUAL(result, T(1));
 }
@@ -165,8 +165,8 @@ void TestReduceCountingIterator()
 
   ASSERT_LEQUAL(T(n), unittest::truncate_to_max_representable<T>(n));
 
-  thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
-  thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
 
   T init = unittest::random_integer<T>();
 
@@ -180,11 +180,11 @@ DECLARE_GENERIC_UNITTEST(TestReduceCountingIterator);
 
 void TestReduceWithBigIndexesHelper(int magnitude)
 {
-  cuda::constant_iterator<long long> begin(1);
-  cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
+  const cuda::constant_iterator<long long> begin(1);
+  const cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  long long result = thrust::reduce(thrust::device, begin, end);
+  const long long result = thrust::reduce(thrust::device, begin, end);
 
   ASSERT_EQUAL(result, 1ll << magnitude);
 }

--- a/thrust/testing/reduce_by_key.cu
+++ b/thrust/testing/reduce_by_key.cu
@@ -130,15 +130,15 @@ struct TestReduceByKey
     using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
     using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
-    HostIteratorPair h_last =
+    const HostIteratorPair h_last =
       thrust::reduce_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
-    DeviceIteratorPair d_last =
+    const DeviceIteratorPair d_last =
       thrust::reduce_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys_output.begin(), d_vals_output.begin());
 
     ASSERT_EQUAL(h_last.first - h_keys_output.begin(), d_last.first - d_keys_output.begin());
     ASSERT_EQUAL(h_last.second - h_vals_output.begin(), d_last.second - d_vals_output.begin());
 
-    size_t N = h_last.first - h_keys_output.begin();
+    const size_t N = h_last.first - h_keys_output.begin();
 
     h_keys_output.resize(N);
     h_vals_output.resize(N);
@@ -163,22 +163,22 @@ struct TestReduceByKeyToDiscardIterator
     thrust::device_vector<K> d_keys = h_keys;
     thrust::device_vector<V> d_vals = h_vals;
 
-    thrust::host_vector<K> h_keys_output(n);
+    const thrust::host_vector<K> h_keys_output(n);
     thrust::host_vector<V> h_vals_output(n);
-    thrust::device_vector<K> d_keys_output(n);
+    const thrust::device_vector<K> d_keys_output(n);
     thrust::device_vector<V> d_vals_output(n);
 
     thrust::host_vector<K> unique_keys = h_keys;
     unique_keys.erase(thrust::unique(unique_keys.begin(), unique_keys.end()), unique_keys.end());
 
     // discard key output
-    size_t h_size =
+    const size_t h_size =
       thrust::reduce_by_key(
         h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), h_vals_output.begin())
         .second
       - h_vals_output.begin();
 
-    size_t d_size =
+    const size_t d_size =
       thrust::reduce_by_key(
         d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), d_vals_output.begin())
         .second
@@ -211,7 +211,7 @@ void TestReduceByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::reduce_by_key(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/reduce_into.cu
+++ b/thrust/testing/reduce_into.cu
@@ -45,7 +45,7 @@ void TestReduceIntoDispatchExplicit()
   thrust::device_vector<int> i;
   thrust::device_vector<int> o(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::reduce_into(sys, i.begin(), i.end(), o.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -188,8 +188,8 @@ void TestReduceIntoCountingIterator()
 
   ASSERT_LEQUAL(T(n), unittest::truncate_to_max_representable<T>(n));
 
-  thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
-  thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
+  const thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
   thrust::host_vector<T> h_result(1);
   thrust::device_vector<T> d_result(1);
 

--- a/thrust/testing/reduce_large.cu
+++ b/thrust/testing/reduce_large.cu
@@ -5,7 +5,7 @@
 template <typename T, unsigned int N>
 void _TestReduceWithLargeTypes()
 {
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<FixedVector<T, N>> h_data(n);
 
@@ -16,8 +16,8 @@ void _TestReduceWithLargeTypes()
 
   thrust::device_vector<FixedVector<T, N>> d_data = h_data;
 
-  FixedVector<T, N> h_result = thrust::reduce(h_data.begin(), h_data.end(), FixedVector<T, N>(T{0}));
-  FixedVector<T, N> d_result = thrust::reduce(d_data.begin(), d_data.end(), FixedVector<T, N>(T{0}));
+  const FixedVector<T, N> h_result = thrust::reduce(h_data.begin(), h_data.end(), FixedVector<T, N>(T{0}));
+  const FixedVector<T, N> d_result = thrust::reduce(d_data.begin(), d_data.end(), FixedVector<T, N>(T{0}));
 
   ASSERT_EQUAL_QUIET(h_result, d_result);
 }

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -34,7 +34,7 @@ void TestRemoveSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  typename Vector::iterator end = thrust::remove(data.begin(), data.end(), (T) 2);
+  const typename Vector::iterator end = thrust::remove(data.begin(), data.end(), (T) 2);
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.resize(end - data.begin());
@@ -55,7 +55,7 @@ void TestRemoveDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -88,7 +88,7 @@ void TestRemoveCopySimple()
 
   Vector result(5);
 
-  typename Vector::iterator end = thrust::remove_copy(data.begin(), data.end(), result.begin(), (T) 2);
+  const typename Vector::iterator end = thrust::remove_copy(data.begin(), data.end(), result.begin(), (T) 2);
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());
@@ -109,7 +109,7 @@ void TestRemoveCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove_copy(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -141,7 +141,7 @@ void TestRemoveIfSimple()
 
   Vector data{1, 2, 1, 3, 2};
 
-  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), is_even<T>());
+  const typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), is_even<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.resize(end - data.begin());
@@ -162,7 +162,7 @@ void TestRemoveIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove_if(sys, vec.begin(), vec.end(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -192,7 +192,8 @@ void TestRemoveIfStencilSimple()
   Vector data{1, 2, 1, 3, 2};
   Vector stencil{0, 1, 0, 0, 1};
 
-  typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), stencil.begin(), ::cuda::std::identity{});
+  const typename Vector::iterator end =
+    thrust::remove_if(data.begin(), data.end(), stencil.begin(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(end - data.begin(), 3);
   data.resize(end - data.begin());
@@ -213,7 +214,7 @@ void TestRemoveIfStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove_if(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -247,7 +248,7 @@ void TestRemoveCopyIfSimple()
 
   Vector result(5);
 
-  typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), is_even<T>());
+  const typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), is_even<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
   result.resize(end - result.begin());
@@ -268,7 +269,7 @@ void TestRemoveCopyIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove_copy_if(sys, vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -301,7 +302,7 @@ void TestRemoveCopyIfStencilSimple()
 
   Vector result(5);
 
-  typename Vector::iterator end =
+  const typename Vector::iterator end =
     thrust::remove_copy_if(data.begin(), data.end(), stencil.begin(), result.begin(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(end - result.begin(), 3);
@@ -324,7 +325,7 @@ void TestRemoveCopyIfStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::remove_copy_if(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -359,8 +360,8 @@ void TestRemove(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t h_size = thrust::remove(h_data.begin(), h_data.end(), T(0)) - h_data.begin();
-  size_t d_size = thrust::remove(d_data.begin(), d_data.end(), T(0)) - d_data.begin();
+  const size_t h_size = thrust::remove(h_data.begin(), h_data.end(), T(0)) - h_data.begin();
+  const size_t d_size = thrust::remove(d_data.begin(), d_data.end(), T(0)) - d_data.begin();
 
   ASSERT_EQUAL(h_size, d_size);
 
@@ -377,8 +378,8 @@ void TestRemoveIf(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t h_size = thrust::remove_if(h_data.begin(), h_data.end(), is_true<T>()) - h_data.begin();
-  size_t d_size = thrust::remove_if(d_data.begin(), d_data.end(), is_true<T>()) - d_data.begin();
+  const size_t h_size = thrust::remove_if(h_data.begin(), h_data.end(), is_true<T>()) - h_data.begin();
+  const size_t d_size = thrust::remove_if(d_data.begin(), d_data.end(), is_true<T>()) - d_data.begin();
 
   ASSERT_EQUAL(h_size, d_size);
 
@@ -398,8 +399,10 @@ void TestRemoveIfStencil(const size_t n)
   thrust::host_vector<bool> h_stencil   = unittest::random_integers<bool>(n);
   thrust::device_vector<bool> d_stencil = h_stencil;
 
-  size_t h_size = thrust::remove_if(h_data.begin(), h_data.end(), h_stencil.begin(), is_true<T>()) - h_data.begin();
-  size_t d_size = thrust::remove_if(d_data.begin(), d_data.end(), d_stencil.begin(), is_true<T>()) - d_data.begin();
+  const size_t h_size =
+    thrust::remove_if(h_data.begin(), h_data.end(), h_stencil.begin(), is_true<T>()) - h_data.begin();
+  const size_t d_size =
+    thrust::remove_if(d_data.begin(), d_data.end(), d_stencil.begin(), is_true<T>()) - d_data.begin();
 
   ASSERT_EQUAL(h_size, d_size);
 
@@ -419,8 +422,8 @@ void TestRemoveCopy(const size_t n)
   thrust::host_vector<T> h_result(n);
   thrust::device_vector<T> d_result(n);
 
-  size_t h_size = thrust::remove_copy(h_data.begin(), h_data.end(), h_result.begin(), T(0)) - h_result.begin();
-  size_t d_size = thrust::remove_copy(d_data.begin(), d_data.end(), d_result.begin(), T(0)) - d_result.begin();
+  const size_t h_size = thrust::remove_copy(h_data.begin(), h_data.end(), h_result.begin(), T(0)) - h_result.begin();
+  const size_t d_size = thrust::remove_copy(d_data.begin(), d_data.end(), d_result.begin(), T(0)) - d_result.begin();
 
   ASSERT_EQUAL(h_size, d_size);
 
@@ -437,16 +440,16 @@ void TestRemoveCopyToDiscardIterator(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t num_zeros    = thrust::count(h_data.begin(), h_data.end(), T(0));
-  size_t num_nonzeros = h_data.size() - num_zeros;
+  const size_t num_zeros    = thrust::count(h_data.begin(), h_data.end(), T(0));
+  const size_t num_nonzeros = h_data.size() - num_zeros;
 
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::remove_copy(h_data.begin(), h_data.end(), thrust::make_discard_iterator(), T(0));
 
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::remove_copy(d_data.begin(), d_data.end(), thrust::make_discard_iterator(), T(0));
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_nonzeros));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_nonzeros));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -462,8 +465,8 @@ void TestRemoveCopyToDiscardIteratorZipped(const size_t n)
   thrust::host_vector<T> h_output(n);
   thrust::device_vector<T> d_output(n);
 
-  size_t num_zeros    = thrust::count(h_data.begin(), h_data.end(), T(0));
-  size_t num_nonzeros = h_data.size() - num_zeros;
+  const size_t num_zeros    = thrust::count(h_data.begin(), h_data.end(), T(0));
+  const size_t num_nonzeros = h_data.size() - num_zeros;
 
   using Tuple1 = cuda::std::tuple<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>>;
   using Tuple2 = cuda::std::tuple<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>>;
@@ -471,19 +474,19 @@ void TestRemoveCopyToDiscardIteratorZipped(const size_t n)
   using ZipIterator1 = thrust::zip_iterator<Tuple1>;
   using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
-  ZipIterator1 h_result = thrust::remove_copy(
+  const ZipIterator1 h_result = thrust::remove_copy(
     thrust::make_zip_iterator(h_data.begin(), h_data.begin()),
     thrust::make_zip_iterator(h_data.end(), h_data.end()),
     thrust::make_zip_iterator(h_output.begin(), thrust::make_discard_iterator()),
     cuda::std::tuple(T(0), T(0)));
 
-  ZipIterator2 d_result = thrust::remove_copy(
+  const ZipIterator2 d_result = thrust::remove_copy(
     thrust::make_zip_iterator(d_data.begin(), d_data.begin()),
     thrust::make_zip_iterator(d_data.end(), d_data.end()),
     thrust::make_zip_iterator(d_output.begin(), thrust::make_discard_iterator()),
     cuda::std::tuple(T(0), T(0)));
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_nonzeros));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_nonzeros));
 
   ASSERT_EQUAL(h_output, d_output);
   ASSERT_EQUAL_QUIET(reference, cuda::std::get<1>(h_result.get_iterator_tuple()));
@@ -500,9 +503,9 @@ void TestRemoveCopyIf(const size_t n)
   thrust::host_vector<T> h_result(n);
   thrust::device_vector<T> d_result(n);
 
-  size_t h_size =
+  const size_t h_size =
     thrust::remove_copy_if(h_data.begin(), h_data.end(), h_result.begin(), is_true<T>()) - h_result.begin();
-  size_t d_size =
+  const size_t d_size =
     thrust::remove_copy_if(d_data.begin(), d_data.end(), d_result.begin(), is_true<T>()) - d_result.begin();
 
   ASSERT_EQUAL(h_size, d_size);
@@ -520,15 +523,15 @@ void TestRemoveCopyIfToDiscardIterator(const size_t n)
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  size_t num_false = thrust::count_if(h_data.begin(), h_data.end(), ::cuda::std::not_fn(is_true<T>()));
+  const size_t num_false = thrust::count_if(h_data.begin(), h_data.end(), ::cuda::std::not_fn(is_true<T>()));
 
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::remove_copy_if(h_data.begin(), h_data.end(), thrust::make_discard_iterator(), is_true<T>());
 
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::remove_copy_if(d_data.begin(), d_data.end(), thrust::make_discard_iterator(), is_true<T>());
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_false));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_false));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -547,10 +550,10 @@ void TestRemoveCopyIfStencil(const size_t n)
   thrust::host_vector<T> h_result(n);
   thrust::device_vector<T> d_result(n);
 
-  size_t h_size =
+  const size_t h_size =
     thrust::remove_copy_if(h_data.begin(), h_data.end(), h_stencil.begin(), h_result.begin(), is_true<T>())
     - h_result.begin();
-  size_t d_size =
+  const size_t d_size =
     thrust::remove_copy_if(d_data.begin(), d_data.end(), d_stencil.begin(), d_result.begin(), is_true<T>())
     - d_result.begin();
 
@@ -572,15 +575,15 @@ void TestRemoveCopyIfStencilToDiscardIterator(const size_t n)
   thrust::host_vector<bool> h_stencil   = unittest::random_integers<bool>(n);
   thrust::device_vector<bool> d_stencil = h_stencil;
 
-  size_t num_false = thrust::count_if(h_stencil.begin(), h_stencil.end(), ::cuda::std::not_fn(is_true<T>()));
+  const size_t num_false = thrust::count_if(h_stencil.begin(), h_stencil.end(), ::cuda::std::not_fn(is_true<T>()));
 
-  thrust::discard_iterator<> h_result = thrust::remove_copy_if(
+  const thrust::discard_iterator<> h_result = thrust::remove_copy_if(
     h_data.begin(), h_data.end(), h_stencil.begin(), thrust::make_discard_iterator(), is_true<T>());
 
-  thrust::discard_iterator<> d_result = thrust::remove_copy_if(
+  const thrust::discard_iterator<> d_result = thrust::remove_copy_if(
     d_data.begin(), d_data.end(), d_stencil.begin(), thrust::make_discard_iterator(), is_true<T>());
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_false));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(num_false));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/replace.cu
+++ b/thrust/testing/replace.cu
@@ -43,7 +43,7 @@ void TestReplaceDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace(sys, vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -112,7 +112,7 @@ void TestReplaceCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace_copy(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -166,13 +166,13 @@ void TestReplaceCopyToDiscardIterator(const size_t n)
   T old_value = 0;
   T new_value = 1;
 
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::replace_copy(h_data.begin(), h_data.end(), thrust::make_discard_iterator(), old_value, new_value);
 
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::replace_copy(d_data.begin(), d_data.end(), thrust::make_discard_iterator(), old_value, new_value);
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -213,7 +213,7 @@ void TestReplaceIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace_if(sys, vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -262,7 +262,7 @@ void TestReplaceIfStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace_if(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -343,7 +343,7 @@ void TestReplaceCopyIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace_copy_if(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -398,7 +398,7 @@ void TestReplaceCopyIfStencilDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::replace_copy_if(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -452,13 +452,13 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfToDiscardIterator(con
   thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_data = h_data;
 
-  thrust::discard_iterator<> h_result =
+  const thrust::discard_iterator<> h_result =
     thrust::replace_copy_if(h_data.begin(), h_data.end(), thrust::make_discard_iterator(), less_than_five<T>(), T{0});
 
-  thrust::discard_iterator<> d_result =
+  const thrust::discard_iterator<> d_result =
     thrust::replace_copy_if(d_data.begin(), d_data.end(), thrust::make_discard_iterator(), less_than_five<T>(), T{0});
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -494,13 +494,13 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfStencilToDiscardItera
   thrust::host_vector<T> h_stencil   = unittest::random_samples<T>(n);
   thrust::device_vector<T> d_stencil = h_stencil;
 
-  thrust::discard_iterator<> h_result = thrust::replace_copy_if(
+  const thrust::discard_iterator<> h_result = thrust::replace_copy_if(
     h_data.begin(), h_data.end(), h_stencil.begin(), thrust::make_discard_iterator(), less_than_five<T>(), T{0});
 
-  thrust::discard_iterator<> d_result = thrust::replace_copy_if(
+  const thrust::discard_iterator<> d_result = thrust::replace_copy_if(
     d_data.begin(), d_data.end(), d_stencil.begin(), thrust::make_discard_iterator(), less_than_five<T>(), T{0});
 
-  thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+  const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -29,7 +29,7 @@ void TestReverseDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::reverse(sys, vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -60,7 +60,7 @@ void TestReverseCopySimple()
   Vector input{1, 2, 3, 4, 5};
   Vector output(8); // arm GCC is complaining about destination size
 
-  Iterator iter = thrust::reverse_copy(input.begin(), input.end(), output.begin());
+  const Iterator iter = thrust::reverse_copy(input.begin(), input.end(), output.begin());
 
   output.resize(5);
   Vector ref{5, 4, 3, 2, 1};
@@ -80,7 +80,7 @@ void TestReverseCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::reverse_copy(sys, vec.begin(), vec.end(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -148,13 +148,13 @@ struct TestReverseCopyToDiscardIterator
     thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_data = h_data;
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::reverse_copy(h_data.begin(), h_data.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::reverse_copy(d_data.begin(), d_data.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     ASSERT_EQUAL_QUIET(reference, h_result);
     ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -39,16 +39,16 @@ void TestReverseIteratorCopyConstructor()
 {
   thrust::host_vector<int> h_v(1, 13);
 
-  thrust::reverse_iterator<thrust::host_vector<int>::iterator> h_iter0(h_v.end());
-  thrust::reverse_iterator<thrust::host_vector<int>::iterator> h_iter1(h_iter0);
+  const thrust::reverse_iterator<thrust::host_vector<int>::iterator> h_iter0(h_v.end());
+  const thrust::reverse_iterator<thrust::host_vector<int>::iterator> h_iter1(h_iter0);
 
   ASSERT_EQUAL_QUIET(h_iter0, h_iter1);
   ASSERT_EQUAL(*h_iter0, *h_iter1);
 
   thrust::device_vector<int> d_v(1, 13);
 
-  thrust::reverse_iterator<thrust::device_vector<int>::iterator> d_iter2(d_v.end());
-  thrust::reverse_iterator<thrust::device_vector<int>::iterator> d_iter3(d_iter2);
+  const thrust::reverse_iterator<thrust::device_vector<int>::iterator> d_iter2(d_v.end());
+  const thrust::reverse_iterator<thrust::device_vector<int>::iterator> d_iter3(d_iter2);
 
   ASSERT_EQUAL_QUIET(d_iter2, d_iter3);
   ASSERT_EQUAL(*d_iter2, *d_iter3);

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -112,7 +112,7 @@ void TestInclusiveScanDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::inclusive_scan(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -148,7 +148,7 @@ void TestExclusiveScanDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::exclusive_scan(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -175,8 +175,8 @@ DECLARE_UNITTEST(TestExclusiveScanDispatchImplicit);
 
 void TestInclusiveScan32()
 {
-  using T  = int;
-  size_t n = 32;
+  using T        = int;
+  const size_t n = 32;
 
   thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
   thrust::device_vector<T> d_input = h_input;
@@ -193,9 +193,9 @@ DECLARE_UNITTEST(TestInclusiveScan32);
 
 void TestExclusiveScan32()
 {
-  using T  = int;
-  size_t n = 32;
-  T init   = 13;
+  using T        = int;
+  const size_t n = 32;
+  const T init   = 13;
 
   thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
   thrust::device_vector<T> d_input = h_input;
@@ -303,7 +303,7 @@ struct TestScanWithOperatorToDiscardIterator
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     thrust::discard_iterator<> h_result =
       thrust::inclusive_scan(h_input.begin(), h_input.end(), thrust::make_discard_iterator(), cuda::maximum<T>{});
@@ -380,7 +380,7 @@ struct TestScanToDiscardIterator
     thrust::discard_iterator<> d_result =
       thrust::inclusive_scan(d_input.begin(), d_input.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     ASSERT_EQUAL_QUIET(reference, h_result);
     ASSERT_EQUAL_QUIET(reference, d_result);
@@ -438,7 +438,7 @@ DECLARE_UNITTEST(TestScanMixedTypes);
 template <typename T, unsigned int N>
 void _TestScanWithLargeTypes()
 {
-  size_t n = (1024 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (1024 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<FixedVector<T, N>> h_input(n);
   thrust::host_vector<FixedVector<T, N>> h_output(n);
@@ -600,18 +600,18 @@ _CCCL_END_NAMESPACE_CUDA_STD
 
 void TestInclusiveScanWithBigIndexesHelper(int magnitude)
 {
-  cuda::constant_iterator<long long> begin(1);
-  cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
+  const cuda::constant_iterator<long long> begin(1);
+  const cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1); // NOLINT(misc-const-correctness)
   *has_executed                         = false;
 
-  only_set_when_expected_it out = {(1ll << magnitude), thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_expected_it out = {(1ll << magnitude), thrust::raw_pointer_cast(has_executed)};
 
   thrust::inclusive_scan(thrust::device, begin, end, out);
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);
@@ -631,18 +631,18 @@ DECLARE_UNITTEST(TestInclusiveScanWithBigIndexes);
 
 void TestExclusiveScanWithBigIndexesHelper(int magnitude)
 {
-  cuda::constant_iterator<long long> begin(1);
-  cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
+  const cuda::constant_iterator<long long> begin(1);
+  const cuda::constant_iterator<long long> end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1);
+  thrust::device_ptr<bool> has_executed = thrust::device_malloc<bool>(1); // NOLINT(misc-const-correctness)
   *has_executed                         = false;
 
-  only_set_when_expected_it out = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
+  const only_set_when_expected_it out = {(1ll << magnitude) - 1, thrust::raw_pointer_cast(has_executed)};
 
   thrust::exclusive_scan(thrust::device, begin, end, out, 0ll);
 
-  bool has_executed_h = *has_executed;
+  const bool has_executed_h = *has_executed;
   thrust::device_free(has_executed);
 
   ASSERT_EQUAL(has_executed_h, true);
@@ -815,7 +815,7 @@ void TestInclusiveScanForInvalidValues()
   if (policy_selector_t{}(cc).algorithm == cub::ScanAlgorithm::lookahead)
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
   {
-    for (int n : {1, 100, 10'000})
+    for (const int n : {1, 100, 10'000})
     {
       const thrust::device_vector<value_t> input(n, checking_identity::sentinel);
       thrust::device_vector<value_t> output(n, thrust::no_init);
@@ -922,7 +922,7 @@ void TestScanEdgeCases()
     auto r = thrust::inclusive_scan(d_input.begin(), d_input.end(), d_output.begin(), 2, ::cuda::std::multiplies<>{});
     ASSERT_EQUAL((d_output.end() == r), true);
 
-    thrust::device_vector<int> expected = {6, 42};
+    const thrust::device_vector<int> expected = {6, 42};
     ASSERT_EQUAL(d_output, expected);
   }
 
@@ -970,7 +970,7 @@ void TestScanEdgeCases()
     auto r = thrust::exclusive_scan(d_input.begin(), d_input.end(), d_output.begin(), 3, ::cuda::std::multiplies<>{});
     ASSERT_EQUAL((d_output.end() == r), true);
 
-    thrust::device_vector<int> expected = {3, 6};
+    const thrust::device_vector<int> expected = {3, 6};
     ASSERT_EQUAL(d_output, expected);
   }
 }

--- a/thrust/testing/scan_by_key.exclusive.cu
+++ b/thrust/testing/scan_by_key.exclusive.cu
@@ -17,7 +17,7 @@ void TestExclusiveScanByKeySimple()
   Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
 
-  Iterator iter = thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
+  const Iterator iter = thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
@@ -61,7 +61,7 @@ void TestExclusiveScanByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::exclusive_scan_by_key(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -263,14 +263,14 @@ void TestScanByKeyDiscardOutput(std::size_t n)
       k++;
     }
   }
-  thrust::device_vector<T> d_keys = h_keys;
+  const thrust::device_vector<T> d_keys = h_keys;
 
   thrust::host_vector<T> h_vals(n);
   for (size_t i = 0; i < n; i++)
   {
     h_vals[i] = static_cast<T>(i % 10);
   }
-  thrust::device_vector<T> d_vals = h_vals;
+  const thrust::device_vector<T> d_vals = h_vals;
 
   auto out = thrust::make_discard_iterator();
 
@@ -287,7 +287,7 @@ void TestScanByKeyLargeInput()
 {
   const unsigned int N = 1 << 20;
 
-  thrust::host_vector<unsigned int> vals_sizes = unittest::random_integers<unsigned int>(10);
+  const thrust::host_vector<unsigned int> vals_sizes = unittest::random_integers<unsigned int>(10);
 
   thrust::host_vector<unsigned int> h_vals   = unittest::random_integers<unsigned int>(N);
   thrust::device_vector<unsigned int> d_vals = h_vals;
@@ -322,7 +322,7 @@ DECLARE_UNITTEST(TestScanByKeyLargeInput);
 template <typename T, unsigned int N>
 void _TestScanByKeyWithLargeTypes()
 {
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<unsigned int> h_keys(n);
   thrust::host_vector<FixedVector<T, N>> h_vals(n);

--- a/thrust/testing/scan_by_key.inclusive.cu
+++ b/thrust/testing/scan_by_key.inclusive.cu
@@ -17,7 +17,7 @@ void TestInclusiveScanByKeySimple()
   Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
 
-  Iterator iter = thrust::inclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
+  const Iterator iter = thrust::inclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
@@ -49,7 +49,7 @@ void TestInclusiveScanByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::inclusive_scan_by_key(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -230,8 +230,8 @@ void TestScanByKeyMixedTypes()
 
   thrust::host_vector<float> h_float_output(n);
   thrust::device_vector<float> d_float_output(n);
-  thrust::host_vector<int> h_int_output(n);
-  thrust::device_vector<int> d_int_output(n);
+  const thrust::host_vector<int> h_int_output(n);
+  const thrust::device_vector<int> d_int_output(n);
 
   // mixed vals/output types
   thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_float_output.begin());
@@ -254,14 +254,14 @@ void TestScanByKeyDiscardOutput(std::size_t n)
       k++;
     }
   }
-  thrust::device_vector<T> d_keys = h_keys;
+  const thrust::device_vector<T> d_keys = h_keys;
 
   thrust::host_vector<T> h_vals(n);
   for (size_t i = 0; i < n; i++)
   {
     h_vals[i] = static_cast<T>(i % 10);
   }
-  thrust::device_vector<T> d_vals = h_vals;
+  const thrust::device_vector<T> d_vals = h_vals;
 
   auto out = thrust::make_discard_iterator();
 
@@ -277,7 +277,7 @@ void TestScanByKeyLargeInput()
 {
   const unsigned int N = 1 << 20;
 
-  thrust::host_vector<unsigned int> vals_sizes = unittest::random_integers<unsigned int>(10);
+  const thrust::host_vector<unsigned int> vals_sizes = unittest::random_integers<unsigned int>(10);
 
   thrust::host_vector<unsigned int> h_vals   = unittest::random_integers<unsigned int>(N);
   thrust::device_vector<unsigned int> d_vals = h_vals;
@@ -312,7 +312,7 @@ DECLARE_UNITTEST(TestScanByKeyLargeInput);
 template <typename T, unsigned int N>
 void _TestScanByKeyWithLargeTypes()
 {
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<unsigned int> h_keys(n);
   thrust::host_vector<FixedVector<T, N>> h_vals(n);

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -33,7 +33,7 @@ void TestScatterDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::scatter(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -135,7 +135,7 @@ void TestScatterIfDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::scatter_if(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/sequence.cu
+++ b/thrust/testing/sequence.cu
@@ -14,7 +14,7 @@ void TestSequenceDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::sequence(sys, vec.begin(), vec.end());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -91,8 +91,8 @@ DECLARE_VARIABLE_UNITTEST(TestSequence);
 template <typename T>
 void TestSequenceToDiscardIterator(size_t n)
 {
-  thrust::host_vector<T> h_data(n);
-  thrust::device_vector<T> d_data(n);
+  const thrust::host_vector<T> h_data(n);
+  const thrust::device_vector<T> d_data(n);
 
   thrust::sequence(thrust::discard_iterator<thrust::device_system_tag>(),
                    thrust::discard_iterator<thrust::device_system_tag>(13),

--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -18,7 +18,7 @@ void TestSetDifferenceDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_difference(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -57,7 +57,7 @@ void TestSetDifferenceSimple()
   Vector ref{2, 5};
   Vector result(2);
 
-  Iterator end = thrust::set_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());
+  const Iterator end = thrust::set_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);
@@ -67,8 +67,8 @@ DECLARE_VECTOR_UNITTEST(TestSetDifferenceSimple);
 template <typename T>
 void TestSetDifference(const size_t n)
 {
-  size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
-  size_t num_sizes = sizeof(sizes) / sizeof(size_t);
+  size_t sizes[]         = {0, 1, n / 2, n, n + 1, 2 * n};
+  const size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
   thrust::host_vector<T> random =
     unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
@@ -104,8 +104,8 @@ DECLARE_VARIABLE_UNITTEST(TestSetDifference);
 template <typename T>
 void TestSetDifferenceEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
-  thrust::host_vector<T> h_a  = temp;
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  thrust::host_vector<T> h_a        = temp;
   thrust::sort(h_a.begin(), h_a.end());
   thrust::host_vector<T> h_b = h_a;
 
@@ -173,9 +173,9 @@ DECLARE_VARIABLE_UNITTEST(TestSetDifferenceMultiset);
 #if !_CCCL_COMPILER(MSVC)
 void TestSetDifferenceWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin(0);
-  thrust::counting_iterator<long long> end        = begin + (1ll << magnitude);
-  thrust::counting_iterator<long long> end_longer = end + 1;
+  const thrust::counting_iterator<long long> begin(0);
+  const thrust::counting_iterator<long long> end        = begin + (1ll << magnitude);
+  const thrust::counting_iterator<long long> end_longer = end + 1;
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
   thrust::device_vector<long long> result;

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -30,7 +30,7 @@ void TestSetDifferenceByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_difference_by_key(
     sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
@@ -93,7 +93,7 @@ void TestSetDifferenceByKeySimple()
 
   Vector result_key(2), result_val(2);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -180,7 +180,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetDifferenceByKey);
 template <typename T>
 void TestSetDifferenceByKeyEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
 
   thrust::host_vector<T> h_a_key = temp;
   thrust::sort(h_a_key.begin(), h_a_key.end());

--- a/thrust/testing/set_difference_by_key_descending.cu
+++ b/thrust/testing/set_difference_by_key_descending.cu
@@ -17,7 +17,7 @@ void TestSetDifferenceByKeyDescendingSimple()
 
   Vector result_key(2), result_val(2);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),

--- a/thrust/testing/set_difference_descending.cu
+++ b/thrust/testing/set_difference_descending.cu
@@ -15,7 +15,7 @@ void TestSetDifferenceDescendingSimple()
   Vector ref{5, 2};
   Vector result(2);
 
-  Iterator end =
+  const Iterator end =
     thrust::set_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(result.end(), end);

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -19,7 +19,7 @@ void TestSetIntersectionDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_intersection(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -59,7 +59,7 @@ void TestSetIntersectionSimple()
 
   Vector result(2);
 
-  Iterator end = thrust::set_intersection(a.begin(), a.end(), b.begin(), b.end(), result.begin());
+  const Iterator end = thrust::set_intersection(a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);
@@ -69,8 +69,8 @@ DECLARE_VECTOR_UNITTEST(TestSetIntersectionSimple);
 template <typename T>
 void TestSetIntersection(const size_t n)
 {
-  size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
-  size_t num_sizes = sizeof(sizes) / sizeof(size_t);
+  size_t sizes[]         = {0, 1, n / 2, n, n + 1, 2 * n};
+  const size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
   thrust::host_vector<T> random =
     unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
@@ -120,7 +120,7 @@ void TestSetIntersectionToDiscardIterator(const size_t n)
   thrust::discard_iterator<> d_result;
 
   thrust::host_vector<T> h_reference(n);
-  typename thrust::host_vector<T>::iterator h_end =
+  const typename thrust::host_vector<T>::iterator h_end =
     thrust::set_intersection(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), h_reference.begin());
   h_reference.erase(h_end, h_reference.end());
 
@@ -128,7 +128,7 @@ void TestSetIntersectionToDiscardIterator(const size_t n)
 
   d_result = thrust::set_intersection(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> reference(h_reference.size());
+  const thrust::discard_iterator<> reference(h_reference.size());
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);
@@ -138,8 +138,8 @@ DECLARE_VARIABLE_UNITTEST(TestSetIntersectionToDiscardIterator);
 template <typename T>
 void TestSetIntersectionEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
-  thrust::host_vector<T> h_a  = temp;
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  thrust::host_vector<T> h_a        = temp;
   thrust::sort(h_a.begin(), h_a.end());
   thrust::host_vector<T> h_b = h_a;
 
@@ -207,10 +207,10 @@ DECLARE_VARIABLE_UNITTEST(TestSetIntersectionMultiset);
 #if !_CCCL_COMPILER(MSVC)
 void TestSetDifferenceWithBigIndexesHelper(int magnitude)
 {
-  thrust::counting_iterator<long long> begin1(0);
-  thrust::counting_iterator<long long> begin2 = begin1 + (1ll << magnitude);
-  thrust::counting_iterator<long long> end1   = begin2 + 1;
-  thrust::counting_iterator<long long> end2   = begin2 + (1ll << magnitude);
+  const thrust::counting_iterator<long long> begin1(0);
+  const thrust::counting_iterator<long long> begin2 = begin1 + (1ll << magnitude);
+  const thrust::counting_iterator<long long> end1   = begin2 + 1;
+  const thrust::counting_iterator<long long> end2   = begin2 + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin2, end1), 1);
 
   thrust::device_vector<long long> result;

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -28,7 +28,7 @@ void TestSetIntersectionByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_intersection_by_key(
     sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
@@ -83,7 +83,7 @@ void TestSetIntersectionByKeySimple()
   Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
     a_key.begin(), a_key.end(), b_key.begin(), b_key.end(), a_val.begin(), result_key.begin(), result_val.begin());
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
@@ -159,7 +159,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetIntersectionByKey);
 template <typename T>
 void TestSetIntersectionByKeyEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
 
   thrust::host_vector<T> h_a_key = temp;
   thrust::sort(h_a_key.begin(), h_a_key.end());

--- a/thrust/testing/set_intersection_by_key_descending.cu
+++ b/thrust/testing/set_intersection_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetIntersectionByKeyDescendingSimple()
   Vector ref_key{4, 0}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),

--- a/thrust/testing/set_intersection_descending.cu
+++ b/thrust/testing/set_intersection_descending.cu
@@ -15,7 +15,7 @@ void TestSetIntersectionDescendingSimple()
 
   Vector result(2);
 
-  Iterator end =
+  const Iterator end =
     thrust::set_intersection(a.begin(), a.end(), b.begin(), b.end(), result.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(result.end(), end);

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -18,7 +18,7 @@ void TestSetSymmetricDifferenceDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_symmetric_difference(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -58,7 +58,7 @@ void TestSetSymmetricDifferenceSimple()
   Vector ref{2, 3, 3, 6, 7};
   Vector result(5);
 
-  Iterator end = thrust::set_symmetric_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());
+  const Iterator end = thrust::set_symmetric_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);
@@ -68,8 +68,8 @@ DECLARE_VECTOR_UNITTEST(TestSetSymmetricDifferenceSimple);
 template <typename T>
 void TestSetSymmetricDifference(const size_t n)
 {
-  size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
-  size_t num_sizes = sizeof(sizes) / sizeof(size_t);
+  size_t sizes[]         = {0, 1, n / 2, n, n + 1, 2 * n};
+  const size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
   thrust::host_vector<T> random =
     unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
@@ -105,8 +105,8 @@ DECLARE_VARIABLE_UNITTEST(TestSetSymmetricDifference);
 template <typename T>
 void TestSetSymmetricDifferenceEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
-  thrust::host_vector<T> h_a  = temp;
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  thrust::host_vector<T> h_a        = temp;
   thrust::sort(h_a.begin(), h_a.end());
   thrust::host_vector<T> h_b = h_a;
 

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -30,7 +30,7 @@ void TestSetSymmetricDifferenceByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_symmetric_difference_by_key(
     sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
@@ -88,7 +88,7 @@ void TestSetSymmetricDifferenceByKeySimple()
   Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -132,7 +132,7 @@ void TestSetSymmetricDifferenceByKey(const size_t n)
     thrust::device_vector<T> d_a_vals = h_a_vals;
     thrust::device_vector<T> d_b_vals = h_b_vals;
 
-    size_t max_size = h_a_keys.size() + h_b_keys.size();
+    const size_t max_size = h_a_keys.size() + h_b_keys.size();
 
     thrust::host_vector<T> h_result_keys(max_size);
     thrust::host_vector<T> h_result_vals(max_size);
@@ -177,7 +177,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetSymmetricDifferenceByKey);
 template <typename T>
 void TestSetSymmetricDifferenceByKeyEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
 
   thrust::host_vector<T> h_a_key = temp;
   thrust::sort(h_a_key.begin(), h_a_key.end());
@@ -192,7 +192,7 @@ void TestSetSymmetricDifferenceByKeyEquivalentRanges(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
 
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
@@ -258,7 +258,7 @@ void TestSetSymmetricDifferenceByKeyMultiset(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 

--- a/thrust/testing/set_symmetric_difference_by_key_descending.cu
+++ b/thrust/testing/set_symmetric_difference_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetSymmetricDifferenceByKeyDescendingSimple()
   Vector ref_key{7, 6, 3, 3, 2}, ref_val{1, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -53,7 +53,7 @@ void TestSetSymmetricDifferenceByKeyDescending(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 

--- a/thrust/testing/set_symmetric_difference_descending.cu
+++ b/thrust/testing/set_symmetric_difference_descending.cu
@@ -15,7 +15,7 @@ void TestSetSymmetricDifferenceDescendingSimple()
   Vector ref{7, 6, 3, 3, 2};
   Vector result(5);
 
-  Iterator end =
+  const Iterator end =
     thrust::set_symmetric_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(result.end(), end);

--- a/thrust/testing/set_union.cu
+++ b/thrust/testing/set_union.cu
@@ -19,7 +19,7 @@ void TestSetUnionDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_union(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -58,7 +58,7 @@ void TestSetUnionSimple()
   Vector ref{0, 2, 3, 3, 4};
   Vector result(5);
 
-  Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());
+  const Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);
@@ -75,7 +75,7 @@ void TestSetUnionWithEquivalentElementsSimple()
   Vector ref{0, 2, 2, 2, 3};
   Vector result(5);
 
-  Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());
+  const Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);
@@ -85,8 +85,8 @@ DECLARE_VECTOR_UNITTEST(TestSetUnionWithEquivalentElementsSimple);
 template <typename T>
 void TestSetUnion(const size_t n)
 {
-  size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
-  size_t num_sizes = sizeof(sizes) / sizeof(size_t);
+  size_t sizes[]         = {0, 1, n / 2, n, n + 1, 2 * n};
+  const size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
   thrust::host_vector<T> random =
     unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
@@ -136,7 +136,7 @@ void TestSetUnionToDiscardIterator(const size_t n)
   thrust::discard_iterator<> d_result;
 
   thrust::host_vector<T> h_reference(2 * n);
-  typename thrust::host_vector<T>::iterator h_end =
+  const typename thrust::host_vector<T>::iterator h_end =
     thrust::set_union(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), h_reference.begin());
   h_reference.erase(h_end, h_reference.end());
 
@@ -144,7 +144,7 @@ void TestSetUnionToDiscardIterator(const size_t n)
 
   d_result = thrust::set_union(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), thrust::make_discard_iterator());
 
-  thrust::discard_iterator<> reference(h_reference.size());
+  const thrust::discard_iterator<> reference(h_reference.size());
 
   ASSERT_EQUAL_QUIET(reference, h_result);
   ASSERT_EQUAL_QUIET(reference, d_result);

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -30,7 +30,7 @@ void TestSetUnionByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::set_union_by_key(
     sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
@@ -88,7 +88,7 @@ void TestSetUnionByKeySimple()
   Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -132,7 +132,7 @@ void TestSetUnionByKey(const size_t n)
     thrust::device_vector<T> d_a_vals = h_a_vals;
     thrust::device_vector<T> d_b_vals = h_b_vals;
 
-    size_t max_size = h_a_keys.size() + h_b_keys.size();
+    const size_t max_size = h_a_keys.size() + h_b_keys.size();
 
     thrust::host_vector<T> h_result_keys(max_size);
     thrust::host_vector<T> h_result_vals(max_size);
@@ -177,7 +177,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetUnionByKey);
 template <typename T>
 void TestSetUnionByKeyEquivalentRanges(const size_t n)
 {
-  thrust::host_vector<T> temp = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> temp = unittest::random_integers<T>(n);
 
   thrust::host_vector<T> h_a_key = temp;
   thrust::sort(h_a_key.begin(), h_a_key.end());
@@ -192,7 +192,7 @@ void TestSetUnionByKeyEquivalentRanges(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
 
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
@@ -258,7 +258,7 @@ void TestSetUnionByKeyMultiset(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 

--- a/thrust/testing/set_union_by_key_descending.cu
+++ b/thrust/testing/set_union_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetUnionByKeyDescendingSimple()
   Vector ref_key{4, 3, 3, 2, 0}, ref_val{0, 1, 1, 0, 0};
   Vector result_key(5), result_val(5);
 
-  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
+  const cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -53,7 +53,7 @@ void TestSetUnionByKeyDescending(const size_t n)
   thrust::device_vector<T> d_a_val = h_a_val;
   thrust::device_vector<T> d_b_val = h_b_val;
 
-  size_t max_size = h_a_key.size() + h_b_key.size();
+  const size_t max_size = h_a_key.size() + h_b_key.size();
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 

--- a/thrust/testing/set_union_descending.cu
+++ b/thrust/testing/set_union_descending.cu
@@ -15,7 +15,8 @@ void TestSetUnionDescendingSimple()
   Vector ref{4, 3, 3, 2, 0};
   Vector result(5);
 
-  Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin(), ::cuda::std::greater<T>());
+  const Iterator end =
+    thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin(), ::cuda::std::greater<T>());
 
   ASSERT_EQUAL_QUIET(result.end(), end);
   ASSERT_EQUAL(ref, result);

--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -228,15 +228,15 @@ void TestShuffleIteratorConstructibleFromBijection()
 {
   thrust::default_random_engine g(0xD5);
 
-  thrust::detail::feistel_bijection f(32, g);
-  thrust::shuffle_iterator<uint64_t, decltype(f)> it(f);
+  const thrust::detail::feistel_bijection f(32, g);
+  const thrust::shuffle_iterator<uint64_t, thrust::detail::feistel_bijection> it(f);
 
   g.seed(0xD5);
-  thrust::detail::random_bijection<uint64_t> f2(f.size(), g);
-  thrust::shuffle_iterator<uint64_t, decltype(f2)> it2(f2);
+  const thrust::detail::random_bijection<uint64_t> f2(f.size(), g);
+  const thrust::shuffle_iterator<uint64_t, thrust::detail::random_bijection<uint64_t>> it2(f2);
 
   g.seed(0xD5);
-  thrust::shuffle_iterator<uint64_t> it3(f.size(), g);
+  const thrust::shuffle_iterator<uint64_t> it3(f.size(), g);
 
   ASSERT_EQUAL(true, thrust::equal(thrust::device, it, it + f.size(), it2));
   ASSERT_EQUAL(true, thrust::equal(thrust::device, it, it + f.size(), it3));
@@ -311,18 +311,18 @@ void TestShuffleKeyPositionBase()
     }
   }
 
-  double mu    = (n - 1) / 2.0;
-  double sigma = cuda::std::sqrt((n * n - 1) / 12.0);
-  double zmax  = 0.0;
+  const double mu    = (n - 1) / 2.0;
+  const double sigma = cuda::std::sqrt((n * n - 1) / 12.0);
+  double zmax        = 0.0;
   for (size_t i = 0; i < n; ++i)
   {
-    double mean = expected_value[i] / double(num_samples);
-    double z    = cuda::std::abs(mean - mu) / (sigma / cuda::std::sqrt(double(num_samples)));
-    zmax        = cuda::std::max(zmax, cuda::std::abs(z));
+    const double mean = expected_value[i] / double(num_samples);
+    const double z    = cuda::std::abs(mean - mu) / (sigma / cuda::std::sqrt(double(num_samples)));
+    zmax              = cuda::std::max(zmax, cuda::std::abs(z));
   }
 
-  double alpha = 0.05;
-  double zcrit = inverse_erf(1.0 - alpha / (2.0 * n)) * cuda::std::sqrt(2.0);
+  const double alpha = 0.05;
+  const double zcrit = inverse_erf(1.0 - alpha / (2.0 * n)) * cuda::std::sqrt(2.0);
   ASSERT_LESS(zmax, zcrit);
 }
 template <typename Vector>
@@ -366,9 +366,9 @@ void TestShuffleUniformPermutationBase()
 {
   using T = typename Vector::value_type;
 
-  size_t m                  = 5;
-  size_t num_samples        = 1000;
-  size_t total_permutations = 1 * 2 * 3 * 4 * 5;
+  const size_t m                  = 5;
+  const size_t num_samples        = 1000;
+  const size_t total_permutations = 1 * 2 * 3 * 4 * 5;
   std::map<thrust::host_vector<T>, size_t, vector_compare> permutation_counts;
   Vector sequence(m);
   thrust::sequence(sequence.begin(), sequence.end(), T(0));
@@ -376,14 +376,14 @@ void TestShuffleUniformPermutationBase()
   for (auto i = 0ull; i < num_samples; i++)
   {
     ShuffleFunc{}(sequence.begin(), sequence.end(), g);
-    thrust::host_vector<T> tmp(sequence.begin(), sequence.end());
+    const thrust::host_vector<T> tmp(sequence.begin(), sequence.end());
     permutation_counts[tmp]++;
   }
 
   ASSERT_EQUAL(permutation_counts.size(), total_permutations);
 
-  double chi_squared    = 0.0;
-  double expected_count = static_cast<double>(num_samples) / static_cast<double>(total_permutations);
+  double chi_squared          = 0.0;
+  const double expected_count = static_cast<double>(num_samples) / static_cast<double>(total_permutations);
   for (const auto& kv : permutation_counts)
   {
     chi_squared += std::pow(expected_count - kv.second, 2) / expected_count;

--- a/thrust/testing/sort.cu
+++ b/thrust/testing/sort.cu
@@ -14,7 +14,7 @@ void TestSortDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::sort(sys, vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -119,8 +119,8 @@ DECLARE_UNITTEST(TestSortBoolDescending);
 // See also: https://github.com/NVIDIA/cccl/issues/4919
 void TestSortTrivial()
 {
-  thrust::host_vector<int> h_data = {1, 0, -1, -2, -3};
-  thrust::host_vector<int> ref    = {-3, -2, -1, 0, 1};
+  thrust::host_vector<int> h_data    = {1, 0, -1, -2, -3};
+  const thrust::host_vector<int> ref = {-3, -2, -1, 0, 1};
 
   thrust::sort(h_data.begin(), h_data.end());
   ASSERT_EQUAL(h_data, ref);

--- a/thrust/testing/sort_by_key.cu
+++ b/thrust/testing/sort_by_key.cu
@@ -14,7 +14,7 @@ void TestSortByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::sort_by_key(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -140,9 +140,9 @@ DECLARE_UNITTEST(TestSortByKeyBoolDescending);
 
 void TestSortByKeyLongDouble()
 {
-  thrust::host_vector<long double> h_keys    = {10.0L, 9.0L, 8.0L, 7.0L, 6.0L, 5.0L, 4.0L, 3.0L, 2.0L, 1.0L};
-  thrust::host_vector<int> h_values          = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  thrust::host_vector<int> h_values_expected = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  thrust::host_vector<long double> h_keys          = {10.0L, 9.0L, 8.0L, 7.0L, 6.0L, 5.0L, 4.0L, 3.0L, 2.0L, 1.0L};
+  thrust::host_vector<int> h_values                = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  const thrust::host_vector<int> h_values_expected = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
 
   thrust::sort_by_key(h_keys.begin(), h_keys.end(), h_values.begin());
 

--- a/thrust/testing/sort_permutation_iterator.cu
+++ b/thrust/testing/sort_permutation_iterator.cu
@@ -63,7 +63,7 @@ void TestSortPermutationIterator()
 
   Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
 
-  strided_range<Iterator> S(A.begin(), A.end(), 2);
+  const strided_range<Iterator> S(A.begin(), A.end(), 2);
 
   thrust::sort(S.begin(), S.end());
 
@@ -79,7 +79,7 @@ void TestStableSortPermutationIterator()
 
   Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
 
-  strided_range<Iterator> S(A.begin(), A.end(), 2);
+  const strided_range<Iterator> S(A.begin(), A.end(), 2);
 
   thrust::stable_sort(S.begin(), S.end());
 
@@ -96,8 +96,8 @@ void TestSortByKeyPermutationIterator()
   Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
   Vector B{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  strided_range<Iterator> S(A.begin(), A.end(), 2);
-  strided_range<Iterator> T(B.begin(), B.end(), 2);
+  const strided_range<Iterator> S(A.begin(), A.end(), 2);
+  const strided_range<Iterator> T(B.begin(), B.end(), 2);
 
   thrust::sort_by_key(S.begin(), S.end(), T.begin());
 
@@ -117,8 +117,8 @@ void TestStableSortByKeyPermutationIterator()
   Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
   Vector B{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  strided_range<Iterator> S(A.begin(), A.end(), 2);
-  strided_range<Iterator> T(B.begin(), B.end(), 2);
+  const strided_range<Iterator> S(A.begin(), A.end(), 2);
+  const strided_range<Iterator> T(B.begin(), B.end(), 2);
 
   thrust::stable_sort_by_key(S.begin(), S.end(), T.begin());
 

--- a/thrust/testing/sort_variable_bits.cu
+++ b/thrust/testing/sort_variable_bits.cu
@@ -18,7 +18,7 @@ struct TestSortVariableBits
     {
       thrust::host_vector<T> h_keys = unittest::random_integers<T>(n);
 
-      size_t mask = (1 << num_bits) - 1;
+      const size_t mask = (1 << num_bits) - 1;
       for (size_t i = 0; i < n; i++)
       {
         h_keys[i] &= mask;

--- a/thrust/testing/stable_sort.cu
+++ b/thrust/testing/stable_sort.cu
@@ -14,7 +14,7 @@ void TestStableSortDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_sort(sys, vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/stable_sort_by_key.cu
+++ b/thrust/testing/stable_sort_by_key.cu
@@ -14,7 +14,7 @@ void TestStableSortByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::stable_sort_by_key(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/stable_sort_by_key_large_keys.cu
+++ b/thrust/testing/stable_sort_by_key_large_keys.cu
@@ -6,7 +6,7 @@
 template <unsigned int N>
 void _TestStableSortByKeyWithLargeKeys()
 {
-  size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
+  const size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
 
   thrust::host_vector<FixedVector<int, N>> h_keys(n);
   thrust::host_vector<unsigned int> h_vals(n);

--- a/thrust/testing/stable_sort_by_key_large_keys_and_values.cu
+++ b/thrust/testing/stable_sort_by_key_large_keys_and_values.cu
@@ -6,7 +6,7 @@
 template <unsigned int N>
 void _TestStableSortByKeyWithLargeKeysAndValues()
 {
-  size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
+  const size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
 
   thrust::host_vector<FixedVector<int, N>> h_keys(n);
   thrust::host_vector<FixedVector<int, N>> h_vals(n);

--- a/thrust/testing/stable_sort_by_key_large_values.cu
+++ b/thrust/testing/stable_sort_by_key_large_values.cu
@@ -15,7 +15,7 @@ struct greater_div_10
 template <unsigned int N>
 void _TestStableSortByKeyWithLargeValues()
 {
-  size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
+  const size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
 
   thrust::host_vector<unsigned int> h_keys(n);
   thrust::host_vector<FixedVector<int, N>> h_vals(n);

--- a/thrust/testing/stable_sort_large.cu
+++ b/thrust/testing/stable_sort_large.cu
@@ -6,7 +6,7 @@
 template <typename T, unsigned int N>
 void _TestStableSortWithLargeKeys()
 {
-  size_t n = (128 * 1024) / sizeof(FixedVector<T, N>);
+  const size_t n = (128 * 1024) / sizeof(FixedVector<T, N>);
 
   thrust::host_vector<FixedVector<T, N>> h_keys(n);
 

--- a/thrust/testing/swap_ranges.cu
+++ b/thrust/testing/swap_ranges.cu
@@ -16,7 +16,7 @@ void TestSwapRangesDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::swap_ranges(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -60,8 +60,8 @@ DECLARE_VECTOR_UNITTEST(TestSwapRangesSimple);
 template <typename T>
 void TestSwapRanges(const size_t n)
 {
-  thrust::host_vector<T> a1 = unittest::random_integers<T>(n);
-  thrust::host_vector<T> a2 = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> a1 = unittest::random_integers<T>(n);
+  const thrust::host_vector<T> a2 = unittest::random_integers<T>(n);
 
   thrust::host_vector<T> h1   = a1;
   thrust::host_vector<T> h2   = a2;

--- a/thrust/testing/tabulate.cu
+++ b/thrust/testing/tabulate.cu
@@ -15,7 +15,7 @@ void TestTabulateDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::tabulate(sys, vec.begin(), vec.end(), ::cuda::std::identity{});
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/tabulate_output_iterator.cu
+++ b/thrust/testing/tabulate_output_iterator.cu
@@ -127,7 +127,7 @@ void TestTabulateOutputIterator()
                                                  device_write_first_op<it_t>>::type;
 
   // Construct tabulate_output_iterator
-  op_t op{output.begin()};
+  const op_t op{output.begin()};
   auto tabulate_out_it = thrust::make_tabulate_output_iterator(op);
 
   // Prepare input
@@ -160,7 +160,7 @@ void TestTabulateOutputIterator()
   using op_t     = host_write_op<vec_it_t>;
 
   vector_t out(4, 42);
-  thrust::tabulate_output_iterator<op_t> tabulate_out_it{op_t{out.begin()}};
+  thrust::tabulate_output_iterator<op_t> tabulate_out_it{op_t{out.begin()}}; // NOLINT(misc-const-correctness)
 
   tabulate_out_it[1] = 2;
   vector_t ref{42, 2, 42, 42};

--- a/thrust/testing/transform_input_output_iterator.cu
+++ b/thrust/testing/transform_input_output_iterator.cu
@@ -62,6 +62,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformInputOutputIterator()
   thrust::sequence(input.begin(), input.end(), 1);
 
   // construct transform_iterator
+  // NOLINTNEXTLINE(misc-const-correctness)
   thrust::transform_input_output_iterator<InputFunction, OutputFunction, Iterator> transform_iter(
     squared.begin(), InputFunction(), OutputFunction());
 

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -54,7 +54,7 @@ void TestTransformIterator()
   thrust::sequence(input.begin(), input.end(), 1);
 
   // construct transform_iterator
-  thrust::transform_iterator<UnaryFunction, Iterator> iter(input.begin(), UnaryFunction());
+  const thrust::transform_iterator<UnaryFunction, Iterator> iter(input.begin(), UnaryFunction());
 
   thrust::copy(iter, iter + 4, output.begin());
 
@@ -78,7 +78,7 @@ void TestMakeTransformIterator()
   thrust::sequence(input.begin(), input.end(), 1);
 
   // construct transform_iterator
-  thrust::transform_iterator<UnaryFunction, Iterator> iter(input.begin(), UnaryFunction());
+  const thrust::transform_iterator<UnaryFunction, Iterator> iter(input.begin(), UnaryFunction());
 
   thrust::copy(thrust::make_transform_iterator(input.begin(), UnaryFunction()),
                thrust::make_transform_iterator(input.end(), UnaryFunction()),

--- a/thrust/testing/transform_output_iterator.cu
+++ b/thrust/testing/transform_output_iterator.cu
@@ -54,6 +54,7 @@ void TestTransformOutputIterator()
   thrust::sequence(input.begin(), input.end(), T{1});
 
   // construct transform_iterator
+  // NOLINTNEXTLINE(misc-const-correctness)
   thrust::transform_output_iterator<UnaryFunction, Iterator> output_iter(output.begin(), UnaryFunction());
 
   thrust::copy(input.begin(), input.end(), output_iter);

--- a/thrust/testing/transform_reduce.cu
+++ b/thrust/testing/transform_reduce.cu
@@ -17,7 +17,7 @@ void TestTransformReduceDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_reduce(sys, vec.begin(), vec.begin(), 0, 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -48,8 +48,9 @@ void TestTransformReduceSimple()
 
   Vector data{1, -2, 3};
 
-  T init   = 10;
-  T result = thrust::transform_reduce(data.begin(), data.end(), ::cuda::std::negate<T>(), init, ::cuda::std::plus<T>());
+  const T init = 10;
+  const T result =
+    thrust::transform_reduce(data.begin(), data.end(), ::cuda::std::negate<T>(), init, ::cuda::std::plus<T>());
 
   ASSERT_EQUAL(result, 8);
 }
@@ -75,8 +76,8 @@ DECLARE_VARIABLE_UNITTEST(TestTransformReduce);
 template <typename T>
 void TestTransformReduceFromConst(const size_t n)
 {
-  thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
-  thrust::device_vector<T> d_data = h_data;
+  const thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
+  const thrust::device_vector<T> d_data = h_data;
 
   T init = 13;
 
@@ -95,9 +96,10 @@ void TestTransformReduceCountingIterator()
   using T     = typename Vector::value_type;
   using space = typename thrust::iterator_system<typename Vector::iterator>::type;
 
-  thrust::counting_iterator<T, space> first(1);
+  const thrust::counting_iterator<T, space> first(1);
 
-  T result = thrust::transform_reduce(first, first + 3, ::cuda::std::negate<short>(), 0, ::cuda::std::plus<short>());
+  const T result =
+    thrust::transform_reduce(first, first + 3, ::cuda::std::negate<short>(), 0, ::cuda::std::plus<short>());
 
   ASSERT_EQUAL(result, -6);
 }

--- a/thrust/testing/transform_scan.cu
+++ b/thrust/testing/transform_scan.cu
@@ -23,7 +23,7 @@ void TestTransformInclusiveScanDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_inclusive_scan(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -42,7 +42,7 @@ void TestTransformInclusiveScanInitDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_inclusive_scan(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -80,7 +80,7 @@ void TestTransformExclusiveScanDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::transform_exclusive_scan(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0, 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -222,9 +222,9 @@ void TestTransformInclusiveScanDifferentTypes()
 
   thrust::host_vector<Record> h_input{{1}, {3}, {-2}, {4}, {-5}};
   thrust::host_vector<int> h_output(5);
-  thrust::host_vector<int> result{-1, -4, -2, -6, -1};
+  const thrust::host_vector<int> result{-1, -4, -2, -6, -1};
 
-  thrust::host_vector<Record> input_copy(h_input);
+  const thrust::host_vector<Record> input_copy(h_input);
 
   h_iter = thrust::transform_inclusive_scan(
     h_input.begin(), h_input.end(), h_output.begin(), negate{}, ::cuda::std::plus<int>{});
@@ -306,7 +306,7 @@ void TestTransformScanCountingIterator()
   using T     = typename Vector::value_type;
   using space = typename thrust::iterator_system<typename Vector::iterator>::type;
 
-  thrust::counting_iterator<T, space> first(1);
+  const thrust::counting_iterator<T, space> first(1);
 
   Vector result(3);
 
@@ -325,7 +325,7 @@ struct TestTransformScanToDiscardIterator
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
     thrust::device_vector<T> d_input = h_input;
 
-    thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
+    const thrust::discard_iterator<> reference(static_cast<std::ptrdiff_t>(n));
 
     thrust::discard_iterator<> h_result = thrust::transform_inclusive_scan(
       h_input.begin(), h_input.end(), thrust::make_discard_iterator(), ::cuda::std::negate<T>(), ::cuda::std::plus<T>());
@@ -502,7 +502,7 @@ void TestTransformScanEdgeCases()
       vec.begin(), vec.end(), vec.begin(), ::cuda::std::negate<int>(), 10, ::cuda::std::multiplies<>{});
     ASSERT_EQUAL((vec.end() == r), true);
 
-    thrust::device_vector<int> expected = {10, -20, 60, -240};
+    const thrust::device_vector<int> expected = {10, -20, 60, -240};
     ASSERT_EQUAL(vec, expected);
   }
 
@@ -535,7 +535,7 @@ void TestTransformScanEdgeCases()
       d_input.begin(), d_input.end(), d_output.begin(), ::cuda::std::negate<int>(), 2, ::cuda::std::multiplies<>{});
     ASSERT_EQUAL((d_output.end() == r), true);
 
-    thrust::device_vector<int> expected = {-6, 42};
+    const thrust::device_vector<int> expected = {-6, 42};
     ASSERT_EQUAL(d_output, expected);
   }
 }

--- a/thrust/testing/tuple.cu
+++ b/thrust/testing/tuple.cu
@@ -460,13 +460,13 @@ DECLARE_GENERIC_UNITTEST_WITH_TYPES(TestTupleTie, NumericTypes);
 
 void TestTupleSwap()
 {
-  int a = 7;
-  int b = 13;
-  int c = 42;
+  const int a = 7;
+  const int b = 13;
+  const int c = 42;
 
-  int x = 77;
-  int y = 1313;
-  int z = 4242;
+  const int x = 77;
+  const int y = 1313;
+  const int z = 4242;
 
   thrust::tuple<int, int, int> t1(a, b, c);
   thrust::tuple<int, int, int> t2(x, y, z);
@@ -489,7 +489,7 @@ void TestTupleSwap()
   thrust::swap_ranges(h_v1.begin(), h_v1.end(), h_v2.begin());
   thrust::swap_ranges(d_v1.begin(), d_v1.end(), d_v2.begin());
 
-  swappable_tuple ref(user_swappable(true), user_swappable(true), user_swappable(true), user_swappable(true));
+  const swappable_tuple ref(user_swappable(true), user_swappable(true), user_swappable(true), user_swappable(true));
 
   ASSERT_EQUAL_QUIET(ref, h_v1[0]);
   ASSERT_EQUAL_QUIET(ref, h_v1[0]);

--- a/thrust/testing/tuple_reduce.cu
+++ b/thrust/testing/tuple_reduce.cu
@@ -45,10 +45,10 @@ struct TestTupleReduce
     cuda::std::tuple<T, T> zero(0, 0);
 
     // sum on host
-    cuda::std::tuple<T, T> h_result = thrust::reduce(h_tuples.begin(), h_tuples.end(), zero, SumTupleFunctor());
+    const cuda::std::tuple<T, T> h_result = thrust::reduce(h_tuples.begin(), h_tuples.end(), zero, SumTupleFunctor());
 
     // sum on device
-    cuda::std::tuple<T, T> d_result = thrust::reduce(d_tuples.begin(), d_tuples.end(), zero, SumTupleFunctor());
+    const cuda::std::tuple<T, T> d_result = thrust::reduce(d_tuples.begin(), d_tuples.end(), zero, SumTupleFunctor());
 
     ASSERT_EQUAL_QUIET(h_result, d_result);
   }

--- a/thrust/testing/tuple_scan.cu
+++ b/thrust/testing/tuple_scan.cu
@@ -44,7 +44,7 @@ struct TestTupleScan
     thrust::device_vector<cuda::std::tuple<T, T>> d_input = h_input;
 
     // allocate output
-    cuda::std::tuple<T, T> zero(0, 0);
+    const cuda::std::tuple<T, T> zero(0, 0);
     thrust::host_vector<cuda::std::tuple<T, T>> h_output(n, zero);
     thrust::device_vector<cuda::std::tuple<T, T>> d_output(n, zero);
 

--- a/thrust/testing/uninitialized_copy.cu
+++ b/thrust/testing/uninitialized_copy.cu
@@ -17,7 +17,7 @@ void TestUninitializedCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::uninitialized_copy(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -53,7 +53,7 @@ void TestUninitializedCopyNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::uninitialized_copy_n(sys, vec.begin(), vec.size(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());

--- a/thrust/testing/uninitialized_fill.cu
+++ b/thrust/testing/uninitialized_fill.cu
@@ -16,7 +16,7 @@ void TestUninitializedFillDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::uninitialized_fill(sys, vec.begin(), vec.begin(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -50,7 +50,7 @@ void TestUninitializedFillNDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::uninitialized_fill_n(sys, vec.begin(), vec.size(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -68,7 +68,7 @@ void TestUninitializedFillNDispatchImplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::uninitialized_fill_n(sys, vec.begin(), vec.size(), 0);
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -133,14 +133,14 @@ struct TestUninitializedFillNonPOD
 {
   void operator()(const size_t)
   {
-    using T                 = CopyConstructTest;
-    thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
+    using T                       = CopyConstructTest;
+    const thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
 
-    T exemplar;
+    const T exemplar;
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_device);
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_host);
 
-    T host_copy_of_exemplar(exemplar); // NOLINT(performance-unnecessary-copy-initialization)
+    const T host_copy_of_exemplar(exemplar); // NOLINT(performance-unnecessary-copy-initialization)
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_device);
     ASSERT_EQUAL(true, exemplar.copy_constructed_on_host);
 
@@ -201,14 +201,14 @@ struct TestUninitializedFillNNonPOD
 {
   void operator()(const size_t)
   {
-    using T                 = CopyConstructTest;
-    thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
+    using T                       = CopyConstructTest;
+    const thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
 
-    T exemplar;
+    const T exemplar;
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_device);
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_host);
 
-    T host_copy_of_exemplar(exemplar); // NOLINT(performance-unnecessary-copy-initialization)
+    const T host_copy_of_exemplar(exemplar); // NOLINT(performance-unnecessary-copy-initialization)
     ASSERT_EQUAL(false, exemplar.copy_constructed_on_device);
     ASSERT_EQUAL(true, exemplar.copy_constructed_on_host);
 

--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -18,7 +18,7 @@ void TestUniqueDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::unique(sys, vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -53,7 +53,7 @@ void TestUniqueCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::unique_copy(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -90,7 +90,7 @@ void TestUniqueCountDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::unique_count(sys, vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -238,12 +238,12 @@ struct TestUniqueCopyToDiscardIterator
     thrust::host_vector<T> h_unique = h_data;
     h_unique.erase(thrust::unique(h_unique.begin(), h_unique.end()), h_unique.end());
 
-    thrust::discard_iterator<> reference(h_unique.size());
+    const thrust::discard_iterator<> reference(h_unique.size());
 
-    thrust::discard_iterator<> h_result =
+    const thrust::discard_iterator<> h_result =
       thrust::unique_copy(h_data.begin(), h_data.end(), thrust::make_discard_iterator());
 
-    thrust::discard_iterator<> d_result =
+    const thrust::discard_iterator<> d_result =
       thrust::unique_copy(d_data.begin(), d_data.end(), thrust::make_discard_iterator());
 
     ASSERT_EQUAL_QUIET(reference, h_result);
@@ -259,11 +259,11 @@ void TestUniqueCountSimple()
 
   Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
-  int count = thrust::unique_count(data.begin(), data.end());
+  const int count = thrust::unique_count(data.begin(), data.end());
 
   ASSERT_EQUAL(count, 7);
 
-  int div_10_count = thrust::unique_count(data.begin(), data.end(), is_equal_div_10_unique<T>());
+  const int div_10_count = thrust::unique_count(data.begin(), data.end(), is_equal_div_10_unique<T>());
 
   ASSERT_EQUAL(div_10_count, 3);
 }

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -34,7 +34,7 @@ void TestUniqueByKeyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::unique_by_key(sys, vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -77,7 +77,7 @@ void TestUniqueByKeyCopyDispatchExplicit()
 {
   thrust::device_vector<int> vec(1);
 
-  my_system sys(0);
+  my_system sys(0); // NOLINT(misc-const-correctness)
   thrust::unique_by_key_copy(sys, vec.begin(), vec.begin(), vec.begin(), vec.begin(), vec.begin());
 
   ASSERT_EQUAL(true, sys.is_valid());
@@ -246,13 +246,13 @@ struct TestUniqueByKey
     using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
     using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
-    HostIteratorPair h_last   = thrust::unique_by_key(h_keys.begin(), h_keys.end(), h_vals.begin());
-    DeviceIteratorPair d_last = thrust::unique_by_key(d_keys.begin(), d_keys.end(), d_vals.begin());
+    const HostIteratorPair h_last   = thrust::unique_by_key(h_keys.begin(), h_keys.end(), h_vals.begin());
+    const DeviceIteratorPair d_last = thrust::unique_by_key(d_keys.begin(), d_keys.end(), d_vals.begin());
 
     ASSERT_EQUAL(h_last.first - h_keys.begin(), d_last.first - d_keys.begin());
     ASSERT_EQUAL(h_last.second - h_vals.begin(), d_last.second - d_vals.begin());
 
-    size_t N = h_last.first - h_keys.begin();
+    const size_t N = h_last.first - h_keys.begin();
 
     h_keys.resize(N);
     h_vals.resize(N);
@@ -290,15 +290,15 @@ struct TestUniqueCopyByKey
     using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
     using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
-    HostIteratorPair h_last = thrust::unique_by_key_copy(
+    const HostIteratorPair h_last = thrust::unique_by_key_copy(
       h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
-    DeviceIteratorPair d_last = thrust::unique_by_key_copy(
+    const DeviceIteratorPair d_last = thrust::unique_by_key_copy(
       d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys_output.begin(), d_vals_output.begin());
 
     ASSERT_EQUAL(h_last.first - h_keys_output.begin(), d_last.first - d_keys_output.begin());
     ASSERT_EQUAL(h_last.second - h_vals_output.begin(), d_last.second - d_vals_output.begin());
 
-    size_t N = h_last.first - h_keys_output.begin();
+    const size_t N = h_last.first - h_keys_output.begin();
 
     h_keys_output.resize(N);
     h_vals_output.resize(N);
@@ -332,16 +332,18 @@ struct TestUniqueCopyByKeyToDiscardIterator
     thrust::host_vector<K> h_unique_keys = h_keys;
     h_unique_keys.erase(thrust::unique(h_unique_keys.begin(), h_unique_keys.end()), h_unique_keys.end());
 
-    size_t num_unique_keys = h_unique_keys.size();
+    const size_t num_unique_keys = h_unique_keys.size();
 
     // mask both outputs
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::unique_by_key_copy(
-      h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 =
+      thrust::unique_by_key_copy(
+        h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::unique_by_key_copy(
-      d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 =
+      thrust::unique_by_key_copy(
+        d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
 
-    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 = cuda::std::make_pair(
+    const cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 = cuda::std::make_pair(
       thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)),
       thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)));
 
@@ -349,19 +351,19 @@ struct TestUniqueCopyByKeyToDiscardIterator
     ASSERT_EQUAL_QUIET(reference1, d_result1);
 
     // mask values output
-    cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_result2 =
+    const cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::unique_by_key_copy(
         h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), thrust::make_discard_iterator());
 
-    cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_result2 =
+    const cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::unique_by_key_copy(
         d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys_output.begin(), thrust::make_discard_iterator());
 
-    cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_reference2 =
+    const cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_reference2 =
       cuda::std::make_pair(h_keys_output.begin() + static_cast<std::ptrdiff_t>(num_unique_keys),
                            thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)));
 
-    cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_reference2 =
+    const cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_reference2 =
       cuda::std::make_pair(d_keys_output.begin() + static_cast<std::ptrdiff_t>(num_unique_keys),
                            thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)));
 
@@ -370,19 +372,19 @@ struct TestUniqueCopyByKeyToDiscardIterator
     ASSERT_EQUAL_QUIET(d_reference2, d_result2);
 
     // mask keys output
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_result3 =
       thrust::unique_by_key_copy(
         h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), h_vals_output.begin());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_result3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_result3 =
       thrust::unique_by_key_copy(
         d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), d_vals_output.begin());
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)),
                            h_vals_output.begin() + static_cast<std::ptrdiff_t>(num_unique_keys));
 
-    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_reference3 =
+    const cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_reference3 =
       cuda::std::make_pair(thrust::make_discard_iterator(static_cast<::cuda::std::ptrdiff_t>(num_unique_keys)),
                            d_vals_output.begin() + static_cast<std::ptrdiff_t>(num_unique_keys));
 
@@ -407,8 +409,8 @@ struct TestUniqueCopyByKeyLargeInput
     using index_type = std::int64_t;
 
     const std::size_t num_items = 4400000000ULL;
-    thrust::host_vector<type> reference_keys{static_cast<type>(0), static_cast<type>(1), static_cast<type>(0)};
-    thrust::host_vector<index_type> reference_values{0, 4300000000ULL, 4300000001ULL};
+    const thrust::host_vector<type> reference_keys{static_cast<type>(0), static_cast<type>(1), static_cast<type>(0)};
+    const thrust::host_vector<index_type> reference_values{0, 4300000000ULL, 4300000001ULL};
 
     auto keys_in   = thrust::make_transform_iterator(thrust::make_counting_iterator(0ULL), index_to_value_t<type>{});
     auto values_in = thrust::make_counting_iterator(0ULL);

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -408,10 +408,10 @@ void assert_equal(
 
   bool failure = false;
 
-  difference_type length1 = ::cuda::std::distance(first1, last1);
-  difference_type length2 = ::cuda::std::distance(first2, last2);
+  const difference_type length1 = ::cuda::std::distance(first1, last1);
+  const difference_type length2 = ::cuda::std::distance(first2, last2);
 
-  difference_type min_length = ::cuda::std::min(length1, length2);
+  const difference_type min_length = ::cuda::std::min(length1, length2);
 
   unittest::UnitTestFailure f;
   f << "[" << filename << ":" << lineno << "] ";
@@ -514,7 +514,7 @@ void assert_equal(const THRUST_NS_QUALIFIER::host_vector<T, Alloc1>& A,
                   const std::string& filename = "unknown",
                   int lineno                  = -1)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
   assert_equal(A, B_host, filename, lineno);
 }
 
@@ -524,7 +524,7 @@ void assert_equal(const THRUST_NS_QUALIFIER::device_vector<T, Alloc1>& A,
                   const std::string& filename = "unknown",
                   int lineno                  = -1)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc2> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc2> A_host = A;
   assert_equal(A_host, B, filename, lineno);
 }
 
@@ -534,8 +534,8 @@ void assert_equal(const THRUST_NS_QUALIFIER::device_vector<T, Alloc1>& A,
                   const std::string& filename = "unknown",
                   int lineno                  = -1)
 {
-  THRUST_NS_QUALIFIER::host_vector<T> A_host = A;
-  THRUST_NS_QUALIFIER::host_vector<T> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T> B_host = B;
   assert_equal(A_host, B_host, filename, lineno);
 }
 
@@ -572,7 +572,7 @@ void assert_equal(const THRUST_NS_QUALIFIER::device_vector<T, Alloc1>& A,
                   const std::string& filename = "unknown",
                   int lineno                  = -1)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> A_host = A;
   assert_equal(A_host, B, filename, lineno);
 }
 
@@ -582,7 +582,7 @@ void assert_equal(const THRUST_NS_QUALIFIER::universal_vector<T, Alloc1>& A,
                   const std::string& filename = "unknown",
                   int lineno                  = -1)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
   assert_equal(A, B_host, filename, lineno);
 }
 
@@ -616,7 +616,7 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
   assert_almost_equal(A, B_host, filename, lineno, a_tol, r_tol);
 }
 
@@ -629,7 +629,7 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc2> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc2> A_host = A;
   assert_almost_equal(A_host, B, filename, lineno, a_tol, r_tol);
 }
 
@@ -642,8 +642,8 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  THRUST_NS_QUALIFIER::host_vector<T> A_host = A;
-  THRUST_NS_QUALIFIER::host_vector<T> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T> B_host = B;
   assert_almost_equal(A_host, B_host, filename, lineno, a_tol, r_tol);
 }
 
@@ -692,7 +692,7 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> A_host = A;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> A_host = A;
   assert_almost_equal(A_host, B, filename, lineno, a_tol, r_tol);
 }
 
@@ -705,7 +705,7 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
+  const THRUST_NS_QUALIFIER::host_vector<T, Alloc1> B_host = B;
   assert_almost_equal(A, B_host, filename, lineno, a_tol, r_tol);
 }
 

--- a/thrust/testing/unittest/testframework.h
+++ b/thrust/testing/unittest/testframework.h
@@ -312,7 +312,7 @@ inline constexpr size_t max_threshold     = (std::numeric_limits<size_t>::max)()
 
 inline std::vector<size_t> test_sizes = [] {
   std::vector<size_t> v;
-  for (size_t s : standard_test_sizes)
+  for (const size_t s : standard_test_sizes)
   {
     if (s <= default_threshold)
     {

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -22,11 +22,11 @@ DECLARE_VECTOR_UNITTEST(TestVectorZeroSize);
 
 void TestVectorBool()
 {
-  thrust::host_vector<bool> h{true, false, true};
-  thrust::device_vector<bool> d{true, false, true};
+  const thrust::host_vector<bool> h{true, false, true};
+  const thrust::device_vector<bool> d{true, false, true};
 
-  thrust::host_vector<bool> h_ref{true, false, true};
-  thrust::device_vector<bool> d_ref{true, false, true};
+  const thrust::host_vector<bool> h_ref{true, false, true};
+  const thrust::device_vector<bool> d_ref{true, false, true};
   ASSERT_EQUAL(h, h_ref);
   ASSERT_EQUAL(d, d_ref);
 }
@@ -113,12 +113,12 @@ void TestVectorFromSTLVector()
 {
   using T = typename Vector::value_type;
 
-  std::vector<T> stl_vector{0, 1, 2};
+  const std::vector<T> stl_vector{0, 1, 2};
 
   thrust::host_vector<T> v(stl_vector);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  thrust::host_vector<T> ref{0, 1, 2};
+  const thrust::host_vector<T> ref{0, 1, 2};
   ASSERT_EQUAL(v, ref);
 
   v = stl_vector;
@@ -137,7 +137,7 @@ void TestVectorFillAssign()
   v.assign(3, 13);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  thrust::host_vector<T> ref{13, 13, 13};
+  const thrust::host_vector<T> ref{13, 13, 13};
   ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorFillAssign);
@@ -281,7 +281,7 @@ void TestVectorAssignFromSTLVector()
   v.assign(stl_vector.begin(), stl_vector.end());
 
   ASSERT_EQUAL(v.size(), 3lu);
-  thrust::host_vector<T> ref{0, 1, 2};
+  const thrust::host_vector<T> ref{0, 1, 2};
   ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromSTLVector);
@@ -525,17 +525,17 @@ DECLARE_VECTOR_UNITTEST(TestVectorEraseRange);
 
 void TestVectorEquality()
 {
-  thrust::host_vector<int> h_a{0, 1, 2};
-  thrust::host_vector<int> h_b{0, 1, 3};
-  thrust::host_vector<int> h_c(3);
+  const thrust::host_vector<int> h_a{0, 1, 2};
+  const thrust::host_vector<int> h_b{0, 1, 3};
+  const thrust::host_vector<int> h_c(3);
 
-  thrust::device_vector<int> d_a{0, 1, 2};
-  thrust::device_vector<int> d_b{0, 1, 3};
-  thrust::device_vector<int> d_c(3);
+  const thrust::device_vector<int> d_a{0, 1, 2};
+  const thrust::device_vector<int> d_b{0, 1, 3};
+  const thrust::device_vector<int> d_c(3);
 
-  std::vector<int> s_a{0, 1, 2};
-  std::vector<int> s_b{0, 1, 3};
-  std::vector<int> s_c(3);
+  const std::vector<int> s_a{0, 1, 2};
+  const std::vector<int> s_b{0, 1, 3};
+  const std::vector<int> s_c(3);
 
   ASSERT_EQUAL((h_a == h_a), true);
   ASSERT_EQUAL((h_a == d_a), true);
@@ -623,17 +623,17 @@ DECLARE_UNITTEST(TestVectorEquality);
 
 void TestVectorInequality()
 {
-  thrust::host_vector<int> h_a{0, 1, 2};
-  thrust::host_vector<int> h_b{0, 1, 3};
-  thrust::host_vector<int> h_c(3);
+  const thrust::host_vector<int> h_a{0, 1, 2};
+  const thrust::host_vector<int> h_b{0, 1, 3};
+  const thrust::host_vector<int> h_c(3);
 
-  thrust::device_vector<int> d_a{0, 1, 2};
-  thrust::device_vector<int> d_b{0, 1, 3};
-  thrust::device_vector<int> d_c(3);
+  const thrust::device_vector<int> d_a{0, 1, 2};
+  const thrust::device_vector<int> d_b{0, 1, 3};
+  const thrust::device_vector<int> d_c(3);
 
-  std::vector<int> s_a{0, 1, 2};
-  std::vector<int> s_b{0, 1, 3};
-  std::vector<int> s_c(3);
+  const std::vector<int> s_a{0, 1, 2};
+  const std::vector<int> s_b{0, 1, 3};
+  const std::vector<int> s_c(3);
 
   ASSERT_EQUAL((h_a != h_a), false);
   ASSERT_EQUAL((h_a != d_a), false);
@@ -761,7 +761,7 @@ void TestVectorReserving()
 
   ASSERT_GEQUAL(v.capacity(), 3lu);
 
-  size_t old_capacity = v.capacity();
+  const size_t old_capacity = v.capacity();
 
   v.reserve(0);
 
@@ -773,7 +773,7 @@ template <class Vector>
 void TestVectorUninitialisedCopy()
 {
   thrust::device_vector<int> v;
-  std::vector<int> std_vector;
+  const std::vector<int> std_vector;
 
   v = std_vector;
 
@@ -831,13 +831,13 @@ void TestVectorContainingLargeType()
   const static int N = 100;
   using T            = LargeStruct<N>;
 
-  thrust::device_vector<T> dv1;
-  thrust::host_vector<T> hv1;
+  const thrust::device_vector<T> dv1;
+  const thrust::host_vector<T> hv1;
 
   ASSERT_EQUAL_QUIET(dv1, hv1);
 
-  thrust::device_vector<T> dv2(20);
-  thrust::host_vector<T> hv2(20);
+  const thrust::device_vector<T> dv2(20);
+  const thrust::host_vector<T> hv2(20);
 
   ASSERT_EQUAL_QUIET(dv2, hv2);
 
@@ -941,19 +941,19 @@ void TestVectorDefaultInitCtor()
 {
   // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
   {
-    thrust::host_vector<int> hv(10, thrust::default_init);
-    thrust::device_vector<int> dv(10, thrust::default_init);
+    const thrust::host_vector<int> hv(10, thrust::default_init);
+    const thrust::device_vector<int> dv(10, thrust::default_init);
   }
 
   // non-trivially-constructible type: check that initialization was performed
   {
-    thrust::host_vector<IntWithInit> hv(10, thrust::default_init);
+    const thrust::host_vector<IntWithInit> hv(10, thrust::default_init);
     for (auto e : hv)
     {
       ASSERT_EQUAL(e.value, 42);
     }
 
-    thrust::device_vector<IntWithInit> dv(10, thrust::default_init);
+    const thrust::device_vector<IntWithInit> dv(10, thrust::default_init);
     for (auto e : dv)
     {
       ASSERT_EQUAL(static_cast<IntWithInit>(e).value, 42);
@@ -966,8 +966,8 @@ void TestVectorNoInitCtor()
 {
   // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
   {
-    thrust::host_vector<int> hv(10, thrust::no_init);
-    thrust::device_vector<int> dv(10, thrust::no_init);
+    const thrust::host_vector<int> hv(10, thrust::no_init);
+    const thrust::device_vector<int> dv(10, thrust::no_init);
   }
 
   // non-trivially-constructible type: those should fail to compile

--- a/thrust/testing/vector_allocators.cu
+++ b/thrust/testing/vector_allocators.cu
@@ -123,8 +123,8 @@ template <typename Vector>
 void TestVectorAllocatorConstructors()
 {
   using Alloc = typename Vector::allocator_type;
-  Alloc alloc1(1);
-  Alloc alloc2(2);
+  const Alloc alloc1(1);
+  const Alloc alloc2(2);
 
   Vector v1(alloc1);
   ASSERT_EQUAL(v1.get_allocator(), alloc1);
@@ -180,8 +180,8 @@ void TestVectorAllocatorPropagateOnCopyAssignment()
     cuda::std::allocator_traits<typename Vector::allocator_type>::propagate_on_container_copy_assignment::value, true);
 
   using Alloc = typename Vector::allocator_type;
-  Alloc alloc1(1);
-  Alloc alloc2(2);
+  const Alloc alloc1(1);
+  const Alloc alloc2(2);
 
   Vector v1(10, alloc1);
   Vector v2(15, alloc2);
@@ -213,8 +213,8 @@ void TestVectorAllocatorPropagateOnMoveAssignment()
     cuda::std::allocator_traits<typename Vector::allocator_type>::propagate_on_container_copy_assignment::value, true);
 
   using Alloc = typename Vector::allocator_type;
-  Alloc alloc1(1);
-  Alloc alloc2(2);
+  const Alloc alloc1(1);
+  const Alloc alloc2(2);
 
   {
     Vector v1(10, alloc1);
@@ -245,8 +245,8 @@ template <typename Vector>
 void TestVectorAllocatorPropagateOnSwap()
 {
   using Alloc = typename Vector::allocator_type;
-  Alloc alloc1(1);
-  Alloc alloc2(2);
+  const Alloc alloc1(1);
+  const Alloc alloc2(2);
 
   Vector v1(10, alloc1);
   Vector v2(17, alloc1);

--- a/thrust/testing/vector_insert.cu
+++ b/thrust/testing/vector_insert.cu
@@ -122,7 +122,7 @@ struct TestVectorRangeInsert
     }
 
     // choose insertion position at random
-    size_t position = n > 0 ? (size_t) h_src[n + 2] % n : 0;
+    const size_t position = n > 0 ? (size_t) h_src[n + 2] % n : 0;
 
     // insert on host
     h_dst.insert(h_dst.begin() + position, h_src.begin() + begin, h_src.begin() + end);
@@ -242,10 +242,10 @@ struct TestVectorFillInsert
     thrust::device_vector<T> d_dst = h_dst;
 
     // choose insertion position at random
-    size_t position = n > 0 ? (size_t) h_dst[n] % n : 0;
+    const size_t position = n > 0 ? (size_t) h_dst[n] % n : 0;
 
     // choose insertion size at random
-    size_t insertion_size = n > 0 ? (size_t) h_dst[n] % n : 13;
+    const size_t insertion_size = n > 0 ? (size_t) h_dst[n] % n : 13;
 
     // insert on host
     h_dst.insert(h_dst.begin() + position, insertion_size, 13);

--- a/thrust/testing/vector_manipulation.cu
+++ b/thrust/testing/vector_manipulation.cu
@@ -42,7 +42,7 @@ void TestVectorManipulation(size_t n)
   ASSERT_EQUAL((tail == std::vector<T>(20, T(11))), true);
 
   // shrinking a vector should not invalidate iterators
-  Iterator first = vec1.begin();
+  const Iterator first = vec1.begin();
   vec1.resize(10);
   ASSERT_EQUAL_QUIET(first, vec1.begin());
 

--- a/thrust/testing/zip_function.cu
+++ b/thrust/testing/zip_function.cu
@@ -92,7 +92,7 @@ struct TestZipFunctionMixed
     thrust::device_vector<uint32_t> vecA{0, 0, 2, 0};
     thrust::device_vector<uint32_t> vecB{0, 2, 2, 2};
     thrust::device_vector<float> vecC{88.0f, 88.0f, 89.0f, 89.0f};
-    thrust::device_vector<float> expected{88.0f, 89.0f};
+    const thrust::device_vector<float> expected{88.0f, 89.0f};
 
     auto inputKeyItBegin =
       thrust::make_zip_iterator(thrust::make_zip_iterator(vecA.begin(), vecB.begin()), vecC.begin());
@@ -132,7 +132,7 @@ struct TestNestedZipFunction
     thrust::device_vector<int> PY{0, 1, 2, 2};
     thrust::device_vector<uint32_t> SS{0, 1, 2};
     thrust::device_vector<uint32_t> ST{1, 2, 3};
-    thrust::device_vector<float> vecC{88.0f, 88.0f, 89.0f, 89.0f};
+    const thrust::device_vector<float> vecC{88.0f, 88.0f, 89.0f, 89.0f};
 
     auto segIt = thrust::make_zip_iterator(
       thrust::make_zip_iterator(thrust::make_permutation_iterator(PX.begin(), SS.begin()),
@@ -142,7 +142,7 @@ struct TestNestedZipFunction
     auto idAndSegIt = thrust::make_zip_iterator(thrust::make_counting_iterator(0u), segIt);
 
     thrust::device_vector<bool> isMH{false, false, false};
-    thrust::device_vector<bool> expected{false, false, true};
+    const thrust::device_vector<bool> expected{false, false, true};
     thrust::transform(
       idAndSegIt, idAndSegIt + static_cast<std::ptrdiff_t>(SS.size()), isMH.begin(), NestedFunctionCall{});
     ASSERT_EQUAL(isMH, expected);

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -144,7 +144,7 @@ struct TestZipIteratorConstructionFromIterators
     using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
     // test construction
-    thrust::zip_iterator iter0(v0.begin(), v1.begin());
+    const thrust::zip_iterator iter0(v0.begin(), v1.begin());
     ASSERT_EQUAL(true, iter0 == ZipIterator{cuda::std::make_tuple(v0.begin(), v1.begin())});
   }
 
@@ -176,14 +176,14 @@ struct TestZipIteratorManipulation
     using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
     // test construction from tuple
-    ZipIterator iter0 = thrust::make_zip_iterator(t);
+    const ZipIterator iter0 = thrust::make_zip_iterator(t);
     ASSERT_EQUAL(true, iter0 == ZipIterator{t});
     ASSERT_EQUAL_QUIET(v0.begin(), cuda::std::get<0>(iter0.get_iterator_tuple()));
     ASSERT_EQUAL_QUIET(v1.begin(), cuda::std::get<1>(iter0.get_iterator_tuple()));
     static_assert(cuda::std::is_same_v<decltype(thrust::zip_iterator{t}), ZipIterator>); // CTAD
 
     // test construction from pack
-    ZipIterator iter0_pack = thrust::make_zip_iterator(v0.begin(), v1.begin());
+    const ZipIterator iter0_pack = thrust::make_zip_iterator(v0.begin(), v1.begin());
     ASSERT_EQUAL(true, (iter0_pack == ZipIterator{v0.begin(), v1.begin()}));
     ASSERT_EQUAL_QUIET(v0.begin(), cuda::std::get<0>(iter0_pack.get_iterator_tuple()));
     ASSERT_EQUAL_QUIET(v1.begin(), cuda::std::get<1>(iter0_pack.get_iterator_tuple()));
@@ -194,9 +194,9 @@ struct TestZipIteratorManipulation
     ASSERT_EQUAL(*v1.begin(), cuda::std::get<1>(*iter0));
 
     // test equality
-    ZipIterator iter1 = iter0;
-    ZipIterator iter2 = thrust::make_zip_iterator(v0.begin(), v2.begin());
-    ZipIterator iter3 = thrust::make_zip_iterator(v1.begin(), v2.begin());
+    const ZipIterator iter1 = iter0;
+    const ZipIterator iter2 = thrust::make_zip_iterator(v0.begin(), v2.begin());
+    const ZipIterator iter3 = thrust::make_zip_iterator(v1.begin(), v2.begin());
     ASSERT_EQUAL(true, iter0 == iter1);
     ASSERT_EQUAL(true, iter0 == iter2);
     ASSERT_EQUAL(false, iter0 == iter3);
@@ -390,14 +390,14 @@ void TestZipIteratorCopyAoSToSoA()
 
   // host to host
   thrust::host_vector<int> h_field0(n), h_field1(n);
-  host_structure_of_arrays h_soa = thrust::make_zip_iterator(h_field0.begin(), h_field1.begin());
+  const host_structure_of_arrays h_soa = thrust::make_zip_iterator(h_field0.begin(), h_field1.begin());
 
   thrust::copy(h_aos.begin(), h_aos.end(), h_soa);
   ASSERT_EQUAL_QUIET(cuda::std::make_tuple(7, 13), h_soa[0]);
 
   // host to device
   thrust::device_vector<int> d_field0(n), d_field1(n);
-  device_structure_of_arrays d_soa = thrust::make_zip_iterator(d_field0.begin(), d_field1.begin());
+  const device_structure_of_arrays d_soa = thrust::make_zip_iterator(d_field0.begin(), d_field1.begin());
 
   thrust::copy(h_aos.begin(), h_aos.end(), d_soa);
   ASSERT_EQUAL_QUIET(cuda::std::make_tuple(7, 13), d_soa[0]);
@@ -435,8 +435,8 @@ void TestZipIteratorCopySoAToAoS()
   thrust::host_vector<int> h_field0(n, 7), h_field1(n, 13);
   thrust::device_vector<int> d_field0(n, 7), d_field1(n, 13);
 
-  host_structure_of_arrays h_soa   = thrust::make_zip_iterator(h_field0.begin(), h_field1.begin());
-  device_structure_of_arrays d_soa = thrust::make_zip_iterator(d_field0.begin(), d_field1.begin());
+  const host_structure_of_arrays h_soa   = thrust::make_zip_iterator(h_field0.begin(), h_field1.begin());
+  const device_structure_of_arrays d_soa = thrust::make_zip_iterator(d_field0.begin(), d_field1.begin());
 
   host_array_of_structures h_aos(n);
   device_array_of_structures d_aos(n);
@@ -513,7 +513,7 @@ void TestZipIteratorNestedCopy()
 
     thrust::copy_n(thrust::make_zip_iterator(thrust::make_zip_iterator(a.begin())), a.size(), b.begin());
 
-    decltype(b) b_expected(b.size(), cuda::std::make_tuple(cuda::std::make_tuple(1)));
+    const decltype(b) b_expected(b.size(), cuda::std::make_tuple(cuda::std::make_tuple(1)));
 
     ASSERT_EQUAL_QUIET(b, b_expected);
   }
@@ -527,7 +527,8 @@ void TestZipIteratorNestedCopy()
                    a.size(),
                    b.begin());
 
-    decltype(b) b_expected(b.size(), cuda::std::make_tuple(cuda::std::make_tuple(1, 1), cuda::std::make_tuple(1, 1)));
+    const decltype(b) b_expected(
+      b.size(), cuda::std::make_tuple(cuda::std::make_tuple(1, 1), cuda::std::make_tuple(1, 1)));
 
     ASSERT_EQUAL_QUIET(b, b_expected);
   }
@@ -540,7 +541,7 @@ void TestZipIteratorNestedCopy()
 
     thrust::copy_n(thrust::make_zip_iterator(a.begin(), a.begin(), a.begin(), a.begin()), a.size(), b.begin());
 
-    decltype(b) b_expected(
+    const decltype(b) b_expected(
       b.size(),
       cuda::std::make_tuple(cuda::std::make_tuple(1, 1),
                             cuda::std::make_tuple(1, 1),


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `thrust/testing/`
  - `thrust/examples/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.