### PR TITLE
[cudax] `misc-const-correctness`

### DIFF
--- a/cudax/benchmarks/bench/copy/copy_bench.cu
+++ b/cudax/benchmarks/bench/copy/copy_bench.cu
@@ -61,17 +61,17 @@ void bench_copy(nvbench::state& state,
   using strides_t = cuda::dstrides<idx_t, Rank>;
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
 
-  extents_t ext(shape);
+  const extents_t ext(shape);
   auto src_ptr = thrust::raw_pointer_cast(d_src.data()) + src_offset;
   auto dst_ptr = thrust::raw_pointer_cast(d_dst.data()) + dst_offset;
-  mapping_t src_map(ext, strides_t(src_strides));
-  mapping_t dst_map(ext, strides_t(dst_strides));
+  const mapping_t src_map(ext, strides_t(src_strides));
+  const mapping_t dst_map(ext, strides_t(dst_strides));
 
   cuda::device_mdspan<data_t, extents_t, cuda::layout_stride_relaxed> src(src_ptr, src_map);
   cuda::device_mdspan<data_t, extents_t, cuda::layout_stride_relaxed> dst(dst_ptr, dst_map);
 
   state.exec([&](nvbench::launch& launch) {
-    cuda::stream_ref stream{launch.get_stream()};
+    const cuda::stream_ref stream{launch.get_stream()};
     cuda::experimental::copy(src, dst, stream);
   });
 }
@@ -93,8 +93,8 @@ void bench_copy(nvbench::state& state,
 // dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_0(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
-  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
+  const cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  const cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_0).set_name("contiguous (5D, int, 4GB)");
@@ -103,8 +103,8 @@ NVBENCH_BENCH(memcpy_layout_0).set_name("contiguous (5D, int, 4GB)");
 // dst: (25, 80, 70, 80, 90):(40320000, 1, 576000, 80, 6400)
 void memcpy_layout_1(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{25, 80, 70, 80, 90};
-  cuda::std::array<int, 5> strides{40320000, 1, 576000, 80, 6400};
+  const cuda::std::array<int, 5> shape{25, 80, 70, 80, 90};
+  const cuda::std::array<int, 5> strides{40320000, 1, 576000, 80, 6400};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_1).set_name("contiguous-perm (5D, int, 4GB)");
@@ -113,8 +113,8 @@ NVBENCH_BENCH(memcpy_layout_1).set_name("contiguous-perm (5D, int, 4GB)");
 // dst: (1, 25, 1, 80, 1, 70, 1, 80, 1, 90):(1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400)
 void memcpy_layout_1b(nvbench::state& state)
 {
-  cuda::std::array<int, 10> shape{1, 25, 1, 80, 1, 70, 1, 80, 1, 90};
-  cuda::std::array<int, 10> strides{1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400};
+  const cuda::std::array<int, 10> shape{1, 25, 1, 80, 1, 70, 1, 80, 1, 90};
+  const cuda::std::array<int, 10> strides{1, 40320000, 1, 1, 1, 576000, 1, 80, 1, 6400};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_1b).set_name("contiguous-1-sized (10D, int, 4GB)");
@@ -123,8 +123,8 @@ NVBENCH_BENCH(memcpy_layout_1b).set_name("contiguous-1-sized (10D, int, 4GB)");
 // dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_2(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
-  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
+  const cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  const cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, 1};
   bench_copy(state, 1, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_2).set_name("contiguous-not-aligned (5D, int, 4GB)");
@@ -133,8 +133,8 @@ NVBENCH_BENCH(memcpy_layout_2).set_name("contiguous-not-aligned (5D, int, 4GB)")
 // dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_3(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
-  cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
+  const cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
+  const cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
   bench_copy<char, int64_t>(state, 0, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_3).set_name("contiguous-small (5D, char, 4GB)");
@@ -143,8 +143,8 @@ NVBENCH_BENCH(memcpy_layout_3).set_name("contiguous-small (5D, char, 4GB)");
 // dst: (100, 70, 90, 80, 80):(40320000, 576000, 6400, 80, 1)
 void memcpy_layout_4(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
-  cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
+  const cuda::std::array<int64_t, 5> shape{100, 70, 90, 80, 80};
+  const cuda::std::array<int64_t, 5> strides{40320000, 576000, 6400, 80, 1};
   bench_copy<char, int64_t>(state, 1, shape, strides);
 }
 NVBENCH_BENCH(memcpy_layout_4).set_name("contiguous-small-not-aligned (5D, char, 4GB)");
@@ -153,8 +153,8 @@ NVBENCH_BENCH(memcpy_layout_4).set_name("contiguous-small-not-aligned (5D, char,
 // dst: (25, 70, 90, 80, 80):(40320000, 576000, 6400, 80, -1), offset=80
 void memcpy_neg(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
-  cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, -1};
+  const cuda::std::array<int, 5> shape{25, 70, 90, 80, 80};
+  const cuda::std::array<int, 5> strides{40320000, 576000, 6400, 80, -1};
   bench_copy(state, 80, shape, strides);
 }
 NVBENCH_BENCH(memcpy_neg).set_name("contiguous-negative-stride (5D, int, 4GB)");
@@ -164,8 +164,8 @@ NVBENCH_BENCH(memcpy_neg).set_name("contiguous-negative-stride (5D, int, 4GB)");
 // Copies 4GB while allocating 16GB per tensor because of the padded outer stride.
 void vectorization(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 2> shape{134217600, 32};
-  cuda::std::array<int64_t, 2> strides{128, 1};
+  const cuda::std::array<int64_t, 2> shape{134217600, 32};
+  const cuda::std::array<int64_t, 2> strides{128, 1};
   bench_copy<char, int64_t>(state, 32, shape, strides);
 }
 NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB copy, 16GB alloc)");
@@ -175,8 +175,8 @@ NVBENCH_BENCH(vectorization).set_name("vectorization (2D, char, 4GB copy, 16GB a
 // Copies 4GB while allocating 16GB per tensor because each row is padded to 128K elements.
 void block_contiguous(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{32767, (128 * 1024) / sizeof(int)};
-  cuda::std::array<int, 2> strides{128 * 1024, 1};
+  const cuda::std::array<int, 2> shape{32767, (128 * 1024) / sizeof(int)};
+  const cuda::std::array<int, 2> strides{128 * 1024, 1};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(block_contiguous).set_name("block-contiguous (2D, int, 4GB copy, 16GB alloc)");
@@ -184,16 +184,16 @@ NVBENCH_BENCH(block_contiguous).set_name("block-contiguous (2D, int, 4GB copy, 1
 
 void several_dimensions(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{64, 64, 64, 64, 64};
-  cuda::std::array<int, 5> strides{17043520 + 1, 266304 + 1, 4160 + 1, 64 + 1, 1};
+  const cuda::std::array<int, 5> shape{64, 64, 64, 64, 64};
+  const cuda::std::array<int, 5> strides{17043520 + 1, 266304 + 1, 4160 + 1, 64 + 1, 1};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(several_dimensions).set_name("several_dimensions (5D, int, 4GB)");
 
 void several_dimensions_non_square(nvbench::state& state)
 {
-  cuda::std::array<int, 5> shape{63, 65, 67, 69, 57};
-  cuda::std::array<int, 5> strides{17433131, 268202, 4003, 58, 1};
+  const cuda::std::array<int, 5> shape{63, 65, 67, 69, 57};
+  const cuda::std::array<int, 5> strides{17433131, 268202, 4003, 58, 1};
   bench_copy(state, 0, shape, strides);
 }
 NVBENCH_BENCH(several_dimensions_non_square).set_name("several_dimensions_non_square (5D, int, 4GB)");
@@ -206,126 +206,126 @@ NVBENCH_BENCH(several_dimensions_non_square).set_name("several_dimensions_non_sq
 // dst: (32768,32768):(32768,1)
 void transpose_2D_col_row(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{32768, 32768};
-  cuda::std::array<int, 2> src_strides{1, 32768};
-  cuda::std::array<int, 2> dst_strides{32768, 1};
+  const cuda::std::array<int, 2> shape{32768, 32768};
+  const cuda::std::array<int, 2> src_strides{1, 32768};
+  const cuda::std::array<int, 2> dst_strides{32768, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_col_row).set_name("transpose_2D_col_row (2D, int, 4GB)");
 
 void transpose_2D_row_col(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{32768, 32768};
-  cuda::std::array<int, 2> src_strides{32768, 1};
-  cuda::std::array<int, 2> dst_strides{1, 32768};
+  const cuda::std::array<int, 2> shape{32768, 32768};
+  const cuda::std::array<int, 2> src_strides{32768, 1};
+  const cuda::std::array<int, 2> dst_strides{1, 32768};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_row_col).set_name("transpose_2D_row_col (2D, int, 4GB)");
 
 void transpose_2D_char(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 2> shape{65536, 65536};
-  cuda::std::array<int64_t, 2> src_strides{1, 65536};
-  cuda::std::array<int64_t, 2> dst_strides{65536, 1};
+  const cuda::std::array<int64_t, 2> shape{65536, 65536};
+  const cuda::std::array<int64_t, 2> src_strides{1, 65536};
+  const cuda::std::array<int64_t, 2> dst_strides{65536, 1};
   bench_copy<char, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_char).set_name("transpose_2D_char (2D, char, 4GB)");
 
 void transpose_2D_short(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{32760, 32768 * 2};
-  cuda::std::array<int, 2> src_strides{1, 32760};
-  cuda::std::array<int, 2> dst_strides{32768 * 2, 1};
+  const cuda::std::array<int, 2> shape{32760, 32768 * 2};
+  const cuda::std::array<int, 2> src_strides{1, 32760};
+  const cuda::std::array<int, 2> dst_strides{32768 * 2, 1};
   bench_copy<short>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_short).set_name("transpose_2D_short (2D, short, 4GB)");
 
 void transpose_2D_double(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 2> shape{32768, 16384};
-  cuda::std::array<int64_t, 2> src_strides{1, 32768};
-  cuda::std::array<int64_t, 2> dst_strides{16384, 1};
+  const cuda::std::array<int64_t, 2> shape{32768, 16384};
+  const cuda::std::array<int64_t, 2> src_strides{1, 32768};
+  const cuda::std::array<int64_t, 2> dst_strides{16384, 1};
   bench_copy<double, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_double).set_name("transpose_2D_double (2D, double, 4GB)");
 
 void transpose_2D_odd_both(nvbench::state& state)
 {
-  cuda::std::array<int, 2> shape{32767, 32769};
-  cuda::std::array<int, 2> src_strides{1, 32767};
-  cuda::std::array<int, 2> dst_strides{32769, 1};
+  const cuda::std::array<int, 2> shape{32767, 32769};
+  const cuda::std::array<int, 2> src_strides{1, 32767};
+  const cuda::std::array<int, 2> dst_strides{32769, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_2D_odd_both).set_name("transpose_2D_odd_both (2D, int, 4GB)");
 
 void transpose_3D(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{1024, 1024, 1024};
-  cuda::std::array<int, 3> src_strides{1, 1024, 1024 * 1024};
-  cuda::std::array<int, 3> dst_strides{1024 * 1024, 1024, 1};
+  const cuda::std::array<int, 3> shape{1024, 1024, 1024};
+  const cuda::std::array<int, 3> src_strides{1, 1024, 1024 * 1024};
+  const cuda::std::array<int, 3> dst_strides{1024 * 1024, 1024, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_3D).set_name("transpose_3D (3D, int, 4GB)");
 
 void transpose_3D_odd_edges(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{1023, 1025, 1024};
-  cuda::std::array<int, 3> src_strides{1, 1023, 1023 * 1025};
-  cuda::std::array<int, 3> dst_strides{1025 * 1024, 1024, 1};
+  const cuda::std::array<int, 3> shape{1023, 1025, 1024};
+  const cuda::std::array<int, 3> src_strides{1, 1023, 1023 * 1025};
+  const cuda::std::array<int, 3> dst_strides{1025 * 1024, 1024, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_3D_odd_edges).set_name("transpose_3D_odd_edges (3D, int, 4GB)");
 
 void transpose_src_small_15(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{15, 2236962, 32};
-  cuda::std::array<int, 3> src_strides{1, 15 * 32, 15};
-  cuda::std::array<int, 3> dst_strides{2236962 * 32, 32, 1};
+  const cuda::std::array<int, 3> shape{15, 2236962, 32};
+  const cuda::std::array<int, 3> src_strides{1, 15 * 32, 15};
+  const cuda::std::array<int, 3> dst_strides{2236962 * 32, 32, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_src_small_15).set_name("transpose_src_small_15 (3D, int, 4GB)");
 
 void transpose_src_small_16(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{16, 2097152, 32};
-  cuda::std::array<int, 3> src_strides{1, 16 * 32, 16};
-  cuda::std::array<int, 3> dst_strides{2097152 * 32, 32, 1};
+  const cuda::std::array<int, 3> shape{16, 2097152, 32};
+  const cuda::std::array<int, 3> src_strides{1, 16 * 32, 16};
+  const cuda::std::array<int, 3> dst_strides{2097152 * 32, 32, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_src_small_16).set_name("transpose_src_small_16 (3D, int, 4GB)");
 
 void transpose_src_small_17(nvbench::state& state)
 {
-  cuda::std::array<int, 3> shape{17, 1973790, 32};
-  cuda::std::array<int, 3> src_strides{1, 17 * 32, 17};
-  cuda::std::array<int, 3> dst_strides{1973790 * 32, 32, 1};
+  const cuda::std::array<int, 3> shape{17, 1973790, 32};
+  const cuda::std::array<int, 3> src_strides{1, 17 * 32, 17};
+  const cuda::std::array<int, 3> dst_strides{1973790 * 32, 32, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_src_small_17).set_name("transpose_src_small_17 (3D, int, 4GB)");
 
 void transpose_dst_small_8_padded(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 3> shape{32, 4194304, 8};
-  cuda::std::array<int64_t, 3> src_strides{1, 32 * 8, 32};
-  cuda::std::array<int64_t, 3> dst_strides{4194304 * 16, 16, 1};
+  const cuda::std::array<int64_t, 3> shape{32, 4194304, 8};
+  const cuda::std::array<int64_t, 3> src_strides{1, 32 * 8, 32};
+  const cuda::std::array<int64_t, 3> dst_strides{4194304 * 16, 16, 1};
   bench_copy<int, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_dst_small_8_padded).set_name("transpose_dst_small_8_padded (3D, int, 4GB)");
 
 void transpose_dst_small_16_padded(nvbench::state& state)
 {
-  cuda::std::array<int64_t, 3> shape{32, 2097152, 16};
-  cuda::std::array<int64_t, 3> src_strides{1, 32 * 16, 32};
-  cuda::std::array<int64_t, 3> dst_strides{2097152 * 32, 32, 1};
+  const cuda::std::array<int64_t, 3> shape{32, 2097152, 16};
+  const cuda::std::array<int64_t, 3> src_strides{1, 32 * 16, 32};
+  const cuda::std::array<int64_t, 3> dst_strides{2097152 * 32, 32, 1};
   bench_copy<int, int64_t>(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_dst_small_16_padded).set_name("transpose_dst_small_16_padded (3D, int, 4GB)");
 
 void transpose_src_small_16_4D(nvbench::state& state)
 {
-  cuda::std::array<int, 4> shape{16, 1024, 2048, 32};
-  cuda::std::array<int, 4> src_strides{1, 16 * 32, 16 * 32 * 1024, 16};
-  cuda::std::array<int, 4> dst_strides{1024 * 2048 * 32, 32, 1024 * 32, 1};
+  const cuda::std::array<int, 4> shape{16, 1024, 2048, 32};
+  const cuda::std::array<int, 4> src_strides{1, 16 * 32, 16 * 32 * 1024, 16};
+  const cuda::std::array<int, 4> dst_strides{1024 * 2048 * 32, 32, 1024 * 32, 1};
   bench_copy(state, 0, shape, src_strides, 0, dst_strides);
 }
 NVBENCH_BENCH(transpose_src_small_16_4D).set_name("transpose_src_small_16_4D (4D, int, 4GB)");

--- a/cudax/benchmarks/bench/cuco/common/key_generator.cuh
+++ b/cudax/benchmarks/bench/cuco/common/key_generator.cuh
@@ -115,7 +115,7 @@ struct dropout_pred
   __host__ __device__ bool operator()(cuda::std::size_t seed) const noexcept
   {
     Rng rng;
-    thrust::uniform_real_distribution<double> dist{0.0, 1.0};
+    thrust::uniform_real_distribution<double> dist{0.0, 1.0}; // NOLINT(misc-const-correctness)
     rng.seed(seed);
     return dist(rng) > keep_prob;
   }
@@ -235,7 +235,7 @@ public:
     if (keep_prob < 1.0)
     {
       const auto num_keys = static_cast<cuda::std::size_t>(cuda::std::distance(begin, end));
-      cuda::counting_iterator<cuda::std::size_t> seeds{static_cast<cuda::std::size_t>(rng())};
+      const cuda::counting_iterator<cuda::std::size_t> seeds{static_cast<cuda::std::size_t>(rng())};
 
       thrust::transform_if(
         exec_policy,

--- a/cudax/benchmarks/bench/cuco/fixed_capacity_map/contains.cu
+++ b/cudax/benchmarks/bench/cuco/fixed_capacity_map/contains.cu
@@ -50,7 +50,7 @@ void fixed_capacity_map_contains(nvbench::state& state, nvbench::type_list<Key, 
     const auto size = static_cast<cuda::std::size_t>(static_cast<double>(num_keys) / occupancy);
 
     const auto device = cuda::device_ref{0};
-    cuda::stream stream{device};
+    const cuda::stream stream{device};
     const cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(device);
     const auto exec_policy                = thrust::cuda::par_nosync.on(stream.get());
 

--- a/cudax/benchmarks/bench/cuco/fixed_capacity_map/find.cu
+++ b/cudax/benchmarks/bench/cuco/fixed_capacity_map/find.cu
@@ -48,7 +48,7 @@ void fixed_capacity_map_find(nvbench::state& state, nvbench::type_list<Key, Valu
     const auto matching_rate = state.get_float64("MatchingRate");
 
     const auto device = cuda::device_ref{0};
-    cuda::stream stream{device};
+    const cuda::stream stream{device};
     const cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(device);
     const auto exec_policy                = thrust::cuda::par_nosync.on(stream.get());
 

--- a/cudax/benchmarks/bench/cuco/fixed_capacity_map/insert.cu
+++ b/cudax/benchmarks/bench/cuco/fixed_capacity_map/insert.cu
@@ -49,7 +49,7 @@ void fixed_capacity_map_insert(nvbench::state& state, nvbench::type_list<Key, Va
     const auto size = static_cast<cuda::std::size_t>(static_cast<double>(num_keys) / occupancy);
 
     const auto device = cuda::device_ref{0};
-    cuda::stream stream{device};
+    const cuda::stream stream{device};
     const cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(device);
     const auto exec_policy                = thrust::cuda::par_nosync.on(stream.get());
 

--- a/cudax/benchmarks/bench/cuco/hyperloglog.cu
+++ b/cudax/benchmarks/bench/cuco/hyperloglog.cu
@@ -62,7 +62,7 @@ void hyperloglog_e2e(nvbench::state& state, nvbench::type_list<Key>)
   const auto sketch_size_kb = sketch_size_kb_type{static_cast<double>(state.get_int64("SketchSizeKB"))};
 
   const auto device = cuda::device_ref{0};
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
   const cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(device);
 
   auto items = cuda::make_device_buffer<Key>(stream, device, num_items, cuda::no_init);
@@ -99,7 +99,7 @@ void hyperloglog_add(nvbench::state& state, nvbench::type_list<Key>)
   const auto sketch_size_kb = sketch_size_kb_type{static_cast<double>(state.get_int64("SketchSizeKB"))};
 
   const auto device = cuda::device_ref{0};
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
   const cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(device);
 
   auto items = cuda::make_device_buffer<Key>(stream, device, num_items, cuda::no_init);

--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -50,7 +50,7 @@ struct generator
 int main()
 {
   // A CUDA stream on which to execute the vector addition kernel
-  cudax::stream stream{cuda::device_ref{0}};
+  const cudax::stream stream{cuda::device_ref{0}};
 
   // The execution policy we want to use to run all work on the same stream
   auto policy = thrust::cuda::par_nosync.on(stream.get());

--- a/cudax/examples/cub_reduce.cu
+++ b/cudax/examples/cub_reduce.cu
@@ -25,7 +25,7 @@ int main()
   constexpr int num_items = 50000;
 
   // A CUDA stream on which to execute the reduction
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(cuda::devices[0]);
 
   // Allocate input and output, but do not zero initialize output (`cuda::no_init`)
@@ -33,7 +33,7 @@ int main()
   auto d_out = cuda::make_buffer<float>(stream, mr, 1, cuda::no_init);
 
   // An environment we use to pass all necessary information to CUB
-  cudax::env_t<cuda::mr::device_accessible> env{mr, stream};
+  const cudax::env_t<cuda::mr::device_accessible> env{mr, stream};
   auto error = cub::DeviceReduce::Reduce(d_in.begin(), d_out.begin(), num_items, cuda::std::plus{}, 0, env);
   if (error != cudaSuccess)
   {

--- a/cudax/examples/simple_p2p.cu
+++ b/cudax/examples/simple_p2p.cu
@@ -67,9 +67,9 @@ void print_peer_accessibility()
     {
       if (dev_i != dev_j)
       {
-        bool can_access_peer  = dev_i.has_peer_access_to(dev_j);
-        const auto dev_i_name = dev_i.name();
-        const auto dev_j_name = dev_j.name();
+        const bool can_access_peer = dev_i.has_peer_access_to(dev_j);
+        const auto dev_i_name      = dev_i.name();
+        const auto dev_j_name      = dev_j.name();
         printf("> Peer access from %.*s (GPU%d) -> %.*s (GPU%d) : %s\n",
                static_cast<int>(dev_i_name.size()),
                dev_i_name.data(),
@@ -105,7 +105,7 @@ void benchmark_cross_device_ping_pong_copy(
 
   auto end_event = dev1_stream.record_timed_event();
   dev1_stream.sync();
-  cuda::std::chrono::duration<double> duration(end_event - start_event);
+  const cuda::std::chrono::duration<double> duration(end_event - start_event);
   printf("Peer copy between GPU%d and GPU%d: %.2fGB/s\n",
          dev0_stream.device().get(),
          dev1_stream.device().get(),
@@ -117,8 +117,8 @@ template <typename BufferType>
 void test_cross_device_access_from_kernel(
   cudax::stream_ref dev0_stream, cudax::stream_ref dev1_stream, BufferType& dev0_buffer, BufferType& dev1_buffer)
 {
-  cuda::device_ref dev0 = dev0_stream.device();
-  cuda::device_ref dev1 = dev1_stream.device();
+  const cuda::device_ref dev0 = dev0_stream.device();
+  const cuda::device_ref dev1 = dev1_stream.device();
 
   // Prepare host buffer and copy to GPU 0
   printf("Preparing host buffer and copy to GPU%d...\n", dev0.get());
@@ -162,9 +162,9 @@ void test_cross_device_access_from_kernel(
   int error_count = 0;
   for (size_t i = 0; i < host_buffer.size(); i++)
   {
-    cuda::std::span<float> host_span(host_buffer);
+    const cuda::std::span<float> host_span(host_buffer);
     // Re-generate input data and apply 2x '* 2.0f' computation of both kernel runs
-    float expected = float(i % 4096) * 2.0f * 2.0f;
+    const float expected = float(i % 4096) * 2.0f * 2.0f;
     if (host_span[i] != expected)
     {
       printf("Verification error @ element %zu: val = %f, ref = %f\n", i, host_span[i], expected);
@@ -220,8 +220,8 @@ try
     return 0;
   }
 
-  cuda::stream dev0_stream(peers[0]);
-  cuda::stream dev1_stream(peers[1]);
+  const cuda::stream dev0_stream(peers[0]);
+  const cuda::stream dev1_stream(peers[1]);
 
   printf("Enabling peer access between GPU%d and GPU%d...\n", peers[0].get(), peers[1].get());
   cuda::device_memory_pool_ref dev0_resource = cuda::device_default_memory_pool(peers[0]);

--- a/cudax/examples/vector_add.cu
+++ b/cudax/examples/vector_add.cu
@@ -58,7 +58,7 @@ using cudax::out;
  */
 __global__ void vectorAdd(cudax::span<const float> A, cudax::span<const float> B, cudax::span<float> C)
 {
-  int i = static_cast<int>(blockDim.x * blockIdx.x + threadIdx.x);
+  const int i = static_cast<int>(blockDim.x * blockIdx.x + threadIdx.x);
 
   if (i < A.size())
   {
@@ -73,10 +73,10 @@ int main()
 try
 {
   // A CUDA stream on which to execute the vector addition kernel
-  cudax::stream stream(cuda::devices[0]);
+  const cudax::stream stream(cuda::devices[0]);
 
   // Print the vector length to be used, and compute its size
-  int numElements = 50000;
+  const int numElements = 50000;
   printf("[Vector addition of %d elements]\n", numElements);
 
   // Allocate the host vectors

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -35,7 +35,7 @@ inline int get_expected_value(uint8_t pattern_byte)
 template <typename Result>
 void check_result_and_erase(cudax::stream_ref stream, Result&& result, uint8_t pattern_byte = fill_byte)
 {
-  int expected = get_expected_value(pattern_byte);
+  const int expected = get_expected_value(pattern_byte);
 
   stream.sync();
   for (int& i : result)
@@ -49,7 +49,7 @@ template <typename Layout = cuda::std::layout_right, typename Extents>
 auto make_buffer_for_mdspan(Extents extents, char value = 0)
 {
   cuda::mr::legacy_pinned_memory_resource host_resource;
-  auto mapping = typename Layout::template mapping<decltype(extents)>{extents};
+  auto mapping = typename Layout::template mapping<Extents>{extents};
 
   cudax::uninitialized_buffer<int, cuda::mr::host_accessible> buffer(host_resource, mapping.required_span_size());
 
@@ -60,14 +60,14 @@ auto make_buffer_for_mdspan(Extents extents, char value = 0)
 
 inline auto create_fake_strided_mdspan()
 {
-  cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
-  cuda::std::array<size_t, 3> strides{12, 4, 1};
+  const cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
+  const cuda::std::array<size_t, 3> strides{12, 4, 1};
 #if _CCCL_CUDA_COMPILER(NVCC, <, 12, 6)
   auto map = cuda::std::layout_stride::mapping{dynamic_extents, strides};
 #else // ^^^ _CCCL_CUDA_COMPILER(NVCC, <, 12, 6) ^^^ / vvv _CCCL_CUDA_COMPILER(NVCC, >=, 12, 6) vvv
-  cuda::std::layout_stride::mapping map{dynamic_extents, strides};
+  const cuda::std::layout_stride::mapping map{dynamic_extents, strides};
 #endif // ^^^ _CCCL_CUDA_COMPILER(NVCC, >=, 12, 6) ^^^
-  return cuda::std::mdspan<int, decltype(dynamic_extents), cuda::std::layout_stride>(nullptr, map);
+  return cuda::std::mdspan<int, cuda::std::dextents<size_t, 3>, cuda::std::layout_stride>(nullptr, map);
 };
 
 namespace cuda::experimental

--- a/cudax/test/algorithm/copy.cu
+++ b/cudax/test/algorithm/copy.cu
@@ -12,7 +12,7 @@
 
 C2H_TEST("1d Copy", "[data_manipulation]")
 {
-  cuda::stream _stream{cuda::device_ref{0}};
+  const cuda::stream _stream{cuda::device_ref{0}};
 
   SECTION("Device resource")
   {
@@ -133,7 +133,7 @@ void test_mdspan_copy_bytes(
 
 C2H_TEST("Mdspan copy", "[data_manipulation]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("Different extents")
   {
@@ -171,7 +171,7 @@ C2H_TEST("Mdspan copy", "[data_manipulation]")
 
 C2H_TEST("Non exhaustive mdspan copy_bytes", "[data_manipulation]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/cudax/test/algorithm/fill.cu
+++ b/cudax/test/algorithm/fill.cu
@@ -12,7 +12,7 @@
 
 C2H_TEST("Fill", "[data_manipulation]")
 {
-  cuda::stream _stream{cuda::device_ref{0}};
+  const cuda::stream _stream{cuda::device_ref{0}};
   SECTION("Host resource")
   {
     cuda::mr::legacy_pinned_memory_resource host_resource;
@@ -47,19 +47,20 @@ C2H_TEST("Fill", "[data_manipulation]")
 
 C2H_TEST("Mdspan Fill", "[data_manipulation]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
-    cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
+    const cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
     auto buffer = make_buffer_for_mdspan(dynamic_extents, 0);
-    cuda::std::mdspan<int, decltype(dynamic_extents)> dynamic_mdspan(buffer.data(), dynamic_extents);
+    cuda::std::mdspan<int, cuda::std::dextents<size_t, 3>> dynamic_mdspan(buffer.data(), dynamic_extents);
 
     cuda::fill_bytes(stream, dynamic_mdspan, fill_byte);
     check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
   }
   {
-    cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4> mixed_extents{1};
+    const cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4> mixed_extents{1};
     auto buffer = make_buffer_for_mdspan(mixed_extents, 0);
-    cuda::std::mdspan<int, decltype(mixed_extents)> mixed_mdspan(buffer.data(), mixed_extents);
+    cuda::std::mdspan<int, cuda::std::extents<size_t, 2, cuda::std::dynamic_extent, 4>> mixed_mdspan(
+      buffer.data(), mixed_extents);
 
     cuda::fill_bytes(stream, cuda::std::move(mixed_mdspan), fill_byte);
     check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
@@ -77,7 +78,7 @@ C2H_TEST("Mdspan Fill", "[data_manipulation]")
 
 C2H_TEST("Non exhaustive mdspan fill_bytes", "[data_manipulation]")
 {
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -37,13 +37,13 @@ private:
 public:
   explicit _malloc_pinned(std::size_t size)
   {
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
     _CCCL_TRY_RUNTIME_API(::cudaMallocHost, "failed to allocate pinned memory", &pv, size);
   }
 
   ~_malloc_pinned()
   {
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
     [[maybe_unused]] auto status = ::cudaFreeHost(pv);
   }
 
@@ -116,7 +116,7 @@ struct atomic_add_one
 {
   __device__ void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     atomic_pi.fetch_add(1);
   }
 };
@@ -125,7 +125,7 @@ struct atomic_sub_one
 {
   __device__ void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     atomic_pi.fetch_sub(1);
   }
 };
@@ -134,7 +134,7 @@ struct spin_until_80
 {
   __device__ void operator()(int* pi) const noexcept
   {
-    cuda::atomic_ref atomic_pi(*pi);
+    const cuda::atomic_ref atomic_pi(*pi);
     while (atomic_pi.load() != 80)
       ;
   }

--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -247,7 +247,7 @@ C2H_TEST("uninitialized_buffer is usable with cudax::launch", "[container]")
       cuda::device_default_memory_pool(cuda::device_ref{0}), 1024};
     auto configuration = cuda::make_config(cuda::grid_dims(grid_size), cuda::block_dims<256>());
 
-    cudax::stream stream{cuda::device_ref{0}};
+    const cudax::stream stream{cuda::device_ref{0}};
 
     cudax::launch(stream, configuration, kernel, buffer);
   }
@@ -259,7 +259,7 @@ C2H_TEST("uninitialized_buffer is usable with cudax::launch", "[container]")
       cuda::device_default_memory_pool(cuda::device_ref{0}), 1024};
     auto configuration = cuda::make_config(cuda::grid_dims(grid_size), cuda::block_dims<256>());
 
-    cudax::stream stream{cuda::device_ref{0}};
+    const cudax::stream stream{cuda::device_ref{0}};
 
     cudax::launch(stream, configuration, const_kernel, buffer);
   }
@@ -299,7 +299,8 @@ C2H_TEST("uninitialized_buffer's memory resource does not dangle", "[container]"
   {
     CHECK(test_device_memory_pool_ref::count == 0);
 
-    cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> src_buffer{test_device_memory_pool_ref{}, 1024};
+    const cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> src_buffer{
+      test_device_memory_pool_ref{}, 1024};
 
     CHECK(test_device_memory_pool_ref::count == 1);
 

--- a/cudax/test/coop/reduce/this_block.cu
+++ b/cudax/test/coop/reduce/this_block.cu
@@ -41,7 +41,7 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_block block{config};
+    const cudax::this_block block{config};
 
     T thread_data[NumItems];
     for (int i = 0; i < NumItems; ++i)
@@ -164,8 +164,8 @@ C2H_TEST("reduce/this_block Integral Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{cuda::devices[0]};
+  for (const int num_items : {1, 4})
   {
     auto reference_result =
       cuda::std::accumulate(h_in.begin(), h_in.begin() + num_items * block_size_t::value, operator_identity, reduce_op);
@@ -190,8 +190,8 @@ C2H_TEST("reduce/this_block Floating-Point Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{cuda::devices[0]};
+  for (const int num_items : {1, 4})
   {
     auto reference_result =
       cuda::std::accumulate(h_in.begin(), h_in.begin() + num_items * block_size_t::value, operator_identity, reduce_op);
@@ -211,8 +211,8 @@ C2H_TEST("reduce/this_block Broadcasted", "[reduce][this_block]", integral_type_
   c2h::device_vector<value_t> d_in(max_size * block_size_t::value);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{cuda::devices[0]};
+  for (const int num_items : {1, 4})
   {
     c2h::device_vector<value_t> d_out(block_size_t::value);
     auto reference_result =

--- a/cudax/test/coop/reduce/this_cluster.cu
+++ b/cudax/test/coop/reduce/this_cluster.cu
@@ -43,7 +43,7 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_cluster cluster{config};
+    const cudax::this_cluster cluster{config};
 
     T thread_data[NumItems];
     for (int i = 0; i < NumItems; ++i)
@@ -170,8 +170,8 @@ C2H_TEST("reduce/this_cluster Integral Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     auto reference_result = cuda::std::accumulate(
       h_in.begin(), h_in.begin() + num_items * cluster_size_t::value * block_size, operator_identity, reduce_op);
@@ -202,8 +202,8 @@ C2H_TEST("reduce/this_cluster Floating-Point Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     auto reference_result = cuda::std::accumulate(
       h_in.begin(), h_in.begin() + num_items * cluster_size_t::value * block_size, operator_identity, reduce_op);
@@ -229,8 +229,8 @@ C2H_TEST("reduce/this_cluster Broadcasted", "[reduce][this_cluster]", integral_t
   c2h::device_vector<value_t> d_in(max_size * cluster_size_t::value * block_size);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     c2h::device_vector<value_t> d_out(cluster_size_t::value * block_size);
     auto reference_result = cuda::std::accumulate(

--- a/cudax/test/coop/reduce/this_grid.cu
+++ b/cudax/test/coop/reduce/this_grid.cu
@@ -44,7 +44,7 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_grid grid{config};
+    const cudax::this_grid grid{config};
 
     T thread_data[NumItems];
     for (int i = 0; i < NumItems; ++i)
@@ -174,8 +174,8 @@ C2H_TEST("reduce/this_grid Integral Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     auto reference_result = cuda::std::accumulate(
       h_in.begin(),
@@ -206,8 +206,8 @@ C2H_TEST(
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     auto reference_result = cuda::std::accumulate(
       h_in.begin(),
@@ -236,8 +236,8 @@ C2H_TEST("reduce/this_grid Broadcasted", "[reduce][this_grid]", integral_type_li
   c2h::device_vector<value_t> d_in(max_size * grid_size_t::value * cluster_size * block_size);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{device};
-  for (int num_items : {1, 4})
+  const cuda::stream stream{device};
+  for (const int num_items : {1, 4})
   {
     c2h::device_vector<value_t> d_out(grid_size_t::value * cluster_size * block_size);
     auto reference_result = cuda::std::accumulate(

--- a/cudax/test/coop/reduce/this_thread.cu
+++ b/cudax/test/coop/reduce/this_thread.cu
@@ -41,7 +41,7 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_thread thread{config};
+    const cudax::this_thread thread{config};
 
     T thread_data[NumItems];
     for (int i = 0; i < NumItems; ++i)
@@ -192,7 +192,7 @@ C2H_TEST("reduce/this_thread Integral Type Tests", "[reduce][this_thread]", inte
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result = cuda::std::accumulate(h_in.begin(), h_in.begin() + num_items, operator_identity, reduce_op);
@@ -212,7 +212,7 @@ C2H_TEST("reduce/this_thread Floating-Point Type Tests", "[reduce][this_thread]"
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result = cuda::std::accumulate(h_in.begin(), h_in.begin() + num_items, operator_identity, reduce_op);
@@ -232,7 +232,7 @@ C2H_TEST("reduce/this_thread Broadcasted", "[reduce][this_thread]", integral_typ
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result = cuda::std::accumulate(h_in.begin(), h_in.begin() + num_items, operator_identity, reduce_op);

--- a/cudax/test/coop/reduce/this_warp.cu
+++ b/cudax/test/coop/reduce/this_warp.cu
@@ -41,7 +41,7 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_warp warp{config};
+    const cudax::this_warp warp{config};
 
     T thread_data[NumItems];
     for (int i = 0; i < NumItems; ++i)
@@ -160,7 +160,7 @@ C2H_TEST("reduce/this_warp Integral Type Tests", "[reduce][this_warp]", integral
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result =
@@ -181,7 +181,7 @@ C2H_TEST("reduce/this_warp Floating-Point Type Tests", "[reduce][this_warp]", fp
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result =
@@ -201,7 +201,7 @@ C2H_TEST("reduce/this_warp Broadcasted", "[reduce][this_warp]", integral_type_li
   c2h::device_vector<value_t> d_in(max_size * warp_size);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     c2h::device_vector<value_t> d_out(warp_size);

--- a/cudax/test/coop/reduce/threads_within_warp.cu
+++ b/cudax/test/coop/reduce/threads_within_warp.cu
@@ -45,8 +45,9 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_warp warp{config};
-    cudax::group group{cuda::gpu_thread, warp, cudax::group_by<NThreadsInGroup, false>{}, cudax::lane_synchronizer{}};
+    const cudax::this_warp warp{config};
+    const cudax::group group{
+      cuda::gpu_thread, warp, cudax::group_by<NThreadsInGroup, false>{}, cudax::lane_synchronizer{}};
 
     // All threads that are not part of the groups should exit early.
     if (!cuda::gpu_thread.is_part_of(group))
@@ -217,7 +218,7 @@ C2H_TEST("reduce/threads_within_warp Integral Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result =
@@ -244,7 +245,7 @@ C2H_TEST("reduce/threads_within_warp Floating-Point Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result =
@@ -267,7 +268,7 @@ C2H_TEST(
   c2h::device_vector<value_t> d_in(max_size * nthreads_in_group);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     c2h::device_vector<value_t> d_out(nthreads_in_group);

--- a/cudax/test/coop/reduce/warps_within_block.cu
+++ b/cudax/test/coop/reduce/warps_within_block.cu
@@ -45,13 +45,13 @@ struct ReduceKernel
     T* __restrict__ d_out,
     RedOp red_op)
   {
-    cudax::this_block block{config};
+    const cudax::this_block block{config};
 
     using Barriers = cuda::barrier<cuda::thread_scope_block>[1];
     __shared__ cuda::std::aligned_storage_t<sizeof(Barriers), alignof(Barriers)> barriers_storage;
     auto& barriers = reinterpret_cast<Barriers&>(barriers_storage);
 
-    cudax::group group{
+    const cudax::group group{
       cuda::warp, block, cudax::group_by<nwarps_in_group, false>{}, cudax::barrier_synchronizer{barriers}};
 
     // All threads that are not part of the groups should exit early.
@@ -179,7 +179,7 @@ C2H_TEST("reduce/warps_within_block Integral Type Tests",
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result = cuda::std::accumulate(
@@ -201,7 +201,7 @@ C2H_TEST(
   c2h::device_vector<value_t> d_out(1);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     auto reference_result = cuda::std::accumulate(
@@ -221,7 +221,7 @@ C2H_TEST("reduce/warps_within_block Broadcasted", "[reduce][warps_within_block]"
   c2h::device_vector<value_t> d_in(max_size * nwarps_in_group * warp_size);
   c2h::gen(C2H_SEED(num_seeds), d_in, cuda::std::numeric_limits<value_t>::min());
   c2h::host_vector<value_t> h_in = d_in;
-  cuda::stream stream{cuda::devices[0]};
+  const cuda::stream stream{cuda::devices[0]};
   for (int num_items = 1; num_items <= max_size; ++num_items)
   {
     c2h::device_vector<value_t> d_out(nwarps_in_group * warp_size);

--- a/cudax/test/coop/scratch.cu
+++ b/cudax/test/coop/scratch.cu
@@ -266,7 +266,7 @@ struct TestKernel
 C2H_TEST("scratch", "[scratch]")
 {
   const auto device = cuda::devices[0];
-  cuda::stream stream{device};
+  const cuda::stream stream{device};
 
   const auto config = cuda::make_config(cuda::grid_dims<1>(), cuda::block_dims<1>());
   cuda::launch(stream, config, TestKernel{});

--- a/cudax/test/copy/copy.cu
+++ b/cudax/test/copy/copy.cu
@@ -142,8 +142,8 @@ TEST_CASE("copy d2d 2D strided padded row-major", "[copy][d2d][2d][stride][row]"
   constexpr int M  = 4;
   constexpr int N  = 8;
   constexpr int Ld = 16;
-  cuda::std::array<int, 2> shape{M, N};
-  cuda::std::array<int, 2> strides{Ld, 1};
+  const cuda::std::array<int, 2> shape{M, N};
+  const cuda::std::array<int, 2> strides{Ld, 1};
 
   using extents_t      = cuda::std::dextents<int, 2>;
   using mapping_t      = cuda::std::layout_stride::mapping<extents_t>;
@@ -167,8 +167,8 @@ TEST_CASE("copy d2d 2D strided padded column-major", "[copy][d2d][2d][stride][co
   constexpr int M  = 4;
   constexpr int N  = 8;
   constexpr int Ld = 16;
-  cuda::std::array<int, 2> shape{M, N};
-  cuda::std::array<int, 2> strides{1, Ld};
+  const cuda::std::array<int, 2> shape{M, N};
+  const cuda::std::array<int, 2> strides{1, Ld};
 
   using extents_t      = cuda::std::dextents<int, 2>;
   using mapping_t      = cuda::std::layout_stride::mapping<extents_t>;
@@ -193,9 +193,9 @@ TEST_CASE("copy d2d 3D strided permutation", "[copy][d2d][3d][stride][permutatio
   constexpr int D1 = 3;
   constexpr int D2 = 4;
   auto input       = make_iota<int>(D0 * D1 * D2);
-  cuda::std::array<int, 3> shape{D0, D1, D2};
-  cuda::std::array<int, 3> src_strides{D1 * D2, D2, 1};
-  cuda::std::array<int, 3> dst_strides{1, D2 * D0, D0};
+  const cuda::std::array<int, 3> shape{D0, D1, D2};
+  const cuda::std::array<int, 3> src_strides{D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> dst_strides{1, D2 * D0, D0};
 
   using extents_t     = cuda::std::dextents<int, 3>;
   using mapping_t     = cuda::std::layout_stride::mapping<extents_t>;
@@ -224,9 +224,9 @@ TEST_CASE("copy d2d 3D strided different stride order", "[copy][d2d][3d][stride]
   constexpr int D1 = 3;
   constexpr int D2 = 4;
   auto input       = make_iota<int>(D0 * D1 * D2);
-  cuda::std::array<int, 3> shape{D0, D1, D2};
-  cuda::std::array<int, 3> src_strides{D1 * D2, D2, 1};
-  cuda::std::array<int, 3> dst_strides{8, 16, 1};
+  const cuda::std::array<int, 3> shape{D0, D1, D2};
+  const cuda::std::array<int, 3> src_strides{D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> dst_strides{8, 16, 1};
 
   using extents_t     = cuda::std::dextents<int, 3>;
   using mapping_t     = cuda::std::layout_stride::mapping<extents_t>;

--- a/cudax/test/copy/copy_common.cuh
+++ b/cudax/test/copy/copy_common.cuh
@@ -46,20 +46,20 @@ void test_copy(const thrust::host_vector<T>& input, const thrust::host_vector<T>
 {
   [[maybe_unused]] constexpr size_t Rank = sizeof...(Ints); // msvc warns, only used in nttp
   using extents_t                        = cuda::std::dextents<int, Rank>;
-  extents_t ext(static_cast<int>(shape)...);
-  typename SrcLayout::template mapping<extents_t> src_mapping(ext);
-  typename DstLayout::template mapping<extents_t> dst_mapping(ext);
+  const extents_t ext(static_cast<int>(shape)...);
+  const typename SrcLayout::template mapping<extents_t> src_mapping(ext);
+  const typename DstLayout::template mapping<extents_t> dst_mapping(ext);
 
   thrust::device_vector<T> d_src(input.begin(), input.end());
   thrust::device_vector<T> d_dst(expected.size(), T{0});
 
-  cuda::device_mdspan<T, extents_t, SrcLayout> src(thrust::raw_pointer_cast(d_src.data()), src_mapping);
-  cuda::device_mdspan<T, extents_t, DstLayout> dst(thrust::raw_pointer_cast(d_dst.data()), dst_mapping);
+  const cuda::device_mdspan<T, extents_t, SrcLayout> src(thrust::raw_pointer_cast(d_src.data()), src_mapping);
+  const cuda::device_mdspan<T, extents_t, DstLayout> dst(thrust::raw_pointer_cast(d_dst.data()), dst_mapping);
 
   cuda::experimental::copy(src, dst, stream);
   stream.sync();
 
-  thrust::host_vector<T> result(d_dst);
+  const thrust::host_vector<T> result(d_dst);
   REQUIRE(result == expected);
 }
 
@@ -88,20 +88,22 @@ void test_copy_strided(
 {
   using extents_t = cuda::std::dextents<int, Rank>;
   using mapping_t = cuda::std::layout_stride::mapping<extents_t>;
-  extents_t ext(shape);
-  mapping_t src_mapping(ext, src_strides);
-  mapping_t dst_mapping(ext, dst_strides);
+  const extents_t ext(shape);
+  const mapping_t src_mapping(ext, src_strides);
+  const mapping_t dst_mapping(ext, dst_strides);
 
   thrust::device_vector<T> d_src(input.begin(), input.end());
   thrust::device_vector<T> d_dst(expected.size(), T{0});
 
-  cuda::device_mdspan<T, extents_t, cuda::std::layout_stride> src(thrust::raw_pointer_cast(d_src.data()), src_mapping);
-  cuda::device_mdspan<T, extents_t, cuda::std::layout_stride> dst(thrust::raw_pointer_cast(d_dst.data()), dst_mapping);
+  const cuda::device_mdspan<T, extents_t, cuda::std::layout_stride> src(
+    thrust::raw_pointer_cast(d_src.data()), src_mapping);
+  const cuda::device_mdspan<T, extents_t, cuda::std::layout_stride> dst(
+    thrust::raw_pointer_cast(d_dst.data()), dst_mapping);
 
   cuda::experimental::copy(src, dst, stream);
   stream.sync();
 
-  thrust::host_vector<T> result(d_dst);
+  const thrust::host_vector<T> result(d_dst);
   REQUIRE(result == expected);
 }
 
@@ -157,19 +159,19 @@ void test_copy_stride_relaxed(
   using strides_t = cuda::dstrides<int, Rank>;
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
 
-  extents_t ext(shape);
+  const extents_t ext(shape);
   auto src_ptr = thrust::raw_pointer_cast(d_src.data());
   auto dst_ptr = thrust::raw_pointer_cast(d_dst.data());
-  mapping_t src_map(ext, strides_t(src_strides), src_offset);
-  mapping_t dst_map(ext, strides_t(dst_strides), dst_offset);
+  const mapping_t src_map(ext, strides_t(src_strides), src_offset);
+  const mapping_t dst_map(ext, strides_t(dst_strides), dst_offset);
 
-  cuda::device_mdspan<T, extents_t, cuda::layout_stride_relaxed> src(src_ptr, src_map);
-  cuda::device_mdspan<T, extents_t, cuda::layout_stride_relaxed> dst(dst_ptr, dst_map);
+  const cuda::device_mdspan<T, extents_t, cuda::layout_stride_relaxed> src(src_ptr, src_map);
+  const cuda::device_mdspan<T, extents_t, cuda::layout_stride_relaxed> dst(dst_ptr, dst_map);
 
   cuda::experimental::copy(src, dst, stream);
   stream.sync();
 
-  thrust::host_vector<T> result(d_dst);
+  const thrust::host_vector<T> result(d_dst);
   REQUIRE(result == expected);
 }
 

--- a/cudax/test/copy/copy_edge_cases.cu
+++ b/cudax/test/copy/copy_edge_cases.cu
@@ -26,7 +26,7 @@
 // dst: (1):(1)
 TEST_CASE("copy d2d scalar", "[copy][d2d][0d]")
 {
-  thrust::host_vector<int> data(1, 42);
+  const thrust::host_vector<int> data(1, 42);
   test_copy<layout_right>(data, 1);
 }
 
@@ -48,11 +48,11 @@ TEST_CASE("copy d2d different types", "[copy][d2d][1d][mixed_types]")
   thrust::device_vector<float> d_dst(N, 0.0f);
 
   using extents_t = cuda::std::dextents<int, 1>;
-  extents_t ext(N);
-  layout_right::mapping<extents_t> mapping(ext);
+  const extents_t ext(N);
+  const layout_right::mapping<extents_t> mapping(ext);
 
-  cuda::device_mdspan<int, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
-  cuda::device_mdspan<float, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
+  const cuda::device_mdspan<int, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
+  const cuda::device_mdspan<float, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();
@@ -62,7 +62,7 @@ TEST_CASE("copy d2d different types", "[copy][d2d][1d][mixed_types]")
   {
     h_expected[i] = static_cast<float>(i * 10);
   }
-  thrust::host_vector<float> result(d_dst);
+  const thrust::host_vector<float> result(d_dst);
   REQUIRE(result == h_expected);
 }
 
@@ -75,11 +75,11 @@ TEST_CASE("copy d2d size 0", "[copy][d2d][zero_size]")
   thrust::device_vector<int> d_dst(1, 0);
 
   using extents_t = cuda::std::dextents<int, 2>;
-  extents_t ext(0, 0);
-  cuda::std::layout_right::mapping<extents_t> mapping(ext);
+  const extents_t ext(0, 0);
+  const cuda::std::layout_right::mapping<extents_t> mapping(ext);
 
-  cuda::device_mdspan<int, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
-  cuda::device_mdspan<int, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
+  const cuda::device_mdspan<int, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
+  const cuda::device_mdspan<int, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();
@@ -109,12 +109,12 @@ TEST_CASE("copy d2d contiguous scaled_accessor", "[copy][d2d][1d][accessor]")
   using dev_acc_t    = cuda::device_accessor<scaled_acc_t>;
   using src_mdspan_t = cuda::device_mdspan<const int, extents_t, layout_right, scaled_acc_t>;
   using dst_mdspan_t = cuda::device_mdspan<int, extents_t, layout_right>;
-  extents_t ext(N);
-  layout_right::mapping<extents_t> mapping(ext);
+  const extents_t ext(N);
+  const layout_right::mapping<extents_t> mapping(ext);
 
-  src_mdspan_t src(
+  const src_mdspan_t src(
     thrust::raw_pointer_cast(d_src.data()), mapping, dev_acc_t{scaled_acc_t{2, cuda::std::default_accessor<int>{}}});
-  dst_mdspan_t dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
+  const dst_mdspan_t dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();
@@ -124,7 +124,7 @@ TEST_CASE("copy d2d contiguous scaled_accessor", "[copy][d2d][1d][accessor]")
   {
     h_expected[i] = i * 2;
   }
-  thrust::host_vector<int> result(d_dst);
+  const thrust::host_vector<int> result(d_dst);
   REQUIRE(result == h_expected);
 }
 
@@ -204,8 +204,8 @@ TEST_CASE("copy d2d contiguous kernel remainder", "[copy][d2d][contiguous][remai
   constexpr int N  = 513;
   constexpr int Ld = 1024;
 
-  cuda::std::array<int, 2> shape{M, N};
-  cuda::std::array<int, 2> strides{Ld, 1};
+  const cuda::std::array<int, 2> shape{M, N};
+  const cuda::std::array<int, 2> strides{Ld, 1};
 
   using extents_t     = cuda::std::dextents<int, 2>;
   using mapping_t     = cuda::std::layout_stride::mapping<extents_t>;
@@ -220,7 +220,7 @@ TEST_CASE("copy d2d contiguous kernel remainder", "[copy][d2d][contiguous][remai
     }
   }
 
-  large_type_128 zero{};
+  const large_type_128 zero{};
   thrust::host_vector<large_type_128> h_expected(span_size, zero);
   for (int i = 0; i < M; ++i)
   {
@@ -310,12 +310,12 @@ TEST_CASE("copy d2d mismatched shapes", "[copy][d2d][negative]")
 
   using extents_src_t = cuda::std::dextents<int, 2>;
   using extents_dst_t = cuda::std::dextents<int, 2>;
-  extents_src_t src_ext(8, 8);
-  extents_dst_t dst_ext(4, 16);
+  const extents_src_t src_ext(8, 8);
+  const extents_dst_t dst_ext(4, 16);
 
-  cuda::device_mdspan<float, extents_src_t, layout_right> src(
+  const cuda::device_mdspan<float, extents_src_t, layout_right> src(
     thrust::raw_pointer_cast(d_src.data()), layout_right::mapping<extents_src_t>(src_ext));
-  cuda::device_mdspan<float, extents_dst_t, layout_right> dst(
+  const cuda::device_mdspan<float, extents_dst_t, layout_right> dst(
     thrust::raw_pointer_cast(d_dst.data()), layout_right::mapping<extents_dst_t>(dst_ext));
 
   CHECK_THROWS_AS(cudax::copy(src, dst, stream), std::invalid_argument);
@@ -339,18 +339,18 @@ TEST_CASE("copy d2d different extent types", "[copy][d2d][mixed_types]")
 
   using src_extents_t = cuda::std::dextents<int, 2>;
   using dst_extents_t = cuda::std::dextents<long long, 2>;
-  src_extents_t src_ext(M, N);
-  dst_extents_t dst_ext(M, N);
+  const src_extents_t src_ext(M, N);
+  const dst_extents_t dst_ext(M, N);
 
-  cuda::device_mdspan<float, src_extents_t, layout_right> src(
+  const cuda::device_mdspan<float, src_extents_t, layout_right> src(
     thrust::raw_pointer_cast(d_src.data()), layout_right::mapping<src_extents_t>(src_ext));
-  cuda::device_mdspan<float, dst_extents_t, layout_right> dst(
+  const cuda::device_mdspan<float, dst_extents_t, layout_right> dst(
     thrust::raw_pointer_cast(d_dst.data()), layout_right::mapping<dst_extents_t>(dst_ext));
 
   cudax::copy(src, dst, stream);
   stream.sync();
 
-  thrust::host_vector<float> result(d_dst);
+  const thrust::host_vector<float> result(d_dst);
   REQUIRE(result == h_data);
 }
 
@@ -371,18 +371,18 @@ TEST_CASE("copy d2d different extent and stride types", "[copy][d2d][mixed_types
   using src_mapping_t = cuda::std::layout_stride::mapping<src_extents_t>;
   using dst_mapping_t = cuda::std::layout_stride::mapping<dst_extents_t>;
 
-  src_mapping_t src_mapping(src_extents_t(M, N), cuda::std::array<int, 2>{N, 1});
-  dst_mapping_t dst_mapping(dst_extents_t(M, N), cuda::std::array<long long, 2>{N, 1});
+  const src_mapping_t src_mapping(src_extents_t(M, N), cuda::std::array<int, 2>{N, 1});
+  const dst_mapping_t dst_mapping(dst_extents_t(M, N), cuda::std::array<long long, 2>{N, 1});
 
-  cuda::device_mdspan<float, src_extents_t, cuda::std::layout_stride> src(
+  const cuda::device_mdspan<float, src_extents_t, cuda::std::layout_stride> src(
     thrust::raw_pointer_cast(d_src.data()), src_mapping);
-  cuda::device_mdspan<float, dst_extents_t, cuda::std::layout_stride> dst(
+  const cuda::device_mdspan<float, dst_extents_t, cuda::std::layout_stride> dst(
     thrust::raw_pointer_cast(d_dst.data()), dst_mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();
 
-  thrust::host_vector<float> result(d_dst);
+  const thrust::host_vector<float> result(d_dst);
   REQUIRE(result == h_data);
 }
 
@@ -411,17 +411,17 @@ TEST_CASE("copy d2d misaligned pointer", "[copy][d2d][alignment]")
   auto* dst_ptr = thrust::raw_pointer_cast(d_dst_buf.data()) + 1;
 
   using extents_t = cuda::std::dextents<int, 1>;
-  extents_t ext(N);
-  layout_right::mapping<extents_t> mapping(ext);
+  const extents_t ext(N);
+  const layout_right::mapping<extents_t> mapping(ext);
 
-  cuda::device_mdspan<char, extents_t, layout_right> src(src_ptr, mapping);
-  cuda::device_mdspan<char, extents_t, layout_right> dst(dst_ptr, mapping);
+  const cuda::device_mdspan<char, extents_t, layout_right> src(src_ptr, mapping);
+  const cuda::device_mdspan<char, extents_t, layout_right> dst(dst_ptr, mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();
 
   thrust::host_vector<char> h_dst_buf(d_dst_buf);
-  thrust::host_vector<char> result(h_dst_buf.begin() + 1, h_dst_buf.begin() + 1 + N);
+  const thrust::host_vector<char> result(h_dst_buf.begin() + 1, h_dst_buf.begin() + 1 + N);
   REQUIRE(result == h_src);
 }
 
@@ -448,11 +448,11 @@ TEST_CASE("copy d2d large count > INT_MAX", "[copy][d2d][large][.]")
   thrust::device_vector<char> d_dst(N, static_cast<char>(0x00));
 
   using extents_t = cuda::std::dextents<long long, 1>;
-  extents_t ext(static_cast<long long>(N));
-  layout_right::mapping<extents_t> mapping(ext);
+  const extents_t ext(static_cast<long long>(N));
+  const layout_right::mapping<extents_t> mapping(ext);
 
-  cuda::device_mdspan<char, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
-  cuda::device_mdspan<char, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
+  const cuda::device_mdspan<char, extents_t, layout_right> src(thrust::raw_pointer_cast(d_src.data()), mapping);
+  const cuda::device_mdspan<char, extents_t, layout_right> dst(thrust::raw_pointer_cast(d_dst.data()), mapping);
 
   cudax::copy(src, dst, stream);
   stream.sync();

--- a/cudax/test/copy/copy_nvmath.cu
+++ b/cudax/test/copy/copy_nvmath.cu
@@ -22,9 +22,9 @@ using data_t = int8_t;
 // dst: (3,4):(4,1), offset=0, alloc=12
 TEST_CASE("copy d2d nvmath minimal offset", "[copy][d2d][nvmath][debug]")
 {
-  cuda::std::array<int, 2> shape{3, 4};
-  cuda::std::array<int, 2> src_strides{4, 1};
-  cuda::std::array<int, 2> dst_strides{4, 1};
+  const cuda::std::array<int, 2> shape{3, 4};
+  const cuda::std::array<int, 2> src_strides{4, 1};
+  const cuda::std::array<int, 2> dst_strides{4, 1};
   test_copy_stride_relaxed<data_t>(16, 4, shape, src_strides, 12, 0, dst_strides);
 }
 
@@ -32,9 +32,9 @@ TEST_CASE("copy d2d nvmath minimal offset", "[copy][d2d][nvmath][debug]")
 // dst: (4,256):(256,1), offset=0, alloc=1024
 TEST_CASE("copy d2d nvmath medium offset", "[copy][d2d][nvmath][debug]")
 {
-  cuda::std::array<int, 2> shape{4, 256};
-  cuda::std::array<int, 2> src_strides{512, 1};
-  cuda::std::array<int, 2> dst_strides{256, 1};
+  const cuda::std::array<int, 2> shape{4, 256};
+  const cuda::std::array<int, 2> src_strides{512, 1};
+  const cuda::std::array<int, 2> dst_strides{256, 1};
   test_copy_stride_relaxed<data_t>(2048 + 256, 256, shape, src_strides, 1024, 0, dst_strides);
 }
 
@@ -45,9 +45,9 @@ TEST_CASE("copy d2d nvmath small sliced_vec", "[copy][d2d][nvmath][debug]")
   constexpr int src_alloc  = 3 * 256 * 10 * 24;
   constexpr int dst_alloc  = 3 * 255 * 10 * 24;
   constexpr int src_offset = 240;
-  cuda::std::array<int, 4> shape{3, 255, 10, 24};
-  cuda::std::array<int, 4> src_strides{61440, 240, 24, 1};
-  cuda::std::array<int, 4> dst_strides{61200, 240, 24, 1};
+  const cuda::std::array<int, 4> shape{3, 255, 10, 24};
+  const cuda::std::array<int, 4> src_strides{61440, 240, 24, 1};
+  const cuda::std::array<int, 4> dst_strides{61200, 240, 24, 1};
   test_copy_stride_relaxed<data_t>(src_alloc, src_offset, shape, src_strides, dst_alloc, 0, dst_strides);
 }
 
@@ -78,8 +78,8 @@ TEST_CASE("copy d2d nvmath memcpy_layout_2", "[copy][d2d][nvmath][memcpy]")
   constexpr int src_alloc  = 1001 * 1007 * 3 * 31;
   constexpr int dst_alloc  = 1001 * 1007 * 5 * 31;
   constexpr int dst_offset = 31248217;
-  cuda::std::array<int, 4> shape{1001, 1007, 3, 31};
-  cuda::std::array<int, 4> strides{31217, 1, 31248217, 1007};
+  const cuda::std::array<int, 4> shape{1001, 1007, 3, 31};
+  const cuda::std::array<int, 4> strides{31217, 1, 31248217, 1007};
   test_copy_stride_relaxed<data_t>(src_alloc, 0, shape, strides, dst_alloc, dst_offset, strides);
 }
 
@@ -91,9 +91,9 @@ TEST_CASE("copy d2d nvmath memcpy_layout_3", "[copy][d2d][nvmath][memcpy]")
   constexpr int src_offset = 12225987 + 4075329;
   constexpr int dst_alloc  = 57 * 71 * 5 * 1007 * 1;
   constexpr int dst_offset = 3 * 4075329;
-  cuda::std::array<int, 5> shape{57, 71, 1, 1007, 1};
-  cuda::std::array<int, 5> src_strides{71497, 1, 12225987, 71, 4075329};
-  cuda::std::array<int, 5> dst_strides{71497, 1, 4075329, 71, 20376645};
+  const cuda::std::array<int, 5> shape{57, 71, 1, 1007, 1};
+  const cuda::std::array<int, 5> src_strides{71497, 1, 12225987, 71, 4075329};
+  const cuda::std::array<int, 5> dst_strides{71497, 1, 4075329, 71, 20376645};
   test_copy_stride_relaxed<data_t>(src_alloc, src_offset, shape, src_strides, dst_alloc, dst_offset, dst_strides);
 }
 
@@ -103,8 +103,8 @@ TEST_CASE("copy d2d nvmath memcpy_neg", "[copy][d2d][nvmath][memcpy]")
 {
   constexpr int alloc  = 63 * 70 * 1001;
   constexpr int offset = 1000;
-  cuda::std::array<int, 3> shape{63, 70, 1001};
-  cuda::std::array<int, 3> strides{1001, 63063, -1};
+  const cuda::std::array<int, 3> shape{63, 70, 1001};
+  const cuda::std::array<int, 3> strides{1001, 63063, -1};
   test_copy_stride_relaxed<data_t>(alloc, offset, shape, strides);
 }
 
@@ -118,9 +118,9 @@ TEST_CASE("copy d2d nvmath reorder_strides", "[copy][d2d][nvmath][reorder_stride
 {
   constexpr int src_alloc = 8 * 100019 * 11;
   constexpr int dst_alloc = 8 * 100019 * 4;
-  cuda::std::array<int, 3> shape{8, 100019, 4};
-  cuda::std::array<int, 3> src_strides{1100209, 11, 3};
-  cuda::std::array<int, 3> dst_strides{1, 8, 800152};
+  const cuda::std::array<int, 3> shape{8, 100019, 4};
+  const cuda::std::array<int, 3> src_strides{1100209, 11, 3};
+  const cuda::std::array<int, 3> dst_strides{1, 8, 800152};
   test_copy_stride_relaxed<data_t>(src_alloc, 0, shape, src_strides, dst_alloc, 0, dst_strides);
 }
 
@@ -134,9 +134,9 @@ TEST_CASE("copy d2d nvmath src_neg_stride", "[copy][d2d][nvmath][neg_stride]")
 {
   constexpr int alloc      = 63 * 70 * 1001;
   constexpr int src_offset = alloc - 1;
-  cuda::std::array<int, 3> shape{63, 70, 1001};
-  cuda::std::array<int, 3> src_strides{-1001, -63063, -1};
-  cuda::std::array<int, 3> dst_strides{70070, 1001, 1};
+  const cuda::std::array<int, 3> shape{63, 70, 1001};
+  const cuda::std::array<int, 3> src_strides{-1001, -63063, -1};
+  const cuda::std::array<int, 3> dst_strides{70070, 1001, 1};
   test_copy_stride_relaxed<data_t>(alloc, src_offset, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -176,11 +176,11 @@ TEST_CASE("copy d2d nvmath flatten_one", "[copy][d2d][nvmath][flatten]")
 {
   constexpr int src_alloc = 1 << 23;
   constexpr int dst_alloc = 1 << 21;
-  cuda::std::array<int, 20> shape{4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
-  cuda::std::array<int, 20> src_strides{
+  const cuda::std::array<int, 20> shape{4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+  const cuda::std::array<int, 20> src_strides{
     5,       1 << 4,  1 << 5,  1 << 6,  1 << 7,  1 << 8,  1 << 9,  1 << 10, 1 << 11, 1 << 12,
     1 << 13, 1 << 14, 1 << 15, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20, 1 << 21, 1 << 22};
-  cuda::std::array<int, 20> dst_strides{
+  const cuda::std::array<int, 20> dst_strides{
     1 << 19, 1 << 18, 1 << 17, 1 << 16, 1 << 15, 1 << 14, 1 << 13, 1 << 12, 1 << 11, 1 << 10,
     1 << 9,  1 << 8,  1 << 7,  1 << 6,  1 << 5,  1 << 4,  1 << 3,  1 << 2,  1 << 1,  1 << 0};
   test_copy_stride_relaxed<data_t>(src_alloc, 0, shape, src_strides, dst_alloc, 0, dst_strides);
@@ -197,9 +197,9 @@ TEST_CASE("copy d2d nvmath sliced_vec", "[copy][d2d][nvmath][vectorize]")
   constexpr int src_alloc  = 35 * 256 * 10 * 24;
   constexpr int dst_alloc  = 35 * 255 * 10 * 24;
   constexpr int src_offset = 240;
-  cuda::std::array<int, 4> shape{35, 255, 10, 24};
-  cuda::std::array<int, 4> src_strides{61440, 240, 24, 1};
-  cuda::std::array<int, 4> dst_strides{61200, 240, 24, 1};
+  const cuda::std::array<int, 4> shape{35, 255, 10, 24};
+  const cuda::std::array<int, 4> src_strides{61440, 240, 24, 1};
+  const cuda::std::array<int, 4> dst_strides{61200, 240, 24, 1};
   test_copy_stride_relaxed<data_t>(src_alloc, src_offset, shape, src_strides, dst_alloc, 0, dst_strides);
 }
 
@@ -210,9 +210,9 @@ TEST_CASE("copy d2d nvmath sliced_vec_2", "[copy][d2d][nvmath][vectorize]")
   constexpr int src_alloc  = 355 * 256 * 4 * 3;
   constexpr int dst_alloc  = 355 * 255 * 4 * 3;
   constexpr int src_offset = 12;
-  cuda::std::array<int, 4> shape{355, 255, 4, 3};
-  cuda::std::array<int, 4> src_strides{3072, 12, 3, 1};
-  cuda::std::array<int, 4> dst_strides{3060, 12, 3, 1};
+  const cuda::std::array<int, 4> shape{355, 255, 4, 3};
+  const cuda::std::array<int, 4> src_strides{3072, 12, 3, 1};
+  const cuda::std::array<int, 4> dst_strides{3060, 12, 3, 1};
   test_copy_stride_relaxed<data_t>(src_alloc, src_offset, shape, src_strides, dst_alloc, 0, dst_strides);
 }
 
@@ -223,8 +223,8 @@ TEST_CASE("copy d2d nvmath sliced_unaligned_ptr", "[copy][d2d][nvmath][vectorize
   constexpr int src_alloc  = 35 * 255 * 30 * 20;
   constexpr int dst_alloc  = 35 * 255 * 5 * 10;
   constexpr int src_offset = 10 * 20 + 5;
-  cuda::std::array<int, 4> shape{35, 255, 5, 10};
-  cuda::std::array<int, 4> src_strides{153000, 600, 20, 1};
-  cuda::std::array<int, 4> dst_strides{12750, 50, 10, 1};
+  const cuda::std::array<int, 4> shape{35, 255, 5, 10};
+  const cuda::std::array<int, 4> src_strides{153000, 600, 20, 1};
+  const cuda::std::array<int, 4> dst_strides{12750, 50, 10, 1};
   test_copy_stride_relaxed<data_t>(src_alloc, src_offset, shape, src_strides, dst_alloc, 0, dst_strides);
 }

--- a/cudax/test/copy/copy_nvmath_transpose.cu
+++ b/cudax/test/copy/copy_nvmath_transpose.cu
@@ -37,11 +37,11 @@ TEST_CASE("copy d2d nvmath transpose_merge_extents", "[copy][d2d][nvmath][transp
     s = 2;
   }
   // clang-format off
-  cuda::std::array<int, 20> src_strides{
+  const cuda::std::array<int, 20> src_strides{
     1 << 19, 1 << 18, 1 << 17, 1 << 16, 1 << 15, 1 << 14, 1 << 13, 1 << 12,
     1 << 11, 1 << 10, 1 << 9,  1 << 8,  1 << 7,  1 << 6,  1 << 5,  1 << 4,
     1 << 3,  1 << 2,  1 << 1,  1 << 0};
-  cuda::std::array<int, 20> dst_strides{
+  const cuda::std::array<int, 20> dst_strides{
     1 << 0,  1 << 1,  1 << 2,  1 << 3,  1 << 4,  1 << 5,  1 << 6,  1 << 7,
     1 << 8,  1 << 9,  1 << 10, 1 << 11, 1 << 12, 1 << 13, 1 << 14, 1 << 15,
     1 << 16, 1 << 17, 1 << 18, 1 << 19};
@@ -54,9 +54,9 @@ TEST_CASE("copy d2d nvmath transpose_merge_extents", "[copy][d2d][nvmath][transp
 TEST_CASE("copy d2d nvmath transpose", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 55 * 13 * 55 * 55;
-  cuda::std::array<int, 4> shape{55, 13, 55, 55};
-  cuda::std::array<int, 4> src_strides{13, 1, 39325, 715};
-  cuda::std::array<int, 4> dst_strides{39325, 3025, 55, 1};
+  const cuda::std::array<int, 4> shape{55, 13, 55, 55};
+  const cuda::std::array<int, 4> src_strides{13, 1, 39325, 715};
+  const cuda::std::array<int, 4> dst_strides{39325, 3025, 55, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -65,9 +65,9 @@ TEST_CASE("copy d2d nvmath transpose", "[copy][d2d][nvmath][transpose]")
 TEST_CASE("copy d2d nvmath transpose_2", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 55 * 55 * 13 * 55;
-  cuda::std::array<int, 4> shape{55, 55, 13, 55};
-  cuda::std::array<int, 4> src_strides{715, 39325, 1, 13};
-  cuda::std::array<int, 4> dst_strides{39325, 715, 55, 1};
+  const cuda::std::array<int, 4> shape{55, 55, 13, 55};
+  const cuda::std::array<int, 4> src_strides{715, 39325, 1, 13};
+  const cuda::std::array<int, 4> dst_strides{39325, 715, 55, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -76,9 +76,9 @@ TEST_CASE("copy d2d nvmath transpose_2", "[copy][d2d][nvmath][transpose]")
 TEST_CASE("copy d2d nvmath transpose_3", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 101 * 101 * 101 * 101;
-  cuda::std::array<int, 4> shape{101, 101, 101, 101};
-  cuda::std::array<int, 4> src_strides{101, 1030301, 1, 10201};
-  cuda::std::array<int, 4> dst_strides{1030301, 10201, 101, 1};
+  const cuda::std::array<int, 4> shape{101, 101, 101, 101};
+  const cuda::std::array<int, 4> src_strides{101, 1030301, 1, 10201};
+  const cuda::std::array<int, 4> dst_strides{1030301, 10201, 101, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -87,9 +87,9 @@ TEST_CASE("copy d2d nvmath transpose_3", "[copy][d2d][nvmath][transpose]")
 TEST_CASE("copy d2d nvmath transpose_small_tile", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 7 * 100019 * 7;
-  cuda::std::array<int, 3> shape{7, 100019, 7};
-  cuda::std::array<int, 3> src_strides{1, 7, 700133};
-  cuda::std::array<int, 3> dst_strides{700133, 7, 1};
+  const cuda::std::array<int, 3> shape{7, 100019, 7};
+  const cuda::std::array<int, 3> src_strides{1, 7, 700133};
+  const cuda::std::array<int, 3> dst_strides{700133, 7, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -98,9 +98,9 @@ TEST_CASE("copy d2d nvmath transpose_small_tile", "[copy][d2d][nvmath][transpose
 TEST_CASE("copy d2d nvmath transpose_small_tile_2", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 33 * 100019 * 33;
-  cuda::std::array<int, 3> shape{33, 100019, 33};
-  cuda::std::array<int, 3> src_strides{1, 33, 3300627};
-  cuda::std::array<int, 3> dst_strides{3300627, 33, 1};
+  const cuda::std::array<int, 3> shape{33, 100019, 33};
+  const cuda::std::array<int, 3> src_strides{1, 33, 3300627};
+  const cuda::std::array<int, 3> dst_strides{3300627, 33, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -109,9 +109,9 @@ TEST_CASE("copy d2d nvmath transpose_small_tile_2", "[copy][d2d][nvmath][transpo
 TEST_CASE("copy d2d nvmath transpose_small_tile_3", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 7 * 100019 * 7;
-  cuda::std::array<int, 3> shape{7, 100019, 7};
-  cuda::std::array<int, 3> src_strides{1, 49, 7};
-  cuda::std::array<int, 3> dst_strides{700133, 1, 100019};
+  const cuda::std::array<int, 3> shape{7, 100019, 7};
+  const cuda::std::array<int, 3> src_strides{1, 49, 7};
+  const cuda::std::array<int, 3> dst_strides{700133, 1, 100019};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -120,9 +120,9 @@ TEST_CASE("copy d2d nvmath transpose_small_tile_3", "[copy][d2d][nvmath][transpo
 TEST_CASE("copy d2d nvmath transpose_small_tile_4", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 33 * 100019 * 33;
-  cuda::std::array<int, 3> shape{33, 100019, 33};
-  cuda::std::array<int, 3> src_strides{1, 1089, 33};
-  cuda::std::array<int, 3> dst_strides{3300627, 1, 100019};
+  const cuda::std::array<int, 3> shape{33, 100019, 33};
+  const cuda::std::array<int, 3> src_strides{1, 1089, 33};
+  const cuda::std::array<int, 3> dst_strides{3300627, 1, 100019};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -131,9 +131,9 @@ TEST_CASE("copy d2d nvmath transpose_small_tile_4", "[copy][d2d][nvmath][transpo
 TEST_CASE("copy d2d nvmath transpose_channels", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 10001 * 10001 * 3;
-  cuda::std::array<int, 3> shape{10001, 10001, 3};
-  cuda::std::array<int, 3> src_strides{3, 30003, 1};
-  cuda::std::array<int, 3> dst_strides{30003, 3, 1};
+  const cuda::std::array<int, 3> shape{10001, 10001, 3};
+  const cuda::std::array<int, 3> src_strides{3, 30003, 1};
+  const cuda::std::array<int, 3> dst_strides{30003, 3, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -142,9 +142,9 @@ TEST_CASE("copy d2d nvmath transpose_channels", "[copy][d2d][nvmath][transpose]"
 TEST_CASE("copy d2d nvmath transpose_channels_2", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 1001 * 1001 * 3 * 3 * 3;
-  cuda::std::array<int, 5> shape{1001, 1001, 3, 3, 3};
-  cuda::std::array<int, 5> src_strides{27, 27027, 9, 1, 3};
-  cuda::std::array<int, 5> dst_strides{27027, 27, 9, 3, 1};
+  const cuda::std::array<int, 5> shape{1001, 1001, 3, 3, 3};
+  const cuda::std::array<int, 5> src_strides{27, 27027, 9, 1, 3};
+  const cuda::std::array<int, 5> dst_strides{27027, 27, 9, 3, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -153,9 +153,9 @@ TEST_CASE("copy d2d nvmath transpose_channels_2", "[copy][d2d][nvmath][transpose
 TEST_CASE("copy d2d nvmath transpose_inbalanced", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 3 * 1000033;
-  cuda::std::array<int, 2> shape{3, 1000033};
-  cuda::std::array<int, 2> src_strides{1, 3};
-  cuda::std::array<int, 2> dst_strides{1000033, 1};
+  const cuda::std::array<int, 2> shape{3, 1000033};
+  const cuda::std::array<int, 2> src_strides{1, 3};
+  const cuda::std::array<int, 2> dst_strides{1000033, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -167,8 +167,8 @@ TEST_CASE("copy d2d nvmath transpose_inbalanced", "[copy][d2d][nvmath][transpose
 TEST_CASE("copy d2d nvmath transpose_max_shared_mem_rank", "[copy][d2d][nvmath][transpose]")
 {
   constexpr int alloc = 4 * 4 * 4 * 4 * 4 * 4 * 16 * 8; // 524288
-  cuda::std::array<int, 8> shape{4, 4, 4, 4, 4, 4, 16, 8};
-  cuda::std::array<int, 8> src_strides{1, 4, 16, 64, 256, 1024, 4096, 65536};
-  cuda::std::array<int, 8> dst_strides{131072, 32768, 8192, 2048, 512, 128, 8, 1};
+  const cuda::std::array<int, 8> shape{4, 4, 4, 4, 4, 4, 16, 8};
+  const cuda::std::array<int, 8> src_strides{1, 4, 16, 64, 256, 1024, 4096, 65536};
+  const cuda::std::array<int, 8> dst_strides{131072, 32768, 8192, 2048, 512, 128, 8, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }

--- a/cudax/test/copy/copy_shared_memory.cu
+++ b/cudax/test/copy/copy_shared_memory.cu
@@ -24,9 +24,9 @@ TEST_CASE("copy d2d shared_memory 2D transpose", "[copy][d2d][shared_memory][tra
   constexpr int M     = 8192;
   constexpr int N     = 32;
   constexpr int alloc = M * N;
-  cuda::std::array<int, 2> shape{M, N};
-  cuda::std::array<int, 2> src_strides{1, M};
-  cuda::std::array<int, 2> dst_strides{N, 1};
+  const cuda::std::array<int, 2> shape{M, N};
+  const cuda::std::array<int, 2> src_strides{1, M};
+  const cuda::std::array<int, 2> dst_strides{N, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -39,9 +39,9 @@ TEST_CASE("copy d2d shared_memory 2D partial tiles", "[copy][d2d][shared_memory]
   constexpr int M     = 8193;
   constexpr int N     = 37;
   constexpr int alloc = M * N;
-  cuda::std::array<int, 2> shape{M, N};
-  cuda::std::array<int, 2> src_strides{1, M};
-  cuda::std::array<int, 2> dst_strides{N, 1};
+  const cuda::std::array<int, 2> shape{M, N};
+  const cuda::std::array<int, 2> src_strides{1, M};
+  const cuda::std::array<int, 2> dst_strides{N, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -54,9 +54,9 @@ TEST_CASE("copy d2d shared_memory 3D transpose", "[copy][d2d][shared_memory][tra
   constexpr int D1    = 16;
   constexpr int D2    = 16;
   constexpr int alloc = D0 * D1 * D2;
-  cuda::std::array<int, 3> shape{D0, D1, D2};
-  cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
-  cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> shape{D0, D1, D2};
+  const cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
+  const cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -69,9 +69,9 @@ TEST_CASE("copy d2d shared_memory 3D partial tiles", "[copy][d2d][shared_memory]
   constexpr int D1    = 16;
   constexpr int D2    = 16;
   constexpr int alloc = D0 * D1 * D2;
-  cuda::std::array<int, 3> shape{D0, D1, D2};
-  cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
-  cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> shape{D0, D1, D2};
+  const cuda::std::array<int, 3> src_strides{1, D0, D0 * D1};
+  const cuda::std::array<int, 3> dst_strides{D1 * D2, D2, 1};
   test_copy_stride_relaxed<data_t>(alloc, 0, shape, src_strides, alloc, 0, dst_strides);
 }
 
@@ -86,8 +86,8 @@ TEST_CASE("copy d2d shared_memory 3D padded small dimension", "[copy][d2d][share
   constexpr int dst_pitch = 16;
   constexpr int src_alloc = D0 * D1 * D2;
   constexpr int dst_alloc = D0 * D1 * dst_pitch;
-  cuda::std::array<int, 3> shape{D0, D1, D2};
-  cuda::std::array<int, 3> src_strides{1, D0 * D2, D0};
-  cuda::std::array<int, 3> dst_strides{D1 * dst_pitch, dst_pitch, 1};
+  const cuda::std::array<int, 3> shape{D0, D1, D2};
+  const cuda::std::array<int, 3> src_strides{1, D0 * D2, D0};
+  const cuda::std::array<int, 3> dst_strides{D1 * dst_pitch, dst_pitch, 1};
   test_copy_stride_relaxed<data_t>(src_alloc, 0, shape, src_strides, dst_alloc, 0, dst_strides);
 }

--- a/cudax/test/copy_bytes/mdspan_d2h_h2d.cu
+++ b/cudax/test/copy_bytes/mdspan_d2h_h2d.cu
@@ -40,8 +40,8 @@ void test_impl(const thrust::host_vector<T>& input,
     // host to device
     using host_mdspan_t   = cuda::host_mdspan<const T, src_extents_t, SrcLayout>;
     using device_mdspan_t = cuda::device_mdspan<T, dst_extents_t, DstLayout>;
-    host_mdspan_t host_md(input.data(), src_mapping_t(src_extents));
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), dst_mapping_t(dst_extents));
+    const host_mdspan_t host_md(input.data(), src_mapping_t(src_extents));
+    const device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), dst_mapping_t(dst_extents));
     cuda::experimental::copy_bytes(host_md, device_md, stream);
     stream.sync();
     REQUIRE(thrust::host_vector<T>(device_data) == expected_data);
@@ -52,8 +52,8 @@ void test_impl(const thrust::host_vector<T>& input,
     using host_mdspan_t   = cuda::host_mdspan<T, dst_extents_t, DstLayout>;
     thrust::host_vector<T> host_data(input.size(), 0);
     device_data = input;
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), src_mapping_t(src_extents));
-    host_mdspan_t host_md(host_data.data(), dst_mapping_t(dst_extents));
+    const device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), src_mapping_t(src_extents));
+    const host_mdspan_t host_md(host_data.data(), dst_mapping_t(dst_extents));
     cuda::experimental::copy_bytes(device_md, host_md, stream);
     stream.sync();
     REQUIRE(host_data == expected_data);
@@ -78,8 +78,9 @@ void test_impl_stride(
     // host to device
     using host_mdspan_t   = cuda::host_mdspan<const T, src_extents_t, cuda::std::layout_stride>;
     using device_mdspan_t = cuda::device_mdspan<T, dst_extents_t, cuda::std::layout_stride>;
-    host_mdspan_t host_md(input.data(), src_mapping_t(src_extents, src_strides));
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), dst_mapping_t(dst_extents, dst_strides));
+    const host_mdspan_t host_md(input.data(), src_mapping_t(src_extents, src_strides));
+    const device_mdspan_t device_md(
+      thrust::raw_pointer_cast(device_data.data()), dst_mapping_t(dst_extents, dst_strides));
     cuda::experimental::copy_bytes(host_md, device_md, stream);
     stream.sync();
     REQUIRE(thrust::host_vector<T>(device_data) == expected_data);
@@ -90,8 +91,9 @@ void test_impl_stride(
     using host_mdspan_t   = cuda::host_mdspan<T, dst_extents_t, cuda::std::layout_stride>;
     thrust::host_vector<T> host_data(input.size(), 0);
     device_data = input;
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()), src_mapping_t(src_extents, src_strides));
-    host_mdspan_t host_md(host_data.data(), dst_mapping_t(dst_extents, dst_strides));
+    const device_mdspan_t device_md(
+      thrust::raw_pointer_cast(device_data.data()), src_mapping_t(src_extents, src_strides));
+    const host_mdspan_t host_md(host_data.data(), dst_mapping_t(dst_extents, dst_strides));
     cuda::experimental::copy_bytes(device_md, host_md, stream);
     stream.sync();
     REQUIRE(host_data == expected_data);
@@ -119,9 +121,9 @@ void test_impl_stride_offset(
     // host to device
     using host_mdspan_t   = cuda::host_mdspan<const T, src_extents_t, cuda::std::layout_stride>;
     using device_mdspan_t = cuda::device_mdspan<T, dst_extents_t, cuda::std::layout_stride>;
-    host_mdspan_t host_md(input.data() + src_offset, src_mapping_t(src_extents, src_strides));
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()) + dst_offset,
-                              dst_mapping_t(dst_extents, dst_strides));
+    const host_mdspan_t host_md(input.data() + src_offset, src_mapping_t(src_extents, src_strides));
+    const device_mdspan_t device_md(
+      thrust::raw_pointer_cast(device_data.data()) + dst_offset, dst_mapping_t(dst_extents, dst_strides));
     cuda::experimental::copy_bytes(host_md, device_md, stream);
     stream.sync();
     REQUIRE(thrust::host_vector<T>(device_data) == expected_data);
@@ -132,9 +134,9 @@ void test_impl_stride_offset(
     using host_mdspan_t              = cuda::host_mdspan<T, dst_extents_t, cuda::std::layout_stride>;
     thrust::host_vector<T> host_data = initial_output;
     device_data                      = input;
-    device_mdspan_t device_md(thrust::raw_pointer_cast(device_data.data()) + src_offset,
-                              src_mapping_t(src_extents, src_strides));
-    host_mdspan_t host_md(host_data.data() + dst_offset, dst_mapping_t(dst_extents, dst_strides));
+    const device_mdspan_t device_md(
+      thrust::raw_pointer_cast(device_data.data()) + src_offset, src_mapping_t(src_extents, src_strides));
+    const host_mdspan_t host_md(host_data.data() + dst_offset, dst_mapping_t(dst_extents, dst_strides));
     cuda::experimental::copy_bytes(device_md, host_md, stream);
     stream.sync();
     REQUIRE(host_data == expected_data);
@@ -308,7 +310,7 @@ TEST_CASE("copy_bytes 3D", "[copy_bytes][3d]")
 
 TEST_CASE("copy_bytes rank 0", "[copy_bytes][0d]")
 {
-  thrust::host_vector<int> host_data(1, 42);
+  const thrust::host_vector<int> host_data(1, 42);
   using extents = cuda::std::extents<int>;
   test_impl(host_data, host_data, extents(), extents());
 }
@@ -317,8 +319,8 @@ TEST_CASE("copy_bytes size 0", "[copy_bytes][zero_size]")
 {
   int value = 42;
   thrust::device_vector<int> device_data(1, 0);
-  cuda::host_mdspan<int, cuda::std::dims<2>> src(&value, 0, 0);
-  cuda::device_mdspan<int, cuda::std::dims<2>> device_md(thrust::raw_pointer_cast(device_data.data()), 0, 0);
+  const cuda::host_mdspan<int, cuda::std::dims<2>> src(&value, 0, 0);
+  const cuda::device_mdspan<int, cuda::std::dims<2>> device_md(thrust::raw_pointer_cast(device_data.data()), 0, 0);
   cuda::experimental::copy_bytes(src, device_md, stream);
   stream.sync();
 }
@@ -329,8 +331,8 @@ TEST_CASE("copy_bytes size mismatch throws", "[copy_bytes][throw]")
   thrust::host_vector<int> host_data(N, 0);
   thrust::device_vector<int> device_data(N / 2, 0);
   using extents = cuda::std::dims<1>;
-  cuda::host_mdspan<int, extents> src(host_data.data(), extents(N));
-  cuda::device_mdspan<int, extents> dst(thrust::raw_pointer_cast(device_data.data()), extents(N / 2));
+  const cuda::host_mdspan<int, extents> src(host_data.data(), extents(N));
+  const cuda::device_mdspan<int, extents> dst(thrust::raw_pointer_cast(device_data.data()), extents(N / 2));
   REQUIRE_THROWS_AS(cuda::experimental::copy_bytes(src, dst, stream), std::invalid_argument);
 }
 
@@ -342,8 +344,8 @@ TEST_CASE("copy_bytes extent mismatch throws", "[copy_bytes][throw]")
   thrust::device_vector<int> device_data(M * N, 0);
   using src_extents = cuda::std::extents<int, M, N>;
   using dst_extents = cuda::std::extents<int, N, M>;
-  cuda::host_mdspan<int, src_extents> src(host_data.data());
-  cuda::device_mdspan<int, dst_extents> dst(thrust::raw_pointer_cast(device_data.data()));
+  const cuda::host_mdspan<int, src_extents> src(host_data.data());
+  const cuda::device_mdspan<int, dst_extents> dst(thrust::raw_pointer_cast(device_data.data()));
   REQUIRE_THROWS_AS(cuda::experimental::copy_bytes(src, dst, stream), std::invalid_argument);
 }
 
@@ -369,9 +371,9 @@ TEST_CASE("copy_bytes 2D strided, padded layout", "[copy_bytes][2d][stride][row]
       host_data[static_cast<std::size_t>(i) * N * 2 + j] = static_cast<int>(static_cast<std::size_t>(i) * N + j);
     }
   }
-  using src_extents                = cuda::std::extents<int, M, N>;
-  using dst_extents                = cuda::std::extents<int, M, N>;
-  cuda::std::array<int, 2> strides = {Ld, 1};
+  using src_extents                      = cuda::std::extents<int, M, N>;
+  using dst_extents                      = cuda::std::extents<int, M, N>;
+  const cuda::std::array<int, 2> strides = {Ld, 1};
   test_impl_stride(host_data, host_data, src_extents(), dst_extents(), strides, strides);
 }
 
@@ -394,8 +396,8 @@ TEST_CASE("copy_bytes 2D strided, padded column-major", "[copy_bytes][2d][stride
       input_data[i + static_cast<std::size_t>(j) * Ld] = k++;
     }
   }
-  using extents                    = cuda::std::extents<int, M, N>;
-  cuda::std::array<int, 2> strides = {1, Ld};
+  using extents                          = cuda::std::extents<int, M, N>;
+  const cuda::std::array<int, 2> strides = {1, Ld};
   test_impl_stride(input_data, input_data, extents(), extents(), strides, strides);
 }
 
@@ -430,9 +432,9 @@ TEST_CASE("copy_bytes 3D strided, permutation", "[copy_bytes][3d][stride][permut
       }
     }
   }
-  using extents                        = cuda::std::extents<int, D0, D1, D2>;
-  cuda::std::array<int, 3> src_strides = {D1 * D2, D2, 1};
-  cuda::std::array<int, 3> dst_strides = {1, D2 * D0, D0};
+  using extents                              = cuda::std::extents<int, D0, D1, D2>;
+  const cuda::std::array<int, 3> src_strides = {D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> dst_strides = {1, D2 * D0, D0};
   test_impl_stride(input_data, expected, extents(), extents(), src_strides, dst_strides);
 }
 
@@ -474,9 +476,9 @@ TEST_CASE("copy_bytes 3D strided, tile_size > 1 with different stride order", "[
       }
     }
   }
-  using extents                        = cuda::std::extents<int, D0, D1, D2>;
-  cuda::std::array<int, 3> src_strides = {D1 * D2, D2, 1};
-  cuda::std::array<int, 3> dst_strides = {8, 16, 1};
+  using extents                              = cuda::std::extents<int, D0, D1, D2>;
+  const cuda::std::array<int, 3> src_strides = {D1 * D2, D2, 1};
+  const cuda::std::array<int, 3> dst_strides = {8, 16, 1};
   test_impl_stride(input_data, expected, extents(), extents(), src_strides, dst_strides);
 }
 
@@ -495,7 +497,7 @@ TEST_CASE("copy_bytes strided subviews with offsets", "[copy_bytes][stride][offs
   constexpr int DstOffset = 3;
   constexpr int Alloc     = 16;
   thrust::host_vector<int> input(Alloc, -1);
-  thrust::host_vector<int> initial_output(Alloc, -1);
+  const thrust::host_vector<int> initial_output(Alloc, -1);
   thrust::host_vector<int> expected(Alloc, -1);
   int value = 0;
   for (int i = 0; i < M; ++i)
@@ -507,9 +509,9 @@ TEST_CASE("copy_bytes strided subviews with offsets", "[copy_bytes][stride][offs
       ++value;
     }
   }
-  using extents                        = cuda::std::extents<int, M, N>;
-  cuda::std::array<int, 2> src_strides = {SrcLd, 1};
-  cuda::std::array<int, 2> dst_strides = {1, DstLd};
+  using extents                              = cuda::std::extents<int, M, N>;
+  const cuda::std::array<int, 2> src_strides = {SrcLd, 1};
+  const cuda::std::array<int, 2> dst_strides = {1, DstLd};
   test_impl_stride_offset(
     input, initial_output, expected, extents(), extents(), src_strides, dst_strides, SrcOffset, DstOffset);
 }

--- a/cudax/test/copy_bytes/mdspan_d2h_h2d_relaxed.cu
+++ b/cudax/test/copy_bytes/mdspan_d2h_h2d_relaxed.cu
@@ -33,8 +33,8 @@ void test_impl_relaxed(
   thrust::device_vector<T> device_data(expected.size(), 0);
   {
     // host to device
-    cuda::host_mdspan<const T, extents_t, cuda::layout_stride_relaxed> host_md(input.data(), src_mapping);
-    cuda::device_mdspan<T, extents_t> device_md(thrust::raw_pointer_cast(device_data.data()), dst_mapping);
+    const cuda::host_mdspan<const T, extents_t, cuda::layout_stride_relaxed> host_md(input.data(), src_mapping);
+    const cuda::device_mdspan<T, extents_t> device_md(thrust::raw_pointer_cast(device_data.data()), dst_mapping);
     cuda::experimental::copy_bytes(host_md, device_md, stream);
     stream.sync();
     REQUIRE(thrust::host_vector<T>(device_data) == expected);
@@ -43,9 +43,9 @@ void test_impl_relaxed(
     // device to host
     thrust::host_vector<T> host_output(expected.size(), 0);
     thrust::device_vector<T> device_input(input.begin(), input.end());
-    cuda::device_mdspan<const T, extents_t, cuda::layout_stride_relaxed> device_md(
+    const cuda::device_mdspan<const T, extents_t, cuda::layout_stride_relaxed> device_md(
       thrust::raw_pointer_cast(device_input.data()), src_mapping);
-    cuda::host_mdspan<T, extents_t> host_md(host_output.data(), dst_mapping);
+    const cuda::host_mdspan<T, extents_t> host_md(host_output.data(), dst_mapping);
     cuda::experimental::copy_bytes(device_md, host_md, stream);
     stream.sync();
     REQUIRE(host_output == expected);
@@ -143,7 +143,7 @@ TEST_CASE("copy_bytes layout_stride_relaxed, offset subarray", "[copy_bytes][rel
   // src(0,0) = input[2]  = 2,  src(0,1) = input[3]  = 3
   // src(1,0) = input[6]  = 6,  src(1,1) = input[7]  = 7
   // src(2,0) = input[10] = 10, src(2,1) = input[11] = 11
-  thrust::host_vector<int> expected = {2, 3, 6, 7, 10, 11};
+  const thrust::host_vector<int> expected = {2, 3, 6, 7, 10, 11};
 
   using extents_t = cuda::std::extents<int, Rows, Cols>;
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;

--- a/cudax/test/cuco/fixed_capacity_map/test_capacity.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_capacity.cu
@@ -41,10 +41,10 @@ C2H_TEST("fixed_capacity_map dynamic capacity — capacity() reflects the valid 
   const auto valid =
     cudax::cuco::make_valid_capacity<dyn_map_t::probing_scheme_type, dyn_map_t::bucket_size>(requested);
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
-  dyn_map_t map{stream, mr, requested, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
+  const dyn_map_t map{stream, mr, requested, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
   REQUIRE(map.capacity() == valid);
   REQUIRE(map.capacity() >= requested);
 }
@@ -65,10 +65,10 @@ C2H_TEST("fixed_capacity_map static capacity — valid capacity and capacity_v",
   static_assert(smap_t::capacity_v == valid, "the map type carries the valid capacity, not the request");
   static_assert(smap_t::ref_type::capacity_v == valid, "the ref carries the same valid capacity");
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
-  smap_t map{stream, mr, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
+  const smap_t map{stream, mr, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
   REQUIRE(map.capacity() == valid);
 }
 
@@ -77,10 +77,10 @@ C2H_TEST("fixed_capacity_map dynamic extent — load factor constructor", "[capa
   constexpr int num_elements   = 500;
   constexpr double load_factor = 0.5;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
-  cudax::cuco::fixed_capacity_map<int, int> map{
+  const cudax::cuco::fixed_capacity_map<int, int> map{
     stream,
     mr,
     static_cast<::cuda::std::size_t>(num_elements),

--- a/cudax/test/cuco/fixed_capacity_map/test_contains_if.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_contains_if.cu
@@ -119,7 +119,7 @@ C2H_TEST("fixed_capacity_map contains_if", "[container]", key_types, cg_sizes, b
   constexpr int num_queries             = 2 * num_present;
   constexpr key_type empty_key_sentinel = key_type{-1};
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr           = ::cuda::device_default_memory_pool(stream.device());
   const auto policy = ::cuda::execution::gpu.with(::cuda::get_stream, stream).with(::cuda::mr::get_memory_resource, mr);
 

--- a/cudax/test/cuco/fixed_capacity_map/test_find.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_find.cu
@@ -124,7 +124,7 @@ C2H_TEST("fixed_capacity_map find", "[container]", key_types, cg_sizes, bucket_s
   constexpr int num_keys      = 400;
   constexpr key_type sentinel = key_type{-1};
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   map_type map{stream,

--- a/cudax/test/cuco/fixed_capacity_map/test_insert_and_contains.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_insert_and_contains.cu
@@ -96,7 +96,7 @@ C2H_TEST("fixed_capacity_map insert and contains", "[container]", key_types, cg_
 
   constexpr int num_keys = (::cuda::std::numeric_limits<key_type>::max() > 800) ? 400 : 100;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   map_type map{stream,

--- a/cudax/test/cuco/fixed_capacity_map/test_insert_if.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_insert_if.cu
@@ -99,7 +99,7 @@ C2H_TEST("fixed_capacity_map insert_if", "[container]", key_types, cg_sizes, buc
   constexpr int num_keys                = 400;
   constexpr key_type empty_key_sentinel = key_type{-1};
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr           = ::cuda::device_default_memory_pool(stream.device());
   const auto policy = ::cuda::execution::gpu.with(::cuda::get_stream, stream).with(::cuda::mr::get_memory_resource, mr);
 

--- a/cudax/test/cuco/fixed_capacity_map/test_key_sentinel.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_key_sentinel.cu
@@ -63,7 +63,7 @@ C2H_TEST("fixed_capacity_map — empty and erased key sentinels", "[sentinel]")
     cudax::cuco::make_valid_capacity<probing, bucket>(::cuda::std::size_t{num_keys} * 2);
   using map_type = cudax::cuco::fixed_capacity_map<int, int, capacity>;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   map_type map{stream,

--- a/cudax/test/cuco/fixed_capacity_map/test_misaligned_storage.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_misaligned_storage.cu
@@ -102,11 +102,12 @@ void run_misaligned_external_storage()
   REQUIRE(cudaGetLastError() == cudaSuccess);
   REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
 
-  ref_type ref{cudax::cuco::empty_key<Key>{empty_k},
-               cudax::cuco::empty_value<Mapped>{empty_v},
-               ::cuda::std::equal_to<Key>{},
-               probing_type{},
-               span_type{slots, capacity}};
+  const ref_type ref{
+    cudax::cuco::empty_key<Key>{empty_k},
+    cudax::cuco::empty_value<Mapped>{empty_v},
+    ::cuda::std::equal_to<Key>{},
+    probing_type{},
+    span_type{slots, capacity}};
 
   insert_kernel<ref_type, Key><<<(num_keys + block - 1) / block, block>>>(ref, num_keys);
   REQUIRE(cudaGetLastError() == cudaSuccess);

--- a/cudax/test/cuco/fixed_capacity_map/test_rebind.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_rebind.cu
@@ -169,7 +169,7 @@ C2H_TEST("fixed_capacity_map_ref rebind APIs", "[ref][rebind]", key_types, cg_si
   constexpr int threads          = 128;
   constexpr int keys_per_block   = threads / cg_size;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   const auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   const probing_type probing_scheme = [&] {
@@ -255,7 +255,7 @@ C2H_TEST("fixed_capacity_map_ref rebind APIs preserve static capacity", "[ref][r
   constexpr int offset   = 1000;
   constexpr int threads  = 128;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   const auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
   map_type map{stream, mr, cudax::cuco::empty_key{-1}, cudax::cuco::empty_value{-1}};
 

--- a/cudax/test/cuco/fixed_capacity_map/test_retrieve_all.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_retrieve_all.cu
@@ -108,7 +108,7 @@ C2H_TEST(
   constexpr key_type key_sentinel      = key_type{-1};
   constexpr mapped_type value_sentinel = mapped_type{-1};
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   const auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   map_type map{stream,

--- a/cudax/test/cuco/fixed_capacity_map/test_shared_memory.cu
+++ b/cudax/test/cuco/fixed_capacity_map/test_shared_memory.cu
@@ -84,10 +84,11 @@ C2H_TEST("fixed_capacity_map static extent — shared memory sizing via capacity
 {
   constexpr int num_keys = 64;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
-  fixed_capacity_map_512_type map{stream, mr, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
+  const fixed_capacity_map_512_type map{
+    stream, mr, cudax::cuco::empty_key{empty_key}, cudax::cuco::empty_value{empty_value}};
 
   const int block_size = 128;
   const int grid_size  = (num_keys + block_size - 1) / block_size;
@@ -152,7 +153,7 @@ C2H_TEST("fixed_capacity_map_ref device initialize — map fully in shared memor
   constexpr int num_blocks = 8;
   constexpr int block_size = 64;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   auto thread_ok = ::cuda::make_buffer<int>(stream, mr, num_blocks * block_size, 0);
@@ -242,7 +243,7 @@ C2H_TEST("fixed_capacity_map_ref make_copy — shared memory copy of a map",
   constexpr int num_blocks = 8;
   constexpr int block_size = 128;
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   map_type map{stream,
@@ -344,7 +345,7 @@ C2H_TEST("fixed_capacity_map_ref initialize and make_copy — dynamic extent in 
   constexpr int block_size = 128;
   const auto capacity      = cudax::cuco::make_valid_capacity<probing, dynamic_bucket>(::cuda::std::size_t{256});
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   auto slots      = ::cuda::make_buffer<value_type>(stream, mr, capacity, ::cuda::no_init);

--- a/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
+++ b/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
@@ -94,7 +94,7 @@ C2H_TEST("HyperLogLog device ref", "[hyperloglog]", test_types)
 
   CAPTURE(num_items, hll_precision, sketch_size_kb);
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   // Generate `num_items` distinct items
@@ -132,7 +132,7 @@ C2H_TEST("HyperLogLog device ref merge", "[hyperloglog]")
   constexpr std::size_t num_items = 1 << 20;
   const estimator_type::precision precision{8};
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   estimator_type source{stream, mr, precision};
@@ -140,7 +140,7 @@ C2H_TEST("HyperLogLog device ref merge", "[hyperloglog]")
   source.add(stream, first, first + num_items);
   const auto source_estimate = source.estimate(stream);
 
-  estimator_type destination{stream, mr, precision};
+  const estimator_type destination{stream, mr, precision};
   merge_kernel<<<1, 128, 0, stream.get()>>>(destination.ref(), source.ref());
   REQUIRE(cudaGetLastError() == cudaSuccess);
 
@@ -165,7 +165,7 @@ C2H_TEST("HyperLogLog unique sequence", "[hyperloglog]", test_types)
   // RSD for a given precision is given by the following formula
   const double relative_standard_deviation = 1.04 / std::sqrt(static_cast<double>(1ull << hll_precision));
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   // Generate `num_items` distinct items
@@ -233,7 +233,7 @@ C2H_TEST("HyperLogLog Spark parity deterministic", "[hyperloglog]")
 
   auto items_begin = cuda::transform_iterator(cuda::counting_iterator<std::size_t>{0}, scaled_index{repeats});
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   estimator_type estimator{stream, mr, sd};
@@ -269,10 +269,10 @@ C2H_TEST("HyperLogLog precision constructor", "[hyperloglog]")
 
   REQUIRE(estimator_type::sketch_bytes(precision) == expected_sketch_bytes);
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
-  estimator_type estimator{stream, mr, precision};
+  const estimator_type estimator{stream, mr, precision};
 
   REQUIRE(estimator.sketch_bytes() == expected_sketch_bytes);
   REQUIRE(estimator.estimate(stream) == 0);
@@ -282,7 +282,7 @@ C2H_TEST("HyperLogLog estimate preserves fractional cardinality", "[hyperloglog]
 {
   using estimator_type = cudax::cuco::hyperloglog<int32_t>;
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   auto mr = cuda::device_default_memory_pool(cuda::device_ref{0});
 
   estimator_type estimator{stream, mr, estimator_type::precision{8}};
@@ -322,7 +322,7 @@ C2H_TEST("Hyperloglog estimate works with pinned memory pool", "[hyperloglog]")
   constexpr double tolerance_factor        = 2.5;
   const double relative_standard_deviation = 1.04 / std::sqrt(static_cast<double>(1ull << hll_precision));
 
-  ::cuda::stream stream{::cuda::device_ref{0}};
+  const ::cuda::stream stream{::cuda::device_ref{0}};
   auto mr = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
 
   auto items = ::cuda::make_buffer<T>(stream, mr, num_items, ::cuda::no_init);

--- a/cudax/test/execution/common/checked_receiver.cuh
+++ b/cudax/test/execution/common/checked_receiver.cuh
@@ -136,7 +136,7 @@ struct checked_error_receiver
         SUCCEED();
       }
     }
-    _CCCL_CATCH (::std::exception & e)
+    _CCCL_CATCH (const ::std::exception& e)
     {
 #if defined(_CCCL_NO_TYPEID)
       INFO("expected an error completion; got a different error. what: " << e.what());

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -55,7 +55,7 @@ C2H_TEST("env_t is queryable for all properties we want", "[execution][env]")
 
 C2H_TEST("env_t is default constructible", "[execution][env]")
 {
-  env_t env{cuda::device_default_memory_pool(cuda::device_ref{0})};
+  const env_t env{cuda::device_default_memory_pool(cuda::device_ref{0})};
   CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
   CHECK(env.query(cuda::mr::get_memory_resource) == cuda::device_default_memory_pool(cuda::device_ref{0}));
@@ -67,7 +67,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")
 
   SECTION("Passing an any_resource")
   {
-    env_t env{mr};
+    const env_t env{mr};
     CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -75,8 +75,8 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -84,8 +84,8 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream, cuda::std::execution::par_unseq};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{mr, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK((env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq));
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -96,7 +96,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
 {
   SECTION("Passing an any_resource")
   {
-    env_t env{cuda::mr::any_resource<cuda::mr::device_accessible>{test_resource{}}};
+    const env_t env{cuda::mr::any_resource<cuda::mr::device_accessible>{test_resource{}}};
     CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource)
@@ -105,8 +105,8 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{cuda::mr::any_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{cuda::mr::any_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource)
@@ -115,8 +115,8 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{
       cuda::mr::any_resource<cuda::mr::device_accessible>{test_resource{}}, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
@@ -131,7 +131,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution][env]")
 
   SECTION("Passing an any_resource")
   {
-    env_t env{mr};
+    const env_t env{mr};
     CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -139,8 +139,8 @@ C2H_TEST("env_t is constructible from a resource", "[execution][env]")
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -148,8 +148,8 @@ C2H_TEST("env_t is constructible from a resource", "[execution][env]")
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream, cuda::std::execution::par_unseq};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{mr, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -160,7 +160,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 {
   SECTION("Passing an any_resource")
   {
-    env_t env{test_resource{}};
+    const env_t env{test_resource{}};
     CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
@@ -168,8 +168,8 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{test_resource{}, stream};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{test_resource{}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
@@ -177,8 +177,8 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{cuda::device_ref{0}};
-    env_t env{test_resource{}, stream, cuda::std::execution::par_unseq};
+    const cudax::stream stream{cuda::device_ref{0}};
+    const env_t env{test_resource{}, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
@@ -208,8 +208,8 @@ struct some_env_t
 };
 C2H_TEST("env_t is constructible from a suitable env", "[execution][env]")
 {
-  some_env_t other_env{};
-  env_t env{other_env};
+  const some_env_t other_env{};
+  const env_t env{other_env};
   CHECK(env.query(cuda::get_stream) == other_env.stream_);
   CHECK(env.query(cudax::execution::get_execution_policy) == other_env.policy_);
   CHECK(env.query(cuda::mr::get_memory_resource) == other_env.res_);
@@ -252,16 +252,17 @@ C2H_TEST("Can use query to construct various objects", "[execution][env]")
 {
   SECTION("Can create an any_resource")
   {
-    env_t env{test_resource{}};
-    cuda::mr::any_synchronous_resource<cuda::mr::device_accessible> resource = env.query(cuda::mr::get_memory_resource);
+    const env_t env{test_resource{}};
+    const cuda::mr::any_synchronous_resource<cuda::mr::device_accessible> resource =
+      env.query(cuda::mr::get_memory_resource);
     CHECK(resource == test_resource{});
   }
 
   SECTION("Can create an __uninitialized_async_buffer")
   {
-    cudax::stream stream_{cuda::device_ref{0}};
-    env_t env{test_resource{}, stream_};
-    cuda::__uninitialized_async_buffer<int, cuda::mr::device_accessible> buf{
+    const cudax::stream stream_{cuda::device_ref{0}};
+    const env_t env{test_resource{}, stream_};
+    const cuda::__uninitialized_async_buffer<int, cuda::mr::device_accessible> buf{
       env.query(cuda::mr::get_memory_resource), env.query(cuda::get_stream), 0ull};
     CHECK(buf.memory_resource() == test_resource{});
     CHECK(buf.stream() == stream_);

--- a/cudax/test/execution/policies/get_execution_policy.cu
+++ b/cudax/test/execution/policies/get_execution_policy.cu
@@ -28,7 +28,7 @@ struct with_get_execution_policy_const_lvalue
 C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy method that returns a const lvalue",
          "[execution][policies]")
 {
-  with_get_execution_policy_const_lvalue val{};
+  with_get_execution_policy_const_lvalue val{}; // NOLINT(misc-const-correctness)
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
@@ -46,7 +46,7 @@ struct with_get_execution_policy_rvalue
 C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy method returns an rvalue",
          "[execution][policies]")
 {
-  with_get_execution_policy_rvalue val{};
+  with_get_execution_policy_rvalue val{}; // NOLINT(misc-const-correctness)
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
@@ -80,7 +80,7 @@ struct env_with_query_const_ref
 C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy query that returns a const lvalue",
          "[execution][policies]")
 {
-  env_with_query_const_ref val{};
+  const env_with_query_const_ref val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
@@ -98,7 +98,7 @@ struct env_with_query_rvalue
 C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy query that returns an rvalue",
          "[execution][policies]")
 {
-  env_with_query_rvalue val{};
+  const env_with_query_rvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
@@ -135,7 +135,7 @@ struct env_with_query_and_method
 };
 C2H_TEST("Can call get_execution_policy on a type with both get_execution_policy and query", "[execution][policies]")
 {
-  env_with_query_and_method val{};
+  const env_with_query_and_method val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
   STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);

--- a/cudax/test/execution/test_bulk.cu
+++ b/cudax/test/execution/test_bulk.cu
@@ -177,9 +177,9 @@ void bulk_keeps_error_types_from_input_sender()
 {
 #if !_CCCL_COMPILER(MSVC)
   constexpr int n = 42;
-  dummy_scheduler sched1{};
-  error_scheduler<ex::exception_ptr> sched2{};
-  error_scheduler<int> sched3{43};
+  const dummy_scheduler sched1{};
+  const error_scheduler<ex::exception_ptr> sched2{};
+  const error_scheduler<int> sched3{43};
 
   // MSVCBUG https://developercommunity.visualstudio.com/t/noexcept-expression-in-lambda-template-n/10718680
   check_error_types<>(ex::just() //
@@ -207,9 +207,9 @@ void bulk_keeps_error_types_from_input_sender()
 void bulk_chunked_keeps_error_types_from_input_sender()
 {
   constexpr int n = 42;
-  dummy_scheduler sched1{};
-  error_scheduler<ex::exception_ptr> sched2{};
-  error_scheduler<int> sched3{43};
+  const dummy_scheduler sched1{};
+  const error_scheduler<ex::exception_ptr> sched2{};
+  const error_scheduler<int> sched3{43};
 
   check_error_types<>(ex::just() //
                       | ex::continues_on(sched1) //
@@ -235,9 +235,9 @@ void bulk_chunked_keeps_error_types_from_input_sender()
 void bulk_unchunked_keeps_error_types_from_input_sender()
 {
   constexpr int n = 42;
-  dummy_scheduler sched1{};
-  error_scheduler<ex::exception_ptr> sched2{};
-  error_scheduler<int> sched3{43};
+  const dummy_scheduler sched1{};
+  const error_scheduler<ex::exception_ptr> sched2{};
+  const error_scheduler<int> sched3{43};
 
   check_error_types<>(ex::just() //
                       | ex::continues_on(sched1) //
@@ -271,7 +271,7 @@ void bulk_can_be_used_with_a_function()
   auto op   = ex::connect(cuda::std::move(sndr), checked_value_receiver{&counter1});
   ex::start(op);
 
-  for (int i : counter1)
+  for (const int i : counter1)
   {
     CHECK(i == 1);
   }
@@ -315,14 +315,14 @@ void bulk_can_be_used_with_a_function_object()
 {
   constexpr int n = 9;
   int counter[n]{0};
-  function_object_t<int> fn{counter};
+  function_object_t<int> fn{counter}; // NOLINT(misc-const-correctness)
 
   auto sndr = ex::just() //
             | ex::bulk(ex::par, n, fn);
   auto op   = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
   ex::start(op);
 
-  for (int i : counter)
+  for (const int i : counter)
   {
     CHECK(i == 1);
   }
@@ -332,7 +332,7 @@ void bulk_chunked_can_be_used_with_a_function_object()
 {
   constexpr int n = 9;
   int counter[n]{0};
-  function_object_range_t<int> fn{counter};
+  function_object_range_t<int> fn{counter}; // NOLINT(misc-const-correctness)
 
   auto sndr = ex::just() //
             | ex::bulk_chunked(ex::par, n, fn);
@@ -349,7 +349,7 @@ void bulk_unchunked_can_be_used_with_a_function_object()
 {
   constexpr int n = 9;
   int counter[n]{0};
-  function_object_t<int> fn{counter};
+  function_object_t<int> fn{counter}; // NOLINT(misc-const-correctness)
 
   auto sndr = ex::just() //
             | ex::bulk_unchunked(ex::par, n, fn);
@@ -479,7 +479,7 @@ void bulk_forwards_values()
   auto op   = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number, &counter});
   ex::start(op);
 
-  for (int i : counter)
+  for (const int i : counter)
   {
     CHECK(i == 1);
   }

--- a/cudax/test/execution/test_continues_on.cu
+++ b/cudax/test/execution/test_continues_on.cu
@@ -143,7 +143,7 @@ C2H_TEST("continues_on can be called with const ref scheduler", "[adaptors][cont
 
 C2H_TEST("continues_on can be called with ref scheduler", "[adaptors][continues_on]")
 {
-  dummy_scheduler<> sched;
+  const dummy_scheduler<> sched;
   auto snd = ex::continues_on(ex::just(13), sched);
   auto op  = ex::connect(std::move(snd), checked_value_receiver{13});
   ex::start(op);
@@ -153,7 +153,7 @@ C2H_TEST("continues_on can be called with ref scheduler", "[adaptors][continues_
 C2H_TEST("continues_on forwards set_error calls", "[adaptors][continues_on]")
 {
   auto ec = error_code{std::errc::invalid_argument};
-  error_scheduler<error_code> sched{ec};
+  const error_scheduler<error_code> sched{ec};
   auto snd = ex::continues_on(ex::just(13), sched);
   auto op  = ex::connect(std::move(snd), checked_error_receiver{ec});
   ex::start(op);
@@ -162,7 +162,7 @@ C2H_TEST("continues_on forwards set_error calls", "[adaptors][continues_on]")
 
 C2H_TEST("continues_on forwards set_error calls of other types", "[adaptors][continues_on]")
 {
-  error_scheduler<string> sched{string{"error"}};
+  const error_scheduler<string> sched{string{"error"}};
   auto snd = ex::continues_on(ex::just(13), sched);
   auto op  = ex::connect(std::move(snd), checked_error_receiver{string{"error"}});
   ex::start(op);
@@ -171,7 +171,7 @@ C2H_TEST("continues_on forwards set_error calls of other types", "[adaptors][con
 
 C2H_TEST("continues_on forwards set_stopped calls", "[adaptors][continues_on]")
 {
-  stopped_scheduler sched{};
+  const stopped_scheduler sched{};
   auto snd = ex::continues_on(ex::just(13), sched);
   auto op  = ex::connect(std::move(snd), checked_stopped_receiver{});
   ex::start(op);
@@ -180,7 +180,7 @@ C2H_TEST("continues_on forwards set_stopped calls", "[adaptors][continues_on]")
 
 C2H_TEST("continues_on has the values_type corresponding to the given values", "[adaptors][continues_on]")
 {
-  dummy_scheduler<> sched{};
+  const dummy_scheduler<> sched{};
 
   check_value_types<types<int>>(ex::continues_on(ex::just(1), sched));
   check_value_types<types<int, double>>(ex::continues_on(ex::just(3, 0.14), sched));
@@ -189,9 +189,9 @@ C2H_TEST("continues_on has the values_type corresponding to the given values", "
 
 C2H_TEST("continues_on keeps error_types from scheduler's sender", "[adaptors][continues_on]")
 {
-  dummy_scheduler<> sched1{};
-  error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
-  error_scheduler<int> sched3{43};
+  const dummy_scheduler<> sched1{};
+  const error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
+  const error_scheduler<int> sched3{43};
 
   check_error_types<>(ex::continues_on(ex::just(1), sched1));
   check_error_types<std::error_code>(ex::continues_on(ex::just(2), sched2));
@@ -201,14 +201,14 @@ C2H_TEST("continues_on keeps error_types from scheduler's sender", "[adaptors][c
 C2H_TEST("continues_on sends an exception_ptr if value types are potentially throwing when copied",
          "[adaptors][continues_on]")
 {
-  dummy_scheduler<> sched{};
+  const dummy_scheduler<> sched{};
   check_error_types<ex::exception_ptr>(ex::continues_on(ex::just(potentially_throwing{}), sched));
 }
 
 C2H_TEST("continues_on keeps sends_stopped from scheduler's sender", "[adaptors][continues_on]")
 {
-  dummy_scheduler<> sched1{};
-  stopped_scheduler sched2{};
+  const dummy_scheduler<> sched1{};
+  const stopped_scheduler sched2{};
 
   check_sends_stopped<false>(ex::continues_on(ex::just(1), sched1));
   check_sends_stopped<true>(ex::continues_on(ex::just_stopped(), sched1));

--- a/cudax/test/execution/test_continues_on.cu
+++ b/cudax/test/execution/test_continues_on.cu
@@ -143,7 +143,7 @@ C2H_TEST("continues_on can be called with const ref scheduler", "[adaptors][cont
 
 C2H_TEST("continues_on can be called with ref scheduler", "[adaptors][continues_on]")
 {
-  const dummy_scheduler<> sched;
+  dummy_scheduler<> sched; // NOLINT(misc-const-correctness)
   auto snd = ex::continues_on(ex::just(13), sched);
   auto op  = ex::connect(std::move(snd), checked_value_receiver{13});
   ex::start(op);

--- a/cudax/test/execution/test_on.cu
+++ b/cudax/test/execution/test_on.cu
@@ -55,7 +55,7 @@ void simple_continue_on_thread_test()
 
 void simple_start_on_stream_test()
 {
-  cudax::stream str{cuda::device_ref(0)};
+  const cudax::stream str{cuda::device_ref(0)};
   auto sch      = cudax::stream_ref{str};
   auto sndr     = ex::on(sch, ex::just(42) | ex::then([] __host__ __device__(int i) noexcept -> int {
                             return _on_device() ? i : -i;
@@ -69,7 +69,7 @@ void simple_start_on_stream_test()
 
 void simple_continue_on_stream_test()
 {
-  cudax::stream str{cuda::device_ref(0)};
+  const cudax::stream str{cuda::device_ref(0)};
   auto sch      = cudax::stream_ref{str};
   auto sndr     = ex::just(42) | ex::on(sch, ex::then([] __host__ __device__(int i) noexcept -> int {
                                       return _on_device() ? i : -i;

--- a/cudax/test/execution/test_starts_on.cu
+++ b/cudax/test/execution/test_starts_on.cu
@@ -135,7 +135,7 @@ C2H_TEST("starts_on can be called with const ref scheduler", "[adaptors][starts_
 
 C2H_TEST("starts_on can be called with ref scheduler", "[adaptors][starts_on]")
 {
-  dummy_scheduler<> sched;
+  const dummy_scheduler<> sched;
   auto snd = ex::starts_on(sched, ex::just(42));
   auto op  = ex::connect(std::move(snd), checked_value_receiver{42});
   ex::start(op);
@@ -144,7 +144,7 @@ C2H_TEST("starts_on can be called with ref scheduler", "[adaptors][starts_on]")
 C2H_TEST("starts_on forwards scheduler errors", "[adaptors][starts_on]")
 {
   auto ec = error_code{std::errc::invalid_argument};
-  error_scheduler<error_code> sched{ec};
+  const error_scheduler<error_code> sched{ec};
   auto snd = ex::starts_on(sched, ex::just(42));
   auto op  = ex::connect(std::move(snd), checked_error_receiver{ec});
   ex::start(op);
@@ -153,7 +153,7 @@ C2H_TEST("starts_on forwards scheduler errors", "[adaptors][starts_on]")
 
 C2H_TEST("starts_on forwards scheduler errors of other types", "[adaptors][starts_on]")
 {
-  error_scheduler<string> sched{string{"scheduler error"}};
+  const error_scheduler<string> sched{string{"scheduler error"}};
   auto snd = ex::starts_on(sched, ex::just(42));
   auto op  = ex::connect(std::move(snd), checked_error_receiver{string{"scheduler error"}});
   ex::start(op);
@@ -161,7 +161,7 @@ C2H_TEST("starts_on forwards scheduler errors of other types", "[adaptors][start
 
 C2H_TEST("starts_on forwards scheduler stopped signal", "[adaptors][starts_on]")
 {
-  stopped_scheduler sched{};
+  const stopped_scheduler sched{};
   auto snd = ex::starts_on(sched, ex::just(42));
   auto op  = ex::connect(std::move(snd), checked_stopped_receiver{});
   ex::start(op);
@@ -191,7 +191,7 @@ C2H_TEST("starts_on preserves multiple values", "[adaptors][starts_on]")
 
 C2H_TEST("starts_on has the values_type corresponding to the child sender", "[adaptors][starts_on]")
 {
-  dummy_scheduler<> sched{};
+  const dummy_scheduler<> sched{};
 
   check_value_types<types<int>>(ex::starts_on(sched, ex::just(1)));
   check_value_types<types<int, double>>(ex::starts_on(sched, ex::just(3, 0.14)));
@@ -200,9 +200,9 @@ C2H_TEST("starts_on has the values_type corresponding to the child sender", "[ad
 
 C2H_TEST("starts_on includes error_types from both scheduler and sender", "[adaptors][starts_on]")
 {
-  dummy_scheduler<> sched1{};
-  error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
-  error_scheduler<int> sched3{43};
+  const dummy_scheduler<> sched1{};
+  const error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
+  const error_scheduler<int> sched3{43};
 
   // Inline scheduler has no errors, sender has no errors
   check_error_types<>(ex::starts_on(sched1, ex::just(1)));
@@ -216,9 +216,9 @@ C2H_TEST("starts_on includes error_types from both scheduler and sender", "[adap
 
 C2H_TEST("starts_on sends_stopped includes both scheduler and sender", "[adaptors][starts_on]")
 {
-  dummy_scheduler<> sched1{};
-  error_scheduler<error_code> sched2{error_code{std::errc::invalid_argument}};
-  stopped_scheduler sched3{};
+  const dummy_scheduler<> sched1{};
+  const error_scheduler<error_code> sched2{error_code{std::errc::invalid_argument}};
+  const stopped_scheduler sched3{};
 
   // Neither scheduler nor sender sends stopped
   check_sends_stopped<false>(ex::starts_on(sched1, ex::just(1)));

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -102,7 +102,7 @@ void stream_context_test2()
 void stream_ref_as_scheduler()
 {
   ex::thread_context tctx;
-  cudax::stream sctx{cuda::device_ref{0}};
+  const cudax::stream sctx{cuda::device_ref{0}};
   auto sch = sctx.get_scheduler();
   static_assert(ex::__is_scheduler<decltype(sch)>);
 
@@ -131,16 +131,16 @@ void stream_ref_as_scheduler()
 
 void bulk_on_stream_scheduler()
 {
-  cuda::device_ref _dev{0};
-  cudax::stream sctx{_dev};
+  const cuda::device_ref _dev{0};
+  const cudax::stream sctx{_dev};
   auto sch = sctx.get_scheduler();
 
   using _env_t = cudax::env_t<cuda::mr::device_accessible>;
   auto mr      = cuda::device_default_memory_pool(_dev);
   auto mr2     = cuda::mr::any_resource<cuda::mr::device_accessible>(mr);
-  _env_t env{mr, cuda::get_stream(sch), ex::par_unseq};
+  const _env_t env{mr, cuda::get_stream(sch), ex::par_unseq};
   auto buf = cuda::make_buffer<int>(sctx, mr2, 10, 40, env); // a device buffer of 10 integers, initialized to 40
-  cuda::std::span data{buf};
+  const cuda::std::span data{buf};
 
   auto start = //
     ex::schedule(sch) // begin work on the GPU
@@ -177,9 +177,9 @@ void stream_adapt_non_visitable_sender()
 
 void starts_on_with_stream_scheduler1()
 {
-  cuda::device_ref _dev{0};
-  cudax::stream sctx{_dev};
-  ex::thread_context tctx;
+  const cuda::device_ref _dev{0};
+  const cudax::stream sctx{_dev};
+  ex::thread_context tctx; // NOLINT(misc-const-correctness)
   auto sch = sctx.get_scheduler();
 
   auto start = ex::starts_on(sch, ex::just() | ex::then([] __device__() noexcept -> int {
@@ -192,8 +192,8 @@ void starts_on_with_stream_scheduler1()
 
 void starts_on_with_stream_scheduler2()
 {
-  cuda::device_ref _dev{0};
-  cudax::stream sctx{_dev};
+  const cuda::device_ref _dev{0};
+  const cudax::stream sctx{_dev};
   ex::thread_context tctx;
   auto sch = sctx.get_scheduler();
 

--- a/cudax/test/execution/test_task_scheduler.cu
+++ b/cudax/test/execution/test_task_scheduler.cu
@@ -22,7 +22,7 @@ namespace
 {
 C2H_TEST("simple task_scheduler test", "[scheduler][task_scheduler]")
 {
-  ex::task_scheduler sched{dummy_scheduler{}};
+  const ex::task_scheduler sched{dummy_scheduler{}};
   STATIC_CHECK(ex::scheduler<decltype(sched)>);
   auto sndr = sched.schedule();
   STATIC_CHECK(ex::sender<decltype(sndr)>);
@@ -34,7 +34,7 @@ C2H_TEST("simple task_scheduler test", "[scheduler][task_scheduler]")
 C2H_TEST("task_scheduler starts work on the correct execution context", "[scheduler][task_scheduler]")
 {
   ex::thread_context ctx;
-  ex::task_scheduler sched{ctx.get_scheduler()};
+  const ex::task_scheduler sched{ctx.get_scheduler()};
   auto sndr  = ex::starts_on(sched, ex::just() | ex::then([] {
                                      return ::std::this_thread::get_id();
                                     }));
@@ -74,7 +74,7 @@ struct test_domain
 
 C2H_TEST("bulk_unchunked dispatches correctly through task_scheduler", "[scheduler][task_scheduler]")
 {
-  ex::task_scheduler sched{dummy_scheduler<test_domain>{}};
+  const ex::task_scheduler sched{dummy_scheduler<test_domain>{}};
   auto sndr  = ex::on(sched, ex::just(-1) | ex::bulk_chunked(ex::par_unseq, 100, [](int, int, int&) {}));
   g_called   = false;
   auto [val] = ex::sync_wait(cuda::std::move(sndr)).value();
@@ -84,7 +84,7 @@ C2H_TEST("bulk_unchunked dispatches correctly through task_scheduler", "[schedul
 
 C2H_TEST("bulk dispatches correctly through task_scheduler", "[scheduler][task_scheduler]")
 {
-  ex::task_scheduler sched{dummy_scheduler<test_domain>{}};
+  const ex::task_scheduler sched{dummy_scheduler<test_domain>{}};
   auto sndr  = ex::on(sched, ex::just(-1) | ex::bulk(ex::par_unseq, 100, [](int, int&) {}));
   g_called   = false;
   auto [val] = ex::sync_wait(cuda::std::move(sndr)).value();

--- a/cudax/test/execution/test_then.cu
+++ b/cudax/test/execution/test_then.cu
@@ -127,7 +127,7 @@ C2H_TEST("then can be used with just_stopped", "[adaptors][then]")
 C2H_TEST("then function is not called on error", "[adaptors][then]")
 {
   bool called{false};
-  error_scheduler sched{-1};
+  const error_scheduler sched{-1};
   auto snd = ex::just(13) | ex::continues_on(sched) | ex::then([&](int x) -> int {
                called = true;
                return x + 5;
@@ -141,7 +141,7 @@ C2H_TEST("then function is not called on error", "[adaptors][then]")
 C2H_TEST("then function is not called when cancelled", "[adaptors][then]")
 {
   bool called{false};
-  stopped_scheduler sched;
+  const stopped_scheduler sched;
   auto snd = ex::just(13) | ex::continues_on(sched) | ex::then([&](int x) -> int {
                called = true;
                return x + 5;
@@ -194,9 +194,9 @@ C2H_TEST("then has the values_type corresponding to the given values", "[adaptor
 
 C2H_TEST("then keeps error_types from input sender", "[adaptors][then]")
 {
-  dummy_scheduler sched1{};
-  error_scheduler sched2{error_code{std::errc::invalid_argument}};
-  error_scheduler sched3{43};
+  const dummy_scheduler sched1{};
+  const error_scheduler sched2{error_code{std::errc::invalid_argument}};
+  const error_scheduler sched3{43};
 
   check_error_types(ex::just() | ex::continues_on(sched1) | ex::then([]() noexcept {}));
   check_error_types<error_code>(ex::just() | ex::continues_on(sched2) | ex::then([]() noexcept {}));
@@ -205,9 +205,9 @@ C2H_TEST("then keeps error_types from input sender", "[adaptors][then]")
 
 C2H_TEST("then keeps sends_stopped from input sender", "[adaptors][then]")
 {
-  dummy_scheduler sched1{};
-  error_scheduler sched2{error_code{std::errc::invalid_argument}};
-  stopped_scheduler sched3{};
+  const dummy_scheduler sched1{};
+  const error_scheduler sched2{error_code{std::errc::invalid_argument}};
+  const stopped_scheduler sched3{};
 
   check_sends_stopped<false>(ex::just() | ex::continues_on(sched1) | ex::then([] {}));
   check_sends_stopped<false>(ex::just() | ex::continues_on(sched2) | ex::then([] {}));
@@ -267,7 +267,7 @@ struct then_test_domain
 C2H_TEST("then can be customized early", "[adaptors][then]")
 {
   // The customization will return a different value
-  dummy_scheduler<then_test_domain> sched;
+  const dummy_scheduler<then_test_domain> sched;
   auto snd = ex::just(string{"hello"}) | ex::continues_on(sched) | ex::then([](string x) {
                return x + ", world";
              });
@@ -277,7 +277,7 @@ C2H_TEST("then can be customized early", "[adaptors][then]")
 C2H_TEST("then can be customized late", "[adaptors][then]")
 {
   // The customization will return a different value
-  dummy_scheduler<then_test_domain> sched;
+  const dummy_scheduler<then_test_domain> sched;
   auto snd = ex::just(string{"hello"})
            | ex::on(sched, ex::then([](string x) {
                       return x + ", world";

--- a/cudax/test/execution/test_when_all.cu
+++ b/cudax/test/execution/test_when_all.cu
@@ -105,7 +105,7 @@ C2H_TEST("when_all can be used with just_*", "[when_all]")
 
 C2H_TEST("when_all terminates with error if one child terminates with error", "[when_all]")
 {
-  error_scheduler sched{42};
+  const error_scheduler sched{42};
   auto snd = ex::when_all(ex::just(2), ex::just(5) | ex::continues_on(sched), ex::just(7));
   auto op  = ex::connect(std::move(snd), checked_error_receiver{42});
   ex::start(op);
@@ -113,7 +113,7 @@ C2H_TEST("when_all terminates with error if one child terminates with error", "[
 
 C2H_TEST("when_all terminates with stopped if one child is cancelled", "[when_all]")
 {
-  stopped_scheduler sched;
+  stopped_scheduler sched; // NOLINT(misc-const-correctness)
   auto snd = ex::when_all(ex::just(2), ex::just(5) | ex::continues_on(sched), ex::just(7));
   auto op  = ex::connect(std::move(snd), checked_stopped_receiver{});
   ex::start(op);

--- a/cudax/test/fill_bytes/fill_bytes_mdspan.cu
+++ b/cudax/test/fill_bytes/fill_bytes_mdspan.cu
@@ -116,7 +116,8 @@ void test_impl(const thrust::host_vector<Tp>& input,
   using extents_t = cuda::std::extents<Index, Extents...>;
   using mapping_t = typename _Layout::template mapping<extents_t>;
   thrust::device_vector<Tp> device_data(input.begin(), input.end());
-  cuda::device_mdspan<Tp, extents_t, _Layout> dst(thrust::raw_pointer_cast(device_data.data()), mapping_t(extents));
+  const cuda::device_mdspan<Tp, extents_t, _Layout> dst(
+    thrust::raw_pointer_cast(device_data.data()), mapping_t(extents));
 
   cuda::experimental::fill_bytes(dst, value, stream);
   stream.sync();
@@ -139,7 +140,7 @@ void test_impl_stride(
   using mapping_t = cuda::std::layout_stride::mapping<extents_t>;
 
   thrust::device_vector<Tp> device_data(input.begin(), input.end());
-  cuda::device_mdspan<Tp, extents_t, cuda::std::layout_stride> dst(
+  const cuda::device_mdspan<Tp, extents_t, cuda::std::layout_stride> dst(
     thrust::raw_pointer_cast(device_data.data()) + offset, mapping_t(extents, strides));
 
   cuda::experimental::fill_bytes(dst, value, stream);
@@ -163,7 +164,7 @@ void test_impl_relaxed(
   using mapping_t = cuda::layout_stride_relaxed::mapping<extents_t>;
 
   thrust::device_vector<Tp> device_data(input.begin(), input.end());
-  cuda::device_mdspan<Tp, extents_t, cuda::layout_stride_relaxed> dst(
+  const cuda::device_mdspan<Tp, extents_t, cuda::layout_stride_relaxed> dst(
     thrust::raw_pointer_cast(device_data.data()), mapping_t(extents, strides, offset));
 
   cuda::experimental::fill_bytes(dst, value, stream);
@@ -269,10 +270,10 @@ TEST_CASE("fill_bytes preserves padding bytes in strided row-major destination l
   using extents_t    = cuda::std::extents<int, rows, cols>;
   using mapping_t    = cuda::std::layout_stride::mapping<extents_t>;
 
-  cuda::std::array<int, 2> strides{ld, 1};
-  mapping_t mapping(extents_t{}, strides);
-  auto input     = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
-  uint16_t value = 0x1234;
+  const cuda::std::array<int, 2> strides{ld, 1};
+  const mapping_t mapping(extents_t{}, strides);
+  auto input           = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
+  const uint16_t value = 0x1234;
 
   auto expected = to_byte_vector(input);
   for (int row = 0; row < rows; ++row)
@@ -293,10 +294,10 @@ TEST_CASE("fill_bytes preserves padding bytes in strided column-major destinatio
   using extents_t    = cuda::std::extents<int, rows, cols>;
   using mapping_t    = cuda::std::layout_stride::mapping<extents_t>;
 
-  cuda::std::array<int, 2> strides{1, ld};
-  mapping_t mapping(extents_t{}, strides);
-  auto input     = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
-  uint16_t value = 0x1234;
+  const cuda::std::array<int, 2> strides{1, ld};
+  const mapping_t mapping(extents_t{}, strides);
+  auto input           = make_host_data<uint16_t>(mapping.required_span_size(), 0xCD);
+  const uint16_t value = 0x1234;
 
   auto expected = to_byte_vector(input);
   for (int row = 0; row < rows; ++row)
@@ -335,7 +336,7 @@ TEST_CASE("fill_bytes handles 3D strided permutation layouts", "[fill_bytes][3d]
   using extents_t    = cuda::std::extents<int, dim0, dim1, dim2>;
   constexpr int span = (dim0 - 1) + (dim1 - 1) * dim2 * dim0 + (dim2 - 1) * dim0 + 1;
 
-  cuda::std::array<int, 3> strides{1, dim2 * dim0, dim0};
+  const cuda::std::array<int, 3> strides{1, dim2 * dim0, dim0};
   auto input           = make_host_data<uint32_t>(span, 0xCD);
   constexpr auto value = pattern32::value;
 
@@ -346,7 +347,7 @@ TEST_CASE("fill_bytes handles 3D strided permutation layouts", "[fill_bytes][3d]
     {
       for (int k = 0; k < dim2; ++k)
       {
-        int offset = i + j * dim2 * dim0 + k * dim0;
+        const int offset = i + j * dim2 * dim0 + k * dim0;
         fill_expected_element<uint32_t>(expected, offset, value);
       }
     }
@@ -364,7 +365,7 @@ TEST_CASE("fill_bytes handles 3D strided tile_size greater than one", "[fill_byt
   constexpr int stride1   = 2048;
   constexpr int span_size = (dim0 - 1) * stride0 + (dim1 - 1) * stride1 + dim2;
 
-  cuda::std::array<int, 3> strides{stride0, stride1, 1};
+  const cuda::std::array<int, 3> strides{stride0, stride1, 1};
   auto input           = make_host_data<uint32_t>(span_size, 0xCD);
   constexpr auto value = pattern32::value;
 
@@ -375,7 +376,7 @@ TEST_CASE("fill_bytes handles 3D strided tile_size greater than one", "[fill_byt
     {
       for (int k = 0; k < dim2; ++k)
       {
-        int offset = i * stride0 + j * stride1 + k;
+        const int offset = i * stride0 + j * stride1 + k;
         fill_expected_element<uint32_t>(expected, offset, value);
       }
     }
@@ -392,7 +393,7 @@ TEST_CASE("fill_bytes preserves surrounding bytes in strided subviews with offse
   constexpr int alloc  = 16;
   using extents_t      = cuda::std::extents<int, rows, cols>;
 
-  cuda::std::array<int, 2> strides{1, ld};
+  const cuda::std::array<int, 2> strides{1, ld};
   auto input           = make_host_data<uint32_t>(alloc, 0xCD);
   constexpr auto value = uint32_t{0x12345678};
 
@@ -434,7 +435,7 @@ TEST_CASE("fill_bytes rejects interleaved layout", "[fill_bytes][throw]")
   auto input      = make_host_data<uint32_t>(6, 0xCD);
 
   thrust::device_vector<uint32_t> device_data(input.begin(), input.end());
-  cuda::device_mdspan<uint32_t, extents_t, cuda::layout_stride_relaxed> dst(
+  const cuda::device_mdspan<uint32_t, extents_t, cuda::layout_stride_relaxed> dst(
     thrust::raw_pointer_cast(device_data.data()), mapping_t(extents_t{}, cuda::dstrides<int, 2>(2, 3)));
 
   REQUIRE_THROWS_AS(cuda::experimental::fill_bytes(dst, uint32_t{0x12345678}, stream), std::invalid_argument);

--- a/cudax/test/fill_bytes/fill_bytes_mdspan_example.cu
+++ b/cudax/test/fill_bytes/fill_bytes_mdspan_example.cu
@@ -25,13 +25,13 @@ TEST_CASE("fill_bytes mdspan documentation example", "[fill_bytes][example]")
 {
   // example-begin fill-bytes-mdspan
   using extents_t = cuda::std::dims<2>;
-  extents_t extents{2, 3};
+  const extents_t extents{2, 3};
 
   thrust::device_vector<int> device_data(extents.extent(0) * extents.extent(1));
   int* dst_ptr = thrust::raw_pointer_cast(device_data.data());
-  cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
+  const cuda::device_mdspan<int, extents_t> dst(dst_ptr, extents);
 
-  cuda::stream stream{cuda::device_ref{0}};
+  const cuda::stream stream{cuda::device_ref{0}};
   cuda::experimental::fill_bytes(dst, uint32_t{0xFF00FF00}, stream);
   // example-end fill-bytes-mdspan
 

--- a/cudax/test/graph/graph_buffer_smoke.cu
+++ b/cudax/test/graph/graph_buffer_smoke.cu
@@ -107,13 +107,13 @@ struct sum_to_ptr
 
 C2H_TEST("graph_buffer with no_init allocates and can be written/read", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   constexpr int N = 10;
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf(pb, mr, N, cuda::no_init);
 
   REQUIRE(buf.size() == N);
@@ -136,14 +136,14 @@ C2H_TEST("graph_buffer with no_init allocates and can be written/read", "[graph]
 
 C2H_TEST("graph_buffer with zero-fill initializes to zero", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   constexpr int N = 16;
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
-  int zero = 0;
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const int zero = 0;
   cudax::graph_buffer<int> buf(pb, mr, N, zero);
 
   // Verify all zeros
@@ -158,8 +158,8 @@ C2H_TEST("graph_buffer with zero-fill initializes to zero", "[graph][graph_buffe
 
 C2H_TEST("graph_buffer from span", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> host_data{6};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> host_data{6};
   for (int i = 0; i < 6; ++i)
   {
     host_data[i] = i + 1;
@@ -168,12 +168,12 @@ C2H_TEST("graph_buffer from span", "[graph][graph_buffer]")
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf(pb, mr, cuda::std::span<const int>{host_data.get(), 6});
 
   REQUIRE(buf.size() == 6);
 
-  pinned_array<int> result{6};
+  const pinned_array<int> result{6};
   cudax::copy_bytes(pb, buf, cuda::std::span<int>{result.get(), 6});
 
   buf.destroy(pb);
@@ -190,17 +190,17 @@ C2H_TEST("graph_buffer from span", "[graph][graph_buffer]")
 
 C2H_TEST("graph_buffer from initializer_list", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf(pb, mr, {10, 20, 30, 40});
 
   REQUIRE(buf.size() == 4);
 
-  pinned_array<int> result{4};
+  const pinned_array<int> result{4};
   cudax::copy_bytes(pb, buf, cuda::std::span<int>{result.get(), 4});
 
   buf.destroy(pb);
@@ -217,13 +217,13 @@ C2H_TEST("graph_buffer from initializer_list", "[graph][graph_buffer]")
 
 C2H_TEST("make_buffer factory with no_init", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   constexpr int N = 8;
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   auto buf = cudax::make_buffer<int>(pb, mr, N, cuda::no_init);
 
   REQUIRE(buf.size() == N);
@@ -240,8 +240,8 @@ C2H_TEST("make_buffer factory with no_init", "[graph][graph_buffer]")
 
 C2H_TEST("graph_buffer on forked paths", "[graph][graph_buffer]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> result_mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> result_mem{1};
   int* result = result_mem.get();
 
   constexpr int N = 10;
@@ -249,7 +249,7 @@ C2H_TEST("graph_buffer on forked paths", "[graph][graph_buffer]")
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf(pb, mr, N, cuda::no_init);
 
   // Write on one path
@@ -275,9 +275,9 @@ C2H_TEST("graph_buffer move semantics", "[graph][graph_buffer]")
 {
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf1(pb, mr, 4, cuda::no_init);
 
   auto* original_data = buf1.data();
@@ -308,9 +308,9 @@ C2H_TEST("graph_buffer empty buffer", "[graph][graph_buffer]")
 {
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
-  cudax::graph_memory_resource mr{cuda::device_ref{0}};
+  const cudax::graph_memory_resource mr{cuda::device_ref{0}};
   cudax::graph_buffer<int> buf(pb, mr, 0, cuda::no_init);
 
   REQUIRE(buf.data() == nullptr);

--- a/cudax/test/graph/graph_node_ops_smoke.cu
+++ b/cudax/test/graph/graph_node_ops_smoke.cu
@@ -78,10 +78,10 @@ struct count_down_and_stop
 
 C2H_TEST("graph fill_bytes sets every byte to the requested value", "[graph][fill_bytes]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 64;
-  pinned_array<int> mem{N, static_cast<int>(0xDEADBEEF)};
+  const pinned_array<int> mem{N, static_cast<int>(0xDEADBEEF)};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -101,10 +101,10 @@ C2H_TEST("graph fill_bytes sets every byte to the requested value", "[graph][fil
 
 C2H_TEST("graph fill_bytes with non-zero value", "[graph][fill_bytes]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 8;
-  pinned_array<unsigned char> mem{N};
+  const pinned_array<unsigned char> mem{N};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -127,11 +127,11 @@ C2H_TEST("graph fill_bytes with non-zero value", "[graph][fill_bytes]")
 
 C2H_TEST("graph copy_bytes copies data from source to destination", "[graph][copy_bytes]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 32;
-  pinned_array<int> src{N};
-  pinned_array<int> dst{N, -1};
+  const pinned_array<int> src{N};
+  const pinned_array<int> dst{N, -1};
 
   for (std::size_t i = 0; i < N; ++i)
   {
@@ -155,11 +155,11 @@ C2H_TEST("graph copy_bytes copies data from source to destination", "[graph][cop
 
 C2H_TEST("graph copy_bytes can be chained after fill_bytes", "[graph][fill_bytes][copy_bytes]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
 
   constexpr std::size_t N = 16;
-  pinned_array<unsigned char> src{N};
-  pinned_array<unsigned char> dst{N};
+  const pinned_array<unsigned char> src{N};
+  const pinned_array<unsigned char> dst{N};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -184,7 +184,7 @@ C2H_TEST("graph copy_bytes can be chained after fill_bytes", "[graph][fill_bytes
 
 C2H_TEST("graph host_launch executes a lambda callback", "[graph][host_launch]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   // pinned so the host-side increment is visible immediately after sync
   test::pinned<int> counter{0};
 
@@ -206,7 +206,7 @@ C2H_TEST("graph host_launch executes a lambda callback", "[graph][host_launch]")
 
 C2H_TEST("graph host_launch with arguments", "[graph][host_launch]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   test::pinned<int> a{10};
   test::pinned<int> b{20};
   test::pinned<int> result{0};
@@ -235,8 +235,8 @@ C2H_TEST("graph host_launch with arguments", "[graph][host_launch]")
 
 C2H_TEST("graph host_launch can be chained with kernel nodes", "[graph][host_launch]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -262,8 +262,8 @@ C2H_TEST("graph host_launch can be chained with kernel nodes", "[graph][host_lau
 
 C2H_TEST("graph host_launch can be launched multiple times", "[graph][host_launch]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* ptr = mem.get();
 
   cudax::graph_builder g;
@@ -288,11 +288,11 @@ C2H_TEST("graph host_launch can be launched multiple times", "[graph][host_launc
 C2H_TEST("graph host_launch data is cleaned up when graph is destroyed", "[graph][host_launch]")
 {
   // Use a shared_ptr as a witness: the weak_ptr expires when all copies are gone.
-  auto witness              = ::std::make_shared<int>(42);
-  ::std::weak_ptr<int> weak = witness;
+  auto witness                    = ::std::make_shared<int>(42);
+  const ::std::weak_ptr<int> weak = witness;
 
   {
-    cudax::graph_builder g;
+    cudax::graph_builder g; // NOLINT(misc-const-correctness)
     cudax::path_builder pb = cudax::start_path(g);
 
     // The lambda captures a copy of the shared_ptr, which gets stored in the graph's user object.
@@ -316,10 +316,10 @@ C2H_TEST("graph host_launch data is cleaned up when graph is destroyed", "[graph
 C2H_TEST("graph record_event and wait(event_ref) impose ordering across independent paths",
          "[graph][event_record][event_wait]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
 
-  cuda::event ev{cuda::device_ref{0}};
+  const cuda::event ev{cuda::device_ref{0}};
 
   cudax::graph_builder g;
 
@@ -345,10 +345,10 @@ C2H_TEST("graph record_event and wait(event_ref) impose ordering across independ
 
 C2H_TEST("graph record_event node has the correct node type", "[graph][event_record]")
 {
-  cudax::graph_builder g;
+  cudax::graph_builder g; // NOLINT(misc-const-correctness)
   cudax::path_builder pb = cudax::start_path(g);
 
-  cuda::event ev{cuda::device_ref{0}};
+  const cuda::event ev{cuda::device_ref{0}};
   auto node = pb.record_event(ev);
 
   REQUIRE(node.type() == cudax::graph_node_type::event_record);
@@ -356,10 +356,10 @@ C2H_TEST("graph record_event node has the correct node type", "[graph][event_rec
 
 C2H_TEST("graph wait(event_ref) node has the correct node type", "[graph][event_wait]")
 {
-  cudax::graph_builder g;
+  cudax::graph_builder g; // NOLINT(misc-const-correctness)
   cudax::path_builder pb = cudax::start_path(g);
 
-  cuda::event ev{cuda::device_ref{0}};
+  const cuda::event ev{cuda::device_ref{0}};
   auto node = pb.wait(ev);
 
   REQUIRE(node.type() == cudax::graph_node_type::wait_event);
@@ -371,12 +371,12 @@ C2H_TEST("graph wait(event_ref) node has the correct node type", "[graph][event_
 
 C2H_TEST("graph insert_child_graph embeds a subgraph", "[graph][child_graph]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* val = mem.get();
 
   // Build the child graph: kernel that assigns 42.
-  cudax::graph_builder child_g;
+  cudax::graph_builder child_g; // NOLINT(misc-const-correctness)
   {
     cudax::path_builder child_pb = cudax::start_path(child_g);
     cudax::launch(child_pb, test::one_thread_dims, test::assign_42{}, val);
@@ -399,8 +399,8 @@ C2H_TEST("graph insert_child_graph embeds a subgraph", "[graph][child_graph]")
 #  if _CCCL_CTK_AT_LEAST(12, 9)
 C2H_TEST("graph insert_child_graph with ownership transfer", "[graph][child_graph]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder child_g;
@@ -428,13 +428,13 @@ C2H_TEST("graph insert_child_graph with ownership transfer", "[graph][child_grap
 
 C2H_TEST("graph insert_child_graph node has the correct node type", "[graph][child_graph]")
 {
-  cudax::graph_builder child_g;
+  cudax::graph_builder child_g; // NOLINT(misc-const-correctness)
   {
     cudax::path_builder child_pb = cudax::start_path(child_g);
     cudax::launch(child_pb, test::one_thread_dims, test::empty_kernel{});
   }
 
-  cudax::graph_builder parent_g;
+  cudax::graph_builder parent_g; // NOLINT(misc-const-correctness)
   cudax::path_builder pb = cudax::start_path(parent_g);
 
   auto node = cudax::insert_child_graph(pb, child_g);
@@ -450,8 +450,8 @@ C2H_TEST("graph insert_child_graph node has the correct node type", "[graph][chi
 
 C2H_TEST("graph make_if_node body executes when handle is non-zero", "[graph][conditional][if_node]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;
@@ -475,8 +475,8 @@ C2H_TEST("graph make_if_node body executes when handle is non-zero", "[graph][co
 
 C2H_TEST("graph make_if_node body is skipped when handle is zero", "[graph][conditional][if_node]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;
@@ -500,8 +500,8 @@ C2H_TEST("graph make_if_node body is skipped when handle is zero", "[graph][cond
 
 C2H_TEST("graph make_while_node body executes the expected number of times", "[graph][conditional][while_node]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1, 5}; // will be decremented to 0
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1, 5}; // will be decremented to 0
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
@@ -524,15 +524,15 @@ C2H_TEST("graph make_while_node body executes the expected number of times", "[g
 
 C2H_TEST("graph make_if_node with pre-constructed handle", "[graph][conditional][if_node]")
 {
-  cudax::stream s{cuda::device_ref{0}};
-  pinned_array<int> mem{1};
+  const cudax::stream s{cuda::device_ref{0}};
+  const pinned_array<int> mem{1};
   int* val = mem.get();
 
   cudax::graph_builder g;
   cudax::path_builder pb = cudax::start_path(g);
 
   // User constructs handle directly.
-  cudax::conditional_handle my_handle{g, true};
+  const cudax::conditional_handle my_handle{g, true};
   auto [cond_node, body_graph, handle] = cudax::make_if_node(pb, my_handle);
 
   {

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -32,7 +32,7 @@ struct empty_node_descriptor
 
 C2H_TEST("can default construct a graph and destroy it", "[graph]")
 {
-  cuda::experimental::graph_builder g;
+  cuda::experimental::graph_builder g; // NOLINT(misc-const-correctness)
   REQUIRE(g.get() != nullptr);
 }
 
@@ -81,7 +81,7 @@ C2H_TEST("can instantiate and launch a graph", "[graph]")
   REQUIRE(exec.get() != nullptr);
 
   // Create a stream and launch the graph
-  cuda::experimental::stream s{cuda::device_ref{0}};
+  const cuda::experimental::stream s{cuda::device_ref{0}};
   exec.launch(s);
 
   // Wait for completion
@@ -103,7 +103,7 @@ C2H_TEST("graph_node_ref comparison operators work correctly", "[graph]")
   REQUIRE_FALSE(node1 != node1);
 
   // Test null comparison
-  cuda::experimental::graph_node_ref null_ref;
+  const cuda::experimental::graph_node_ref null_ref;
   REQUIRE_FALSE(node1 == null_ref);
   REQUIRE(node1 != null_ref);
   REQUIRE_FALSE(null_ref == node1);
@@ -156,7 +156,7 @@ C2H_TEST("graph_node_ref can be copied", "[graph]")
 
 C2H_TEST("Path builder with kernel nodes", "[graph]")
 {
-  cudax::stream s{cuda::device_ref{0}};
+  const cudax::stream s{cuda::device_ref{0}};
   cuda::mr::legacy_managed_memory_resource mr{};
   int* ptr = static_cast<int*>(mr.allocate_sync(sizeof(int)));
   *ptr     = 0;

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -29,7 +29,7 @@ C2H_TEST("Green context", "[green_context]")
     INFO("Can create a green context");
     {
       {
-        [[maybe_unused]] cudax::green_context ctx(cuda::devices[0]);
+        [[maybe_unused]] const cudax::green_context ctx(cuda::devices[0]);
       }
       {
         cudax::green_context ctx(cuda::devices[0]);
@@ -40,13 +40,13 @@ C2H_TEST("Green context", "[green_context]")
 
     INFO("Can create streams under green context");
     {
-      cudax::green_context green_ctx_dev0(cuda::devices[0]);
-      cudax::stream stream_under_green_ctx(green_ctx_dev0);
+      const cudax::green_context green_ctx_dev0(cuda::devices[0]);
+      const cudax::stream stream_under_green_ctx(green_ctx_dev0);
       REQUIRE(stream_under_green_ctx.device() == 0);
       if (cuda::devices.size() > 1)
       {
-        cudax::green_context green_ctx_dev1(cuda::devices[1]);
-        cudax::stream stream_dev1(green_ctx_dev1);
+        const cudax::green_context green_ctx_dev1(cuda::devices[1]);
+        const cudax::stream stream_dev1(green_ctx_dev1);
         REQUIRE(stream_dev1.device() == 1);
       }
 
@@ -54,7 +54,7 @@ C2H_TEST("Green context", "[green_context]")
       {
         auto ldev1 = stream_under_green_ctx.logical_device();
         REQUIRE(ldev1.kind() == cudax::logical_device::kinds::green_context);
-        cudax::stream side_stream(ldev1);
+        const cudax::stream side_stream(ldev1);
         REQUIRE(side_stream.device() == 0);
         auto ldev2 = side_stream.logical_device();
         REQUIRE(ldev2.kind() == cudax::logical_device::kinds::green_context);

--- a/cudax/test/group/group.cu
+++ b/cudax/test/group/group.cu
@@ -47,7 +47,7 @@ __device__ void test_common_properties(const Hierarchy&, Group& group)
 
     // .sync() method must support calls from different branches. Add some dummy work to make sure the branches are not
     // collided.
-    cuda::atomic_ref<unsigned, cuda::thread_scope_device> atomic{global_var};
+    const cuda::atomic_ref<unsigned, cuda::thread_scope_device> atomic{global_var};
     if ((threadIdx.x + threadIdx.y + threadIdx.z) % 2 == 0)
     {
       atomic++;
@@ -110,8 +110,8 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
   {
     auto& barriers = get_barriers<nbarriers, 0>(level);
 
-    cudax::group_by<N> mapping{};
-    cudax::barrier_synchronizer synchronizer{barriers};
+    const cudax::group_by<N> mapping{};
+    const cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     test_common_properties<Unit, Level>(config.hierarchy(), group);
@@ -121,8 +121,8 @@ __device__ void test_group_by_group(Unit unit, Level level, Config config)
   {
     auto& barriers = get_barriers<nbarriers, 1>(level);
 
-    cudax::group_by mapping{N};
-    cudax::barrier_synchronizer synchronizer{barriers};
+    const cudax::group_by mapping{N};
+    const cudax::barrier_synchronizer synchronizer{barriers};
     cudax::group group{unit, parent_group, mapping, synchronizer};
 
     test_common_properties<Unit, Level>(config.hierarchy(), group);

--- a/cudax/test/group/group_stacking.cu
+++ b/cudax/test/group/group_stacking.cu
@@ -43,20 +43,21 @@ struct TestKernel1
     auto parent_group = cudax::make_this_group(cuda::warp, config);
     const auto rank   = cuda::gpu_thread.rank_as<cuda::std::uint32_t>(parent_group);
 
-    cudax::group group1{cuda::gpu_thread, parent_group, cudax::group_by<16>{}, cudax::lane_synchronizer{}};
+    const cudax::group group1{cuda::gpu_thread, parent_group, cudax::group_by<16>{}, cudax::lane_synchronizer{}};
     test_group_membership(group1, 16, rank % 16);
     REQUIRE(group1.count(parent_group) == 2);
     REQUIRE(group1.rank(parent_group) == rank / 16);
 
-    cudax::group group2{cuda::gpu_thread,
-                        group1,
-                        cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 8, 8>{}},
-                        cudax::lane_synchronizer{}};
+    const cudax::group group2{
+      cuda::gpu_thread,
+      group1,
+      cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 8, 8>{}},
+      cudax::lane_synchronizer{}};
     test_group_membership(group2, 8, rank % 8);
     REQUIRE(group2.count(group1) == 2);
     REQUIRE(group2.rank(group1) == (rank % 16) / 8);
 
-    cudax::group group3{cuda::gpu_thread, group2, cudax::group_by{4}, cudax::lane_synchronizer{}};
+    const cudax::group group3{cuda::gpu_thread, group2, cudax::group_by{4}, cudax::lane_synchronizer{}};
     test_group_membership(group3, 4, rank % 4);
     REQUIRE(group3.count(group2) == 2);
     REQUIRE(group3.rank(group2) == (rank % 8) / 4);
@@ -77,25 +78,27 @@ struct TestKernel2
 
     auto& barriers = get_barriers<4>(cuda::block);
 
-    cudax::group group1{cuda::gpu_thread, parent_group, cudax::group_by<32>{}, cudax::barrier_synchronizer{barriers}};
+    const cudax::group group1{
+      cuda::gpu_thread, parent_group, cudax::group_by<32>{}, cudax::barrier_synchronizer{barriers}};
     test_group_membership(group1, 32, rank % 32);
     REQUIRE(group1.count(parent_group) == 4);
     REQUIRE(group1.rank(parent_group) == rank / 32);
 
-    cudax::group group2{cuda::gpu_thread,
-                        group1,
-                        cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 16, 16>{}},
-                        cudax::lane_synchronizer{}};
+    const cudax::group group2{
+      cuda::gpu_thread,
+      group1,
+      cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 16, 16>{}},
+      cudax::lane_synchronizer{}};
     test_group_membership(group2, 16, rank % 16);
     REQUIRE(group2.count(group1) == 2);
     REQUIRE(group2.rank(group1) == (rank % 32) / 16);
 
-    cudax::group group3{cuda::gpu_thread, group2, cudax::group_by<8>{}, cudax::level_synchronizer{}};
+    const cudax::group group3{cuda::gpu_thread, group2, cudax::group_by<8>{}, cudax::level_synchronizer{}};
     test_group_membership(group3, 8, rank % 8);
     REQUIRE(group3.count(group2) == 2);
     REQUIRE(group3.rank(group2) == (rank % 16) / 8);
 
-    cudax::group group4{cuda::gpu_thread, group3, cudax::identity_mapping{}, cudax::lane_synchronizer{}};
+    const cudax::group group4{cuda::gpu_thread, group3, cudax::identity_mapping{}, cudax::lane_synchronizer{}};
     test_group_membership(group4, 8, rank % 8);
     REQUIRE(group4.count(group3) == 1);
     REQUIRE(group4.rank(group3) == 0);
@@ -117,7 +120,7 @@ struct TestKernel3
 
     auto& barriers1 = get_barriers<2, 0>(cuda::block);
 
-    cudax::group group1{cuda::warp, parent_group, cudax::group_by<16>{}, cudax::barrier_synchronizer{barriers1}};
+    const cudax::group group1{cuda::warp, parent_group, cudax::group_by<16>{}, cudax::barrier_synchronizer{barriers1}};
     REQUIRE(cuda::warp.is_part_of(group1));
     REQUIRE(cuda::warp.count(group1) == 16);
     REQUIRE(cuda::warp.rank(group1) == rank % 16);
@@ -127,10 +130,11 @@ struct TestKernel3
     auto& barriers2a = get_barriers<2, 1>(cuda::block);
     auto& barriers2b = get_barriers<2, 3>(cuda::block);
 
-    cudax::group group2{cuda::warp,
-                        group1,
-                        cudax::group_by<8>{},
-                        cudax::barrier_synchronizer{(group1.rank(parent_group) == 0) ? barriers2a : barriers2b}};
+    const cudax::group group2{
+      cuda::warp,
+      group1,
+      cudax::group_by<8>{},
+      cudax::barrier_synchronizer{(group1.rank(parent_group) == 0) ? barriers2a : barriers2b}};
     REQUIRE(cuda::warp.is_part_of(group2));
     REQUIRE(cuda::warp.count(group2) == 8);
     REQUIRE(cuda::warp.rank(group2) == rank % 8);

--- a/cudax/test/group/group_view.cu
+++ b/cudax/test/group/group_view.cu
@@ -39,7 +39,7 @@ __device__ void test_group_view(Config config, Level level)
 
   // Test view over the group.
   {
-    cudax::group_view gv{g};
+    const cudax::group_view gv{g};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -60,7 +60,7 @@ __device__ void test_group_view(Config config, Level level)
     gv.sync();
 
     // Test that the view is copyable.
-    cudax::group_view gv2{gv};
+    const cudax::group_view gv2{gv};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv2));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -83,7 +83,7 @@ __device__ void test_group_view(Config config, Level level)
 
   // Test view over the group with the unit changed.
   {
-    cudax::group_view gv{cuda::gpu_thread, g};
+    const cudax::group_view gv{cuda::gpu_thread, g};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -104,7 +104,7 @@ __device__ void test_group_view(Config config, Level level)
     gv.sync();
 
     // Test that the view is copyable.
-    cudax::group_view gv2{gv};
+    const cudax::group_view gv2{gv};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv2));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -127,9 +127,9 @@ __device__ void test_group_view(Config config, Level level)
 
   // Test view of the group view of the group with the unit changed.
   {
-    cudax::group_view gv{g};
+    const cudax::group_view gv{g};
 
-    cudax::group_view gv2{cuda::gpu_thread, gv};
+    const cudax::group_view gv2{cuda::gpu_thread, gv};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv2));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -153,9 +153,9 @@ __device__ void test_group_view(Config config, Level level)
   // Test view of a group view of a group with the unit changed twice.
   if constexpr (!cuda::std::is_same_v<Level, cuda::thread_level>)
   {
-    cudax::group_view gv{cuda::warp, g};
+    const cudax::group_view gv{cuda::warp, g};
 
-    cudax::group_view gv2{cuda::gpu_thread, gv};
+    const cudax::group_view gv2{cuda::gpu_thread, gv};
 
     REQUIRE(cuda::gpu_thread.is_part_of(gv2));
     if constexpr (cuda::std::is_same_v<Level, cuda::thread_level>)
@@ -182,17 +182,17 @@ __device__ void test_group_view(Config config, Level level)
     constexpr auto n = 2;
     auto& barriers   = get_barriers<cuda::warp.static_count(level, config) / n>(cuda::warp);
 
-    cudax::group g2{cuda::warp, g, cudax::group_by<n>{}, cudax::barrier_synchronizer{barriers}};
+    const cudax::group g2{cuda::warp, g, cudax::group_by<n>{}, cudax::barrier_synchronizer{barriers}};
     REQUIRE(cuda::warp.count(g2) == n);
     REQUIRE(g2.count(g) == cuda::warp.count(level) / n);
 
-    cudax::group_view g2_view{g2};
+    const cudax::group_view g2_view{g2};
     REQUIRE(cuda::warp.is_part_of(g2_view));
     REQUIRE(cuda::warp.count(g2_view) == n);
     REQUIRE(g2_view.count(g2) == cuda::warp.count(level) / n);
     g2_view.sync();
 
-    cudax::group_view g2_view_threads{cuda::gpu_thread, g2_view};
+    const cudax::group_view g2_view_threads{cuda::gpu_thread, g2_view};
     REQUIRE(cuda::gpu_thread.is_part_of(g2_view_threads));
     REQUIRE(cuda::gpu_thread.count(g2_view_threads) == n * cuda::gpu_thread.count(cuda::warp));
     REQUIRE(g2_view_threads.count(g2) == n);

--- a/cudax/test/group/invoke_one.cu
+++ b/cudax/test/group/invoke_one.cu
@@ -273,8 +273,8 @@ struct TestKernel
     // Test custom groups.
     if (cuda::warp.rank(cuda::grid, config) == 0)
     {
-      cudax::this_warp warp{config};
-      cudax::group group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}};
+      const cudax::this_warp warp{config};
+      const cudax::group group{cuda::gpu_thread, warp, cudax::group_by<4>{}, cudax::lane_synchronizer{}};
 
       if (group.rank(warp) == 0)
       {

--- a/cudax/test/group/mapping/binary_partition.cu
+++ b/cudax/test/group/mapping/binary_partition.cu
@@ -60,7 +60,7 @@ __device__ void test_binary_partition(Config config)
     // Test constructor from pred_fn.
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
-      cudax::binary_partition mapping{Pred{}};
+      const cudax::binary_partition mapping{Pred{}};
     }
 
     // Test map(...).
@@ -101,7 +101,7 @@ __device__ void test_binary_partition(Config config)
     // Test constructor from pred_fn.
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
-      cudax::binary_partition mapping{Pred{}};
+      const cudax::binary_partition mapping{Pred{}};
     }
 
     // Test map(...).
@@ -142,7 +142,7 @@ __device__ void test_binary_partition(Config config)
     // Test constructor from pred_fn.
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Pred>);
-      cudax::binary_partition mapping{Pred{}};
+      const cudax::binary_partition mapping{Pred{}};
     }
 
     // Test map(...).

--- a/cudax/test/group/mapping/composite_mapping.cu
+++ b/cudax/test/group/mapping/composite_mapping.cu
@@ -32,6 +32,7 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
 
   // Test construction from 2 mappings.
   {
+    // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
     cudax::composite_mapping mapping{mapping1, mapping2};
     static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
     static_assert(cuda::std::is_nothrow_constructible_v<Mapping, Mapping1, Mapping2>

--- a/cudax/test/group/mapping/group_as.cu
+++ b/cudax/test/group/mapping/group_as.cu
@@ -43,7 +43,7 @@ __device__ void test_group_as(Config config)
       static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
       static_assert(cuda::std::is_empty_v<Mapping>);
 
-      Mapping mapping;
+      const Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
         CHECK(mapping.unit_count(i) == ns[i]);
@@ -54,6 +54,7 @@ __device__ void test_group_as(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, NsSeq>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_as mapping{NsSeq{}};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
 
@@ -156,6 +157,7 @@ __device__ void test_group_as(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, decltype(ns)>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_as mapping{ns};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
 
@@ -269,7 +271,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
       static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
       static_assert(cuda::std::is_empty_v<Mapping>);
 
-      Mapping mapping;
+      const Mapping mapping;
       for (cuda::std::size_t i = 0; i < ngroups; ++i)
       {
         CHECK(mapping.unit_count(i) == ns[i]);
@@ -283,6 +285,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, NsSeq, cudax::non_exhaustive_t>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_as mapping{NsSeq{}, cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
 
@@ -390,6 +393,7 @@ __device__ void test_group_as_non_exhaustive(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, decltype(ns), cudax::non_exhaustive_t>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_as mapping{ns, cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
 

--- a/cudax/test/group/mapping/group_by.cu
+++ b/cudax/test/group/mapping/group_by.cu
@@ -36,7 +36,7 @@ __device__ void test_group_by(Config config)
       static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
       static_assert(cuda::std::is_empty_v<Mapping>);
 
-      cudax::group_by<N> mapping;
+      const cudax::group_by<N> mapping;
       CHECK(mapping.unit_count() == static_cast<unsigned>(N));
     }
 
@@ -112,6 +112,7 @@ __device__ void test_group_by(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_by mapping{N};
       static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
       CHECK(mapping.unit_count() == static_cast<unsigned>(N));
@@ -192,6 +193,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, cudax::non_exhaustive_t>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       Mapping mapping{cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
       CHECK(mapping.unit_count() == static_cast<unsigned>(N));
@@ -267,6 +269,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       Mapping mapping{N};
       static_assert(cuda::std::is_same_v<Mapping, decltype(mapping)>);
       CHECK(mapping.unit_count() == static_cast<unsigned>(N));
@@ -279,6 +282,7 @@ __device__ void test_group_by_non_exhaustive(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned, cudax::non_exhaustive_t>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::group_by mapping{static_cast<unsigned>(N), cudax::non_exhaustive};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
       CHECK(mapping.unit_count() == static_cast<unsigned>(N));

--- a/cudax/test/group/mapping/identity_mapping.cu
+++ b/cudax/test/group/mapping/identity_mapping.cu
@@ -33,7 +33,7 @@ __device__ void test_identity_mapping(Config config)
     static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
     static_assert(cuda::std::is_empty_v<Mapping>);
 
-    [[maybe_unused]] cudax::identity_mapping mapping;
+    [[maybe_unused]] const cudax::identity_mapping mapping;
   }
 
   // Test map(...).

--- a/cudax/test/group/mapping/take.cu
+++ b/cudax/test/group/mapping/take.cu
@@ -38,7 +38,7 @@ __device__ void test_take(Config config)
       static_assert(cuda::std::is_trivially_default_constructible_v<Mapping>);
       static_assert(cuda::std::is_empty_v<Mapping>);
 
-      Mapping mapping;
+      const Mapping mapping;
       CHECK(mapping.unit_count() == n);
     }
 
@@ -106,7 +106,7 @@ __device__ void test_take(Config config)
     {
       static_assert(cuda::std::is_nothrow_default_constructible_v<Mapping>);
 
-      Mapping mapping;
+      const Mapping mapping;
       CHECK(mapping.unit_count() == 0);
     }
 
@@ -114,6 +114,7 @@ __device__ void test_take(Config config)
     {
       static_assert(cuda::std::is_nothrow_constructible_v<Mapping, unsigned>);
 
+      // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
       cudax::take mapping{n};
       static_assert(cuda::std::is_same_v<decltype(mapping), Mapping>);
       CHECK(mapping.unit_count() == n);

--- a/cudax/test/group/synchronizer/barrier_synchronizer.cu
+++ b/cudax/test/group/synchronizer/barrier_synchronizer.cu
@@ -34,7 +34,8 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     auto& barriers = get_barriers<nbarriers, 0>(level);
     using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
 
-    cuda::std::span<Barrier, nbarriers> barriers_span{barriers, nbarriers};
+    const cuda::std::span<Barrier, nbarriers> barriers_span{barriers, nbarriers};
+    // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
     cudax::barrier_synchronizer synchronizer{barriers_span};
 
     static_assert(cuda::std::is_same_v<cudax::barrier_synchronizer<Barrier, nbarriers>, decltype(synchronizer)>);
@@ -49,7 +50,8 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     auto& barriers = get_barriers<nbarriers, 1>(level);
     using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
 
-    cuda::std::span<Barrier> barriers_span{barriers, nbarriers};
+    const cuda::std::span<Barrier> barriers_span{barriers, nbarriers};
+    // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
     cudax::barrier_synchronizer synchronizer{barriers_span};
 
     static_assert(
@@ -65,6 +67,7 @@ __device__ void test_barrier_synchronizer(const Level& level, Config config)
     auto& barriers = get_barriers<nbarriers, 2>(level);
     using Barrier  = cuda::std::remove_all_extents_t<cuda::std::remove_reference_t<decltype(barriers)>>;
 
+    // NOLINTNEXTLINE(misc-const-correctness): decltype must not be const-qualified
     cudax::barrier_synchronizer synchronizer{barriers};
 
     static_assert(cuda::std::is_same_v<cudax::barrier_synchronizer<Barrier, nbarriers>, decltype(synchronizer)>);

--- a/cudax/test/group/synchronizer/level_synchronizer.cu
+++ b/cudax/test/group/synchronizer/level_synchronizer.cu
@@ -38,7 +38,7 @@ __device__ void test_level_synchronizer(const Level& level, Config config)
     using MappingResult        = cudax::__this_mapping_result<Level>;
     using SynchronizerInstance = typename Synchronizer::template __synchronizer_instance<Level>;
 
-    MappingResult mapping_result{};
+    const MappingResult mapping_result{};
 
     // Test default constructor.
     static_assert(cuda::std::is_nothrow_default_constructible_v<SynchronizerInstance>);

--- a/cudax/test/group/this_group.cu
+++ b/cudax/test/group/this_group.cu
@@ -49,7 +49,7 @@ __device__ void test_common_properties(const Hierarchy&, Group& group)
 
     // .sync() method must support calls from different branches. Add some dummy work to make sure the branches are not
     // collided.
-    cuda::atomic_ref<unsigned, cuda::thread_scope_device> atomic{global_var};
+    const cuda::atomic_ref<unsigned, cuda::thread_scope_device> atomic{global_var};
     if ((threadIdx.x + threadIdx.y + threadIdx.z) % 2 == 0)
     {
       atomic++;

--- a/cudax/test/group/virtual_group.cu
+++ b/cudax/test/group/virtual_group.cu
@@ -27,7 +27,7 @@ __device__ void test_virtual_group(Config config, Level level)
 
   // Test virtual group with identity mapping.
   {
-    cudax::virtual_group vg{cuda::gpu_thread, g, cudax::identity_mapping{}};
+    const cudax::virtual_group vg{cuda::gpu_thread, g, cudax::identity_mapping{}};
 
     REQUIRE(cuda::gpu_thread.is_part_of(vg));
 
@@ -47,7 +47,7 @@ __device__ void test_virtual_group(Config config, Level level)
   {
     constexpr auto n = 4;
 
-    cudax::virtual_group vg{cuda::gpu_thread, g, cudax::group_by<n>{}};
+    const cudax::virtual_group vg{cuda::gpu_thread, g, cudax::group_by<n>{}};
 
     REQUIRE(cuda::gpu_thread.is_part_of(vg));
 

--- a/cudax/test/group/virtual_group_stacking.cu
+++ b/cudax/test/group/virtual_group_stacking.cu
@@ -43,18 +43,18 @@ struct TestKernel1
     auto parent_group = cudax::make_this_group(cuda::warp, config);
     const auto rank   = cuda::gpu_thread.rank_as<cuda::std::uint32_t>(parent_group);
 
-    cudax::virtual_group group1{cuda::gpu_thread, parent_group, cudax::group_by<16>{}};
+    const cudax::virtual_group group1{cuda::gpu_thread, parent_group, cudax::group_by<16>{}};
     test_group_membership(group1, 16, rank % 16);
     REQUIRE(group1.count(parent_group) == 2);
     REQUIRE(group1.rank(parent_group) == rank / 16);
 
-    cudax::virtual_group group2{
+    const cudax::virtual_group group2{
       cuda::gpu_thread, group1, cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 8, 8>{}}};
     test_group_membership(group2, 8, rank % 8);
     REQUIRE(group2.count(group1) == 2);
     REQUIRE(group2.rank(group1) == (rank % 16) / 8);
 
-    cudax::virtual_group group3{cuda::gpu_thread, group2, cudax::group_by{4}};
+    const cudax::virtual_group group3{cuda::gpu_thread, group2, cudax::group_by{4}};
     test_group_membership(group3, 4, rank % 4);
     REQUIRE(group3.count(group2) == 2);
     REQUIRE(group3.rank(group2) == (rank % 8) / 4);
@@ -73,23 +73,23 @@ struct TestKernel2
     auto parent_group = cudax::make_this_group(cuda::block, config);
     const auto rank   = cuda::gpu_thread.rank_as<cuda::std::uint32_t>(parent_group);
 
-    cudax::virtual_group group1{cuda::gpu_thread, parent_group, cudax::group_by<32>{}};
+    const cudax::virtual_group group1{cuda::gpu_thread, parent_group, cudax::group_by<32>{}};
     test_group_membership(group1, 32, rank % 32);
     REQUIRE(group1.count(parent_group) == 4);
     REQUIRE(group1.rank(parent_group) == rank / 32);
 
-    cudax::virtual_group group2{
+    const cudax::virtual_group group2{
       cuda::gpu_thread, group1, cudax::group_as{cuda::std::integer_sequence<cuda::std::size_t, 16, 16>{}}};
     test_group_membership(group2, 16, rank % 16);
     REQUIRE(group2.count(group1) == 2);
     REQUIRE(group2.rank(group1) == (rank % 32) / 16);
 
-    cudax::virtual_group group3{cuda::gpu_thread, group2, cudax::group_by<8>{}};
+    const cudax::virtual_group group3{cuda::gpu_thread, group2, cudax::group_by<8>{}};
     test_group_membership(group3, 8, rank % 8);
     REQUIRE(group3.count(group2) == 2);
     REQUIRE(group3.rank(group2) == (rank % 16) / 8);
 
-    cudax::virtual_group group4{cuda::gpu_thread, group3, cudax::identity_mapping{}};
+    const cudax::virtual_group group4{cuda::gpu_thread, group3, cudax::identity_mapping{}};
     test_group_membership(group4, 8, rank % 8);
     REQUIRE(group4.count(group3) == 1);
     REQUIRE(group4.rank(group3) == 0);
@@ -109,14 +109,14 @@ struct TestKernel3
     auto parent_group = cudax::make_this_group(cuda::block, config);
     const auto rank   = cuda::warp.rank_as<cuda::std::uint32_t>(parent_group);
 
-    cudax::virtual_group group1{cuda::warp, parent_group, cudax::group_by<16>{}};
+    const cudax::virtual_group group1{cuda::warp, parent_group, cudax::group_by<16>{}};
     REQUIRE(cuda::warp.is_part_of(group1));
     REQUIRE(cuda::warp.count(group1) == 16);
     REQUIRE(cuda::warp.rank(group1) == rank % 16);
     REQUIRE(group1.count(parent_group) == 2);
     REQUIRE(group1.rank(parent_group) == rank / 16);
 
-    cudax::virtual_group group2{cuda::warp, group1, cudax::group_by<8>{}};
+    const cudax::virtual_group group2{cuda::warp, group1, cudax::group_by<8>{}};
     REQUIRE(cuda::warp.is_part_of(group2));
     REQUIRE(cuda::warp.count(group2) == 8);
     REQUIRE(cuda::warp.rank(group2) == rank % 8);

--- a/cudax/test/kernel/kernel_ref.cu
+++ b/cudax/test/kernel/kernel_ref.cu
@@ -181,8 +181,8 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   CUkernel kernel_ptx1_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx1");
   CUkernel kernel_ptx2_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx2");
 
-  cuda::device_ref device{0};
-  cuda::__ensure_current_context context_guard{device};
+  const cuda::device_ref device{0};
+  const cuda::__ensure_current_context context_guard{device};
 
   // Types
   {
@@ -201,20 +201,20 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
 
     // We currently have no way to check if the kernel parameters match
     {
-      cudax::kernel_ref<void()> kernel_ref{kernel_ptx1_handle};
+      const cudax::kernel_ref<void()> kernel_ref{kernel_ptx1_handle};
       REQUIRE(kernel_ptx1_handle == kernel_ref.get());
 
-      cudax::kernel_ref<void()> kernel_ref2{kernel_ptx2_handle};
+      const cudax::kernel_ref<void()> kernel_ref2{kernel_ptx2_handle};
       REQUIRE(kernel_ptx2_handle == kernel_ref2.get());
 
       REQUIRE(kernel_ptx1_handle != kernel_ptx2_handle);
       REQUIRE(kernel_ref.get() != kernel_ref2.get());
     }
     {
-      cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
+      const cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
       REQUIRE(kernel_ptx1_handle == kernel_ref.get());
 
-      cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ptx2_handle};
+      const cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ptx2_handle};
       REQUIRE(kernel_ptx2_handle == kernel_ref2.get());
 
       REQUIRE(kernel_ptx1_handle != kernel_ptx2_handle);
@@ -232,7 +232,7 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
     CUkernel kernel_rt_handle{};
     REQUIRE_CUDART(cudaGetKernel(&kernel_rt_handle, kernel_rt));
 
-    cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_rt};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_rt};
     REQUIRE(kernel_rt_handle == kernel_ref1.get());
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 1)
@@ -241,10 +241,10 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   {
     STATIC_REQUIRE(cuda::std::is_trivially_copy_constructible_v<cudax::kernel_ref<void()>>);
 
-    cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_ptx1_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_ptx1_handle};
     REQUIRE(kernel_ptx1_handle == kernel_ref1.get());
 
-    cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ref1};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ref1};
     REQUIRE(kernel_ptx1_handle == kernel_ref2.get());
     REQUIRE(kernel_ref1.get() == kernel_ref2.get());
   }
@@ -255,14 +255,14 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
     STATIC_REQUIRE(
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::kernel_ref<void()>>().name()), cuda::std::string_view>);
 
-    cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
     REQUIRE(kernel_ref.name() == "kernel_ptx1");
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 3)
 
   // Attributes
   {
-    cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
 
     const auto cc = cuda::device_attributes::compute_capability(device);
 
@@ -293,14 +293,14 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   {
     STATIC_REQUIRE(cuda::std::is_same_v<decltype(cuda::std::declval<cudax::kernel_ref<void()>>().get()), CUkernel>);
 
-    cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref{kernel_ptx1_handle};
     REQUIRE(kernel_ptx1_handle == kernel_ref.get());
   }
 
   // Equality/Inequality comparison
   {
-    cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_ptx1_handle};
-    cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ptx2_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref1{kernel_ptx1_handle};
+    const cudax::kernel_ref<void(int*, int)> kernel_ref2{kernel_ptx2_handle};
 
     REQUIRE(kernel_ref1 == kernel_ref1);
     REQUIRE(kernel_ref1 != kernel_ref2);
@@ -309,7 +309,7 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   // Deduction guidelines
 #if _CCCL_CTK_AT_LEAST(12, 1)
   {
-    cudax::kernel_ref kernel_ref1{kernel_rt};
+    cudax::kernel_ref kernel_ref1{kernel_rt}; // NOLINT(misc-const-correctness)
     REQUIRE((cuda::std::is_same_v<decltype(kernel_ref1), cudax::kernel_ref<void(int*, int)>>) );
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 1)

--- a/cudax/test/library/library.cu
+++ b/cudax/test/library/library.cu
@@ -133,7 +133,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
   // Constructor into moved-from state
   {
     STATIC_REQUIRE(cuda::std::is_nothrow_constructible_v<cudax::library, cudax::no_init_t>);
-    cudax::library lib{cudax::no_init};
+    const cudax::library lib{cudax::no_init};
     REQUIRE(lib.get() == CUlibrary{});
 
     // lib is in a moved-from state
@@ -234,7 +234,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
     {
       auto global_sym = lib.global(global_symbol_name, device);
 
-      cuda::__ensure_current_context context_guard{device};
+      const cuda::__ensure_current_context context_guard{device};
 
       CUdeviceptr global_symbol_ptr;
       cuda::std::size_t global_symbol_size;
@@ -250,7 +250,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
     {
       auto const_sym = lib.global(const_symbol_name, device);
 
-      cuda::__ensure_current_context context_guard{device};
+      const cuda::__ensure_current_context context_guard{device};
 
       CUdeviceptr const_symbol_ptr;
       cuda::std::size_t const_symbol_size;
@@ -335,8 +335,8 @@ C2H_CCCLRT_TEST("Library", "[library]")
 
   // Destructor
   {
-    cudax::library lib1 = cudax::library::from_native_handle(lib1_native);
-    cudax::library lib2 = cudax::library::from_native_handle(lib2_native);
+    const cudax::library lib1 = cudax::library::from_native_handle(lib1_native);
+    const cudax::library lib2 = cudax::library::from_native_handle(lib2_native);
 
     // lib1 and lib2 will be destroyed here, which will unload the libraries
   }

--- a/cudax/test/library/library_ref.cu
+++ b/cudax/test/library/library_ref.cu
@@ -125,7 +125,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     STATIC_REQUIRE(cuda::std::is_constructible_v<cudax::library_ref, CUlibrary>);
     STATIC_REQUIRE(cuda::std::is_convertible_v<CUlibrary, cudax::library_ref>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     REQUIRE(lib1 == lib_ref.get());
   }
 
@@ -133,10 +133,10 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
   {
     STATIC_REQUIRE(cuda::std::is_trivially_copy_constructible_v<cudax::library_ref>);
 
-    cudax::library_ref lib_ref1{lib1};
+    const cudax::library_ref lib_ref1{lib1};
     REQUIRE(lib1 == lib_ref1.get());
 
-    cudax::library_ref lib_ref2{lib1};
+    const cudax::library_ref lib_ref2{lib1};
     REQUIRE(lib1 == lib_ref2.get());
     REQUIRE(lib_ref1.get() == lib_ref2.get());
   }
@@ -146,7 +146,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     STATIC_REQUIRE(
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().has_kernel(kernel_name)), bool>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     REQUIRE(lib_ref.has_kernel(kernel_name));
     REQUIRE(!lib_ref.has_kernel("non_existent_kernel"));
   }
@@ -157,7 +157,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().kernel<void(int*, int)>(kernel_name)),
                            cudax::kernel_ref<void(int*, int)>>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     auto kernel = lib_ref.kernel<void(int*, int)>(kernel_name);
 
     CUkernel kernel_handle;
@@ -171,7 +171,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().has_global(global_symbol_name, device)),
                            bool>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     REQUIRE(lib_ref.has_global(global_symbol_name, device));
     REQUIRE(lib_ref.has_global(const_symbol_name, device));
     REQUIRE(!lib_ref.has_global("non_existent_global", device));
@@ -183,13 +183,13 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().global(global_symbol_name, device)),
                            cudax::library_symbol_info>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
 
     // Test global_symbol_name
     {
       auto global_sym = lib_ref.global(global_symbol_name, device);
 
-      cuda::__ensure_current_context context_guard{device};
+      const cuda::__ensure_current_context context_guard{device};
 
       CUdeviceptr global_symbol_ptr;
       cuda::std::size_t global_symbol_size;
@@ -205,7 +205,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     {
       auto const_sym = lib_ref.global(const_symbol_name, device);
 
-      cuda::__ensure_current_context context_guard{device};
+      const cuda::__ensure_current_context context_guard{device};
 
       CUdeviceptr const_symbol_ptr;
       cuda::std::size_t const_symbol_size;
@@ -223,7 +223,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     STATIC_REQUIRE(
       cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().has_managed(managed_symbol_name)), bool>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     REQUIRE(lib_ref.has_managed(managed_symbol_name));
     REQUIRE(!lib_ref.has_managed("non_existent_managed"));
   }
@@ -233,7 +233,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     STATIC_REQUIRE(cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().managed(managed_symbol_name)),
                                         cudax::library_symbol_info>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     auto managed_sym = lib_ref.managed(managed_symbol_name);
 
     CUdeviceptr managed_symbol_ptr;
@@ -250,14 +250,14 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
   {
     STATIC_REQUIRE(cuda::std::is_same_v<decltype(cuda::std::declval<cudax::library_ref>().get()), CUlibrary>);
 
-    cudax::library_ref lib_ref{lib1};
+    const cudax::library_ref lib_ref{lib1};
     REQUIRE(lib1 == lib_ref.get());
   }
 
   // Equality/Inequality comparison
   {
-    cudax::library_ref lib_ref1{lib1};
-    cudax::library_ref lib_ref2{lib2};
+    const cudax::library_ref lib_ref1{lib1};
+    const cudax::library_ref lib_ref2{lib2};
 
     REQUIRE(lib_ref1 == lib_ref1);
     REQUIRE(lib_ref1 != lib_ref2);

--- a/cudax/test/multi_gpu/algorithms/sort/range_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/range_basic.cu
@@ -177,7 +177,7 @@ MULTI_GPU_TEST("sort, no communicators", sort_test_util::sort_types)
   using T = typename c2h::get<0, TestType>;
 
   const auto comms = cuda::std::span<cudax::nccl_communicator_ref>{};
-  std::vector<std::vector<T>> input(comms.size());
+  const std::vector<std::vector<T>> input(comms.size());
 
   check_sort_case_sections(comms, input);
 }
@@ -187,7 +187,7 @@ MULTI_GPU_TEST("sort, all ranks empty", sort_test_util::sort_types)
   using T = typename c2h::get<0, TestType>;
 
   auto comms = this->communicators();
-  std::vector<std::vector<T>> input(comms.size());
+  const std::vector<std::vector<T>> input(comms.size());
 
   check_sort_case_sections(comms, input);
 }

--- a/cudax/test/multi_gpu/algorithms/sort/single_comm_basic.cu
+++ b/cudax/test/multi_gpu/algorithms/sort/single_comm_basic.cu
@@ -188,7 +188,7 @@ MULTI_GPU_TEST("sort single-comm, all ranks empty", sort_test_util::sort_types)
   using T = typename c2h::get<0, TestType>;
 
   auto comms = this->communicators();
-  std::vector<std::vector<T>> input(comms.size());
+  const std::vector<std::vector<T>> input(comms.size());
 
   check_sort_case_sections(comms, input);
 }

--- a/cudax/test/multi_gpu/algorithms/sort/sort_common.cuh
+++ b/cudax/test/multi_gpu/algorithms/sort/sort_common.cuh
@@ -63,6 +63,7 @@ template <>
 template <class T, class RNG>
 void fill_random(std::vector<T>& local, cuda::std::size_t count, RNG& rng)
 {
+  // NOLINTNEXTLINE(misc-const-correctness)
   cuda::std::uniform_int_distribution<cuda::std::int64_t> dist{
     cuda::std::numeric_limits<cuda::std::int64_t>::lowest(), cuda::std::numeric_limits<cuda::std::int64_t>::max()};
 

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -19,7 +19,7 @@
 
 C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")
 {
-  cudax::stream str{cuda::device_ref{0}};
+  const cudax::stream str{cuda::device_ref{0}};
   ::test::pinned<int> i(0);
   cudax::launch(str, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   str.sync();
@@ -28,7 +28,7 @@ C2H_CCCLRT_TEST("Can create a stream and launch work into it", "[stream]")
 
 C2H_CCCLRT_TEST("From native handle", "[stream]")
 {
-  cuda::__ensure_current_context guard(cuda::device_ref{0});
+  const cuda::__ensure_current_context guard(cuda::device_ref{0});
   cudaStream_t handle;
   REQUIRE_CUDART(cudaStreamCreate(&handle));
   {
@@ -50,7 +50,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 
   auto verify_dependency = [&](const auto& insert_dependency) {
     ::test::pinned<int> i(0);
-    ::cuda::atomic_ref atomic_i(*i);
+    const ::cuda::atomic_ref atomic_i(*i);
 
     cudax::launch(waitee, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
     cudax::launch(waitee, ::test::one_thread_dims, ::test::assign_42{}, i.get());
@@ -66,7 +66,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
   SECTION("Stream wait declared event")
   {
     verify_dependency([&]() {
-      cuda::event ev(waitee);
+      const cuda::event ev(waitee);
       waiter.wait(ev);
     });
   }
@@ -97,7 +97,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 
 C2H_CCCLRT_TEST("Can add dependency into a stream", "[stream]")
 {
-  cudax::stream waiter{cuda::device_ref{0}}, waitee{cuda::device_ref{0}};
+  const cudax::stream waiter{cuda::device_ref{0}}, waitee{cuda::device_ref{0}};
 
   add_dependency_test<cudax::stream>(waiter, waitee);
   add_dependency_test<cudax::stream_ref>(waiter, waitee);
@@ -105,20 +105,20 @@ C2H_CCCLRT_TEST("Can add dependency into a stream", "[stream]")
 
 C2H_CCCLRT_TEST("Stream priority", "[stream]")
 {
-  cudax::stream stream_default_prio{cuda::device_ref{0}};
+  const cudax::stream stream_default_prio{cuda::device_ref{0}};
   REQUIRE(stream_default_prio.priority() == cudax::stream::default_priority);
 
   auto priority = cudax::stream::default_priority - 1;
-  cudax::stream stream{cuda::device_ref{0}, priority};
+  const cudax::stream stream{cuda::device_ref{0}, priority};
   REQUIRE(stream.priority() == priority);
 }
 
 C2H_CCCLRT_TEST("Stream get device", "[stream]")
 {
-  cudax::stream dev0_stream(cuda::device_ref{0});
+  const cudax::stream dev0_stream(cuda::device_ref{0});
   REQUIRE(dev0_stream.device() == 0);
 
-  cudax::__ensure_current_device guard(cuda::device_ref{*std::prev(cuda::devices.end())});
+  const cudax::__ensure_current_device guard(cuda::device_ref{*std::prev(cuda::devices.end())});
   cudaStream_t stream_handle;
   REQUIRE_CUDART(cudaStreamCreate(&stream_handle));
   auto stream_cudart = cudax::stream::from_native_handle(stream_handle);
@@ -132,7 +132,7 @@ C2H_CCCLRT_TEST("Stream get device", "[stream]")
     {
       auto ldev = dev0_stream.logical_device();
       REQUIRE(ldev.kind() == cudax::logical_device::kinds::device);
-      cudax::stream side_stream(ldev);
+      const cudax::stream side_stream(ldev);
       REQUIRE(side_stream.device() == dev0_stream.device());
     }
   }
@@ -143,8 +143,8 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
   STATIC_REQUIRE(cuda::std::is_same_v<unsigned long long, cuda::std::underlying_type_t<cuda::stream_id>>);
   STATIC_REQUIRE(cuda::std::is_same_v<cuda::stream_id, decltype(cuda::std::declval<cudax::stream_ref>().id())>);
 
-  cudax::stream stream1{cuda::device_ref{0}};
-  cudax::stream stream2{cuda::device_ref{0}};
+  const cudax::stream stream1{cuda::device_ref{0}};
+  const cudax::stream stream2{cuda::device_ref{0}};
 
   // Test that id() returns a valid ID
   auto id1 = stream1.id();
@@ -169,9 +169,9 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
   {
     // Test that stream_ref also supports id()
     // NULL stream needs a device to be set
-    cuda::__ensure_current_context guard(cuda::device_ref{0});
-    cuda::stream_ref ref1(::cudaStream_t{});
-    cuda::stream_ref ref2(stream1);
+    const cuda::__ensure_current_context guard(cuda::device_ref{0});
+    const cuda::stream_ref ref1(::cudaStream_t{});
+    const cuda::stream_ref ref2(stream1);
 
 #if _CCCL_COMPILER(NVHPC, <, 25, 11)
     REQUIRE(cuda::std::to_underlying(ref1.id()) != cuda::std::to_underlying(ref2.id()));

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -19,7 +19,7 @@ namespace driver = cuda::__driver;
 void recursive_check_device_setter(int id)
 {
   int cudart_id;
-  cudax::__ensure_current_device setter(cuda::device_ref{id});
+  const cudax::__ensure_current_device setter(cuda::device_ref{id});
   REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
   auto ctx = driver::__ctxGetCurrent();
   REQUIRE_CUDART(cudaGetDevice(&cudart_id));
@@ -40,7 +40,7 @@ C2H_TEST("ensure current device", "[device]")
 {
   test::empty_driver_stack();
   // If possible use something different than REQUIRE_CUDART default 0
-  int target_device = static_cast<int>(cuda::devices.size() - 1);
+  const int target_device = static_cast<int>(cuda::devices.size() - 1);
 
   SECTION("device setter")
   {

--- a/cudax/test/utility/scope.cu
+++ b/cudax/test/utility/scope.cu
@@ -20,7 +20,7 @@ TEST_CASE("scope_exit runs on normal exit", "[utility][scope]")
 {
   int count = 0;
   {
-    cudax::scope_exit guard{[&]() noexcept {
+    const cudax::scope_exit guard{[&]() noexcept {
       ++count;
     }};
     CHECK(count == 0);
@@ -34,7 +34,7 @@ TEST_CASE("scope_exit runs on exceptional exit", "[utility][scope]")
   bool caught = false;
   try
   {
-    cudax::scope_exit guard{[&]() noexcept {
+    const cudax::scope_exit guard{[&]() noexcept {
       ++count;
     }};
     throw 42;
@@ -76,7 +76,7 @@ TEST_CASE("scope_fail runs only on exceptional exit", "[utility][scope]")
 {
   int count = 0;
   {
-    cudax::scope_fail guard{[&]() noexcept {
+    const cudax::scope_fail guard{[&]() noexcept {
       ++count;
     }};
   }
@@ -85,7 +85,7 @@ TEST_CASE("scope_fail runs only on exceptional exit", "[utility][scope]")
   bool caught = false;
   try
   {
-    cudax::scope_fail guard{[&]() noexcept {
+    const cudax::scope_fail guard{[&]() noexcept {
       ++count;
     }};
     throw 42;
@@ -142,7 +142,7 @@ TEST_CASE("scope_success runs only on normal exit", "[utility][scope]")
 {
   int count = 0;
   {
-    cudax::scope_success guard{[&] {
+    const cudax::scope_success guard{[&] {
       ++count;
     }};
   }
@@ -152,7 +152,7 @@ TEST_CASE("scope_success runs only on normal exit", "[utility][scope]")
   bool caught = false;
   try
   {
-    cudax::scope_success guard{[&] {
+    const cudax::scope_success guard{[&] {
       ++count;
     }};
     throw 42;


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `cudax/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.