### PR TITLE
[c2h][nvbench_helper][C parallel] `misc-const-correctness`

### DIFF
--- a/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
+++ b/c/experimental/stf/include/cccl/c/experimental/stf/stf.h
@@ -1731,7 +1731,7 @@ static inline cudaError_t stf_cuda_kernel_add_desc(
   const void** args)
 {
   CUfunction cufunc;
-  cudaError_t res = cudaGetFuncBySymbol(&cufunc, func);
+  const cudaError_t res = cudaGetFuncBySymbol(&cufunc, func);
   if (res != cudaSuccess)
   {
     return res;

--- a/c/experimental/stf/test/test_allocate_nd.cpp
+++ b/c/experimental/stf/test/test_allocate_nd.cpp
@@ -76,7 +76,7 @@ C2H_TEST("shaped allocation on composite data places", "[places][allocate]")
   REQUIRE(dp != nullptr);
 
   // A byte count alone cannot carry the tensor geometry: must fail cleanly
-  void* const bad = stf_data_place_allocate(dp, static_cast<ptrdiff_t>(n * sizeof(int)), nullptr);
+  const void* const bad = stf_data_place_allocate(dp, static_cast<ptrdiff_t>(n * sizeof(int)), nullptr);
   REQUIRE(bad == nullptr);
 
   void* const ptr = stf_data_place_allocate_nd(dp, &dims, sizeof(int), nullptr);

--- a/c/experimental/stf/test/test_async_resources_handle.cu
+++ b/c/experimental/stf/test/test_async_resources_handle.cu
@@ -76,12 +76,12 @@ void submit_set_kernel(stf_ctx_handle ctx, int* d_arr, int n, int value, int ite
   stf_cuda_kernel_add_dep(k, lD, STF_RW);
   stf_cuda_kernel_start(k);
 
-  int* arg_ptr = static_cast<int*>(stf_cuda_kernel_get_arg(k, 0));
+  const int* arg_ptr = static_cast<int*>(stf_cuda_kernel_get_arg(k, 0));
   REQUIRE(arg_ptr == d_arr);
   const int threads   = 128;
   const int blocks    = (n + threads - 1) / threads;
   const void* args[4] = {&arg_ptr, &n, &value, &iters};
-  cudaError_t err =
+  const cudaError_t err =
     stf_cuda_kernel_add_desc(k, reinterpret_cast<void*>(slow_set_kernel), dim3(blocks), dim3(threads), 0, 4, args);
   REQUIRE(err == cudaSuccess);
   stf_cuda_kernel_end(k);

--- a/c/experimental/stf/test/test_ctx.cpp
+++ b/c/experimental/stf/test/test_ctx.cpp
@@ -38,9 +38,9 @@ C2H_TEST("stf_ctx_wait reads data without finalizing", "[context]")
   stf_host_launch_add_dep(h, lVal, STF_WRITE);
   stf_host_launch_set_user_data(h, &src_val, sizeof(int), nullptr);
   stf_host_launch_submit(h, [](stf_host_launch_deps_handle deps) {
-    int* data = (int*) stf_host_launch_deps_get(deps, 0);
-    int* src  = (int*) stf_host_launch_deps_get_user_data(deps);
-    data[0]   = *src;
+    int* data      = (int*) stf_host_launch_deps_get(deps, 0);
+    const int* src = (int*) stf_host_launch_deps_get_user_data(deps);
+    data[0]        = *src;
   });
   stf_host_launch_destroy(h);
 
@@ -58,9 +58,9 @@ C2H_TEST("stf_ctx_wait reads data without finalizing", "[context]")
   stf_host_launch_add_dep(h2, lVal, STF_WRITE);
   stf_host_launch_set_user_data(h2, &src_val, sizeof(int), nullptr);
   stf_host_launch_submit(h2, [](stf_host_launch_deps_handle deps) {
-    int* data = (int*) stf_host_launch_deps_get(deps, 0);
-    int* src  = (int*) stf_host_launch_deps_get_user_data(deps);
-    data[0]   = *src;
+    int* data      = (int*) stf_host_launch_deps_get(deps, 0);
+    const int* src = (int*) stf_host_launch_deps_get_user_data(deps);
+    data[0]        = *src;
   });
   stf_host_launch_destroy(h2);
 

--- a/c/experimental/stf/test/test_cuda_kernel.cu
+++ b/c/experimental/stf/test/test_cuda_kernel.cu
@@ -17,8 +17,8 @@
 
 __global__ void axpy(int cnt, double a, const double* x, double* y)
 {
-  int tid      = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
-  int nthreads = static_cast<int>(gridDim.x * blockDim.x);
+  const int tid      = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int nthreads = static_cast<int>(gridDim.x * blockDim.x);
 
   for (int i = tid; i < cnt; i += nthreads)
   {
@@ -68,10 +68,10 @@ C2H_TEST("axpy with stf cuda_kernel", "[cuda_kernel]")
   stf_cuda_kernel_add_dep(k, lX, STF_READ);
   stf_cuda_kernel_add_dep(k, lY, STF_RW);
   stf_cuda_kernel_start(k);
-  double* dX          = (double*) stf_cuda_kernel_get_arg(k, 0);
-  double* dY          = (double*) stf_cuda_kernel_get_arg(k, 1);
-  const void* args[4] = {&N, &alpha, &dX, &dY};
-  cudaError_t err     = stf_cuda_kernel_add_desc(k, (void*) axpy, 2, 4, 0, 4, args);
+  const double* dX      = (double*) stf_cuda_kernel_get_arg(k, 0);
+  const double* dY      = (double*) stf_cuda_kernel_get_arg(k, 1);
+  const void* args[4]   = {&N, &alpha, &dX, &dY};
+  const cudaError_t err = stf_cuda_kernel_add_desc(k, (void*) axpy, 2, 4, 0, 4, args);
   REQUIRE(err == cudaSuccess);
   stf_cuda_kernel_end(k);
   stf_cuda_kernel_destroy(k);

--- a/c/experimental/stf/test/test_host_launch.cu
+++ b/c/experimental/stf/test/test_host_launch.cu
@@ -17,8 +17,8 @@
 
 __global__ void fill_kernel(int cnt, double* data, double value)
 {
-  int tid      = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
-  int nthreads = static_cast<int>(gridDim.x * blockDim.x);
+  const int tid      = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int nthreads = static_cast<int>(gridDim.x * blockDim.x);
 
   for (int i = tid; i < cnt; i += nthreads)
   {

--- a/c/experimental/stf/test/test_logical_data.cpp
+++ b/c/experimental/stf/test/test_logical_data.cpp
@@ -17,7 +17,7 @@
 
 C2H_TEST("basic stf logical_data", "[logical_data]")
 {
-  size_t N = 1000000;
+  const size_t N = 1000000;
 
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);

--- a/c/experimental/stf/test/test_logical_data_with_place.cu
+++ b/c/experimental/stf/test/test_logical_data_with_place.cu
@@ -23,7 +23,7 @@
 
 __global__ void scale_inplace(int n, float* data, float factor)
 {
-  int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
   if (i < n)
   {
     data[i] *= factor;
@@ -32,7 +32,7 @@ __global__ void scale_inplace(int n, float* data, float factor)
 
 C2H_TEST("stf_logical_data_with_place - host place (malloc)", "[logical_data_with_place]")
 {
-  size_t N = 1024;
+  const size_t N = 1024;
 
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);
@@ -66,13 +66,13 @@ C2H_TEST("stf_logical_data_with_place - host place (malloc)", "[logical_data_wit
 
 C2H_TEST("stf_logical_data_with_place - host place (pinned memory)", "[logical_data_with_place]")
 {
-  size_t N = 1024;
+  const size_t N = 1024;
 
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);
 
-  float* A        = nullptr;
-  cudaError_t err = cudaMallocHost(&A, N * sizeof(float));
+  float* A              = nullptr;
+  const cudaError_t err = cudaMallocHost(&A, N * sizeof(float));
   REQUIRE(err == cudaSuccess);
   for (size_t i = 0; i < N; ++i)
   {
@@ -104,7 +104,7 @@ C2H_TEST("stf_logical_data_with_place - host place (pinned memory)", "[logical_d
 
 C2H_TEST("stf_logical_data_with_place - device place (data on current device)", "[logical_data_with_place]")
 {
-  size_t N           = 1024;
+  const size_t N     = 1024;
   const float factor = 2.0f;
 
   stf_ctx_handle ctx = stf_ctx_create();
@@ -113,7 +113,7 @@ C2H_TEST("stf_logical_data_with_place - device place (data on current device)", 
   float* d_raw    = nullptr;
   cudaError_t err = cudaMalloc(&d_raw, N * sizeof(float));
   REQUIRE(err == cudaSuccess);
-  std::unique_ptr<void, decltype(&cudaFree)> d_data_owner(d_raw, cudaFree);
+  const std::unique_ptr<void, decltype(&cudaFree)> d_data_owner(d_raw, cudaFree);
   float* d_data = static_cast<float*>(d_data_owner.get());
 
   std::vector<float> h_init(N);
@@ -135,12 +135,12 @@ C2H_TEST("stf_logical_data_with_place - device place (data on current device)", 
   stf_cuda_kernel_set_symbol(k, "scale_inplace");
   stf_cuda_kernel_add_dep(k, lD, STF_RW);
   stf_cuda_kernel_start(k);
-  float* arg_ptr = static_cast<float*>(stf_cuda_kernel_get_arg(k, 0));
+  const float* arg_ptr = static_cast<float*>(stf_cuda_kernel_get_arg(k, 0));
   REQUIRE(arg_ptr == d_data);
   int n               = static_cast<int>(N);
   const void* args[3] = {&n, &arg_ptr, &factor};
-  dim3 grid(4);
-  dim3 block(256);
+  const dim3 grid(4);
+  const dim3 block(256);
   err = stf_cuda_kernel_add_desc(k, reinterpret_cast<void*>(scale_inplace), grid, block, 0, 3, args);
   REQUIRE(err == cudaSuccess);
   stf_cuda_kernel_end(k);

--- a/c/experimental/stf/test/test_places.cpp
+++ b/c/experimental/stf/test/test_places.cpp
@@ -22,14 +22,14 @@
 // Used to exercise composite data place with a grid of execution places.
 static void blocked_mapper_1d(stf_pos4* result, stf_pos4 data_coords, stf_dim4 data_dims, stf_dim4 grid_dims)
 {
-  uint64_t extent    = data_dims.x;
-  uint64_t nplaces   = grid_dims.x;
-  uint64_t part_size = ::cuda::ceil_div(extent, nplaces);
+  const uint64_t extent  = data_dims.x;
+  const uint64_t nplaces = grid_dims.x;
+  uint64_t part_size     = ::cuda::ceil_div(extent, nplaces);
   if (part_size == 0)
   {
     part_size = 1;
   }
-  int64_t c       = static_cast<int64_t>(data_coords.x);
+  const int64_t c = static_cast<int64_t>(data_coords.x);
   int64_t place_x = c / static_cast<int64_t>(part_size);
   if (place_x >= static_cast<int64_t>(nplaces))
   {
@@ -100,7 +100,7 @@ C2H_TEST("exec place from an externally-owned CUDA context", "[task][places][cud
 
 C2H_TEST("empty stf tasks", "[task]")
 {
-  size_t N = 1000000;
+  const size_t N = 1000000;
 
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);
@@ -187,7 +187,7 @@ C2H_TEST("composite data place with grid of places (same device repeated)", "[ta
   REQUIRE(composite_dplace != nullptr);
   stf_exec_place_grid_destroy(grid);
 
-  size_t N           = 1024;
+  const size_t N     = 1024;
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);
 
@@ -244,7 +244,7 @@ C2H_TEST("composite data place with stf_exec_place_grid_create (vector of places
   {
     place = stf_exec_place_device(0);
   }
-  stf_dim4 grid_dims         = {2, 2, 1, 1};
+  const stf_dim4 grid_dims   = {2, 2, 1, 1};
   stf_exec_place_handle grid = stf_exec_place_grid_create(places, nplaces, &grid_dims);
   REQUIRE(grid != nullptr);
   for (auto& place : places)
@@ -256,7 +256,7 @@ C2H_TEST("composite data place with stf_exec_place_grid_create (vector of places
   REQUIRE(composite_dplace != nullptr);
   stf_exec_place_grid_destroy(grid);
 
-  size_t N           = 512;
+  const size_t N     = 512;
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);
 
@@ -323,7 +323,7 @@ C2H_TEST("task on exec_place_grid: get_grid_dims and get_custream_at_index", "[t
   stf_task_start(t);
 
   stf_dim4 dims;
-  int got_dims = stf_task_get_grid_dims(t, &dims);
+  const int got_dims = stf_task_get_grid_dims(t, &dims);
   REQUIRE(got_dims == 0);
   REQUIRE(dims.x == 2);
   REQUIRE(dims.y == 1);

--- a/c/experimental/stf/test/test_stackable_token_push.cu
+++ b/c/experimental/stf/test/test_stackable_token_push.cu
@@ -186,8 +186,8 @@ C2H_TEST("stackable: logical_data write/read chain + pop_prologue (workaround)",
   stf_ctx_handle ctx = stf_stackable_ctx_create();
   REQUIRE(ctx != nullptr);
 
-  uint8_t* host_dep = nullptr;
-  cudaError_t err   = cudaMallocHost(&host_dep, N * sizeof(uint8_t));
+  uint8_t* host_dep     = nullptr;
+  const cudaError_t err = cudaMallocHost(&host_dep, N * sizeof(uint8_t));
   REQUIRE(err == cudaSuccess);
   for (size_t i = 0; i < N; i++)
   {

--- a/c/experimental/stf/test/test_task.cpp
+++ b/c/experimental/stf/test/test_task.cpp
@@ -17,7 +17,7 @@
 
 C2H_TEST("empty stf tasks", "[task]")
 {
-  size_t N = 1000000;
+  const size_t N = 1000000;
 
   stf_ctx_handle ctx = stf_ctx_create();
   REQUIRE(ctx != nullptr);

--- a/c/experimental/stf/test/test_task_get_graph.cu
+++ b/c/experimental/stf/test/test_task_get_graph.cu
@@ -61,10 +61,10 @@ C2H_TEST("task_get_graph: explicit kernel node in a stackable graph scope", "[st
     cudaGraph_t g = stf_task_get_graph(t);
     REQUIRE(g != nullptr);
 
-    double* d           = static_cast<double*>(stf_task_get(t, 0));
+    double* d           = static_cast<double*>(stf_task_get(t, 0)); // NOLINT(misc-const-correctness)
     int n               = static_cast<int>(N);
     double f            = 3.0;
-    void* kernel_args[] = {&n, &d, &f};
+    void* kernel_args[] = {&n, &d, &f}; // NOLINT(misc-const-correctness)
 
     cudaKernelNodeParams kparams = {};
     kparams.func                 = reinterpret_cast<void*>(&scale_kernel);

--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -50,7 +50,7 @@ public:
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, device_id);
 
-    static BuildInformation singleton{
+    static const BuildInformation singleton{
       deviceProp.major, deviceProp.minor, TEST_CUB_PATH, TEST_THRUST_PATH, TEST_LIBCUDACXX_PATH, TEST_CTK_PATH};
     return singleton;
   }
@@ -160,7 +160,7 @@ void AlgorithmExecute(std::optional<BuildCache>& cache, const std::optional<KeyT
   size_t temp_storage_bytes = 0;
   REQUIRE(CUDA_SUCCESS == Run{}(build, nullptr, &temp_storage_bytes, args..., null_stream));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
 
   REQUIRE(CUDA_SUCCESS == Run{}(build, temp_storage.ptr, &temp_storage_bytes, args..., null_stream));
 

--- a/c/parallel/test/test_binary_search.cpp
+++ b/c/parallel/test/test_binary_search.cpp
@@ -165,7 +165,7 @@ void test_vectorized(Variant variant, HostVariant host_variant)
   variant(data_ptr, num_items, target_values_ptr, target_values.size(), output_ptr, op, build_cache, test_key);
 
   std::vector<std::ptrdiff_t> results(output_ptr);
-  std::vector<std::ptrdiff_t> expected(target_values.size(), 0);
+  const std::vector<std::ptrdiff_t> expected(target_values.size(), 0);
 
   std::vector<std::ptrdiff_t> expected_results(target_values.size(), 0);
 
@@ -200,7 +200,7 @@ C2H_TEST("BinarySearch build result has serialization metadata populated", "[bin
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_less_binary_predicate();
+  const cccl_op_t op = make_well_known_less_binary_predicate();
   pointer_t<T> data(1);
   pointer_t<T> values(1);
   pointer_t<T> out(1);

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -81,7 +81,7 @@ void for_each_pointer_input(pointer_t<T>& input_ptr, uint64_t num_items, cccl_op
 void for_each_uncached(cccl_iterator_t input, uint64_t num_items, cccl_op_t op)
 {
   std::optional<for_each_build_cache_t> no_cache = std::nullopt;
-  std::optional<std::string> no_key              = std::nullopt;
+  const std::optional<std::string> no_key        = std::nullopt;
 
   for_each(input, num_items, op, no_cache, no_key);
 }
@@ -148,8 +148,8 @@ struct invocation_counter_state_t
 C2H_TEST("for_each works with stateful operators", "[for_each]")
 {
   const int num_items = 1 << 12;
-  pointer_t<int> counter(1);
-  invocation_counter_state_t op_state                 = {counter.ptr};
+  const pointer_t<int> counter(1);
+  const invocation_counter_state_t op_state           = {counter.ptr};
   stateful_operation_t<invocation_counter_state_t> op = make_operation(
     "op",
     R"XXX(
@@ -161,7 +161,7 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr) {
 )XXX",
     op_state);
 
-  std::vector<int> input(num_items, 1);
+  const std::vector<int> input(num_items, 1);
   pointer_t<int> input_ptr(input);
 
   for_each_uncached(input_ptr, num_items, op);
@@ -180,8 +180,8 @@ struct large_state_t
 C2H_TEST("for_each works with large stateful operators", "[for_each]")
 {
   const int num_items = 1 << 12;
-  pointer_t<int> counter(1);
-  large_state_t op_state                 = {1, counter.ptr, 2, 3, 4};
+  const pointer_t<int> counter(1);
+  const large_state_t op_state           = {1, counter.ptr, 2, 3, 4};
   stateful_operation_t<large_state_t> op = make_operation(
     "op",
     R"XXX(
@@ -198,7 +198,7 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr) {
 )XXX",
     op_state);
 
-  std::vector<int> input(num_items, 1);
+  const std::vector<int> input(num_items, 1);
   pointer_t<int> input_ptr(input);
 
   for_each_uncached(input_ptr, num_items, op);
@@ -214,7 +214,7 @@ C2H_TEST("for works with C++ source operations", "[for]")
   const uint64_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* a) {
       int* ia = (int*)a;
       *ia = *ia + 1;
@@ -227,7 +227,7 @@ C2H_TEST("for works with C++ source operations", "[for]")
   pointer_t<T> input_ptr(input);
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
 
   auto& cache = fixture<for_each_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
   std::optional<for_each_build_cache_t> cache_opt = cache;
@@ -248,7 +248,7 @@ C2H_TEST("For works with C++ source operations using custom headers", "[for]")
   const uint64_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* a) {
       int* ia = (int*)a;
@@ -259,7 +259,7 @@ C2H_TEST("For works with C++ source operations using custom headers", "[for]")
 
   operation_t op = make_cpp_operation("op", cpp_source);
 
-  std::vector<T> input(num_items, T(1));
+  const std::vector<T> input(num_items, T(1));
   pointer_t<T> input_ptr(input);
 
   // Test _ex version with custom build configuration
@@ -425,9 +425,9 @@ C2H_TEST("For link_ltoir round-trip", "[for][serialization]")
   CHECK(build.library == nullptr);
 
   // Compile the operator LTOIR separately (user-supplied blob).
-  operation_t op_full = make_operation("op", get_for_op(get_type_info<T>().type));
-  const void* op_blob = op_full.code.data();
-  size_t op_size      = op_full.code.size();
+  operation_t op_full  = make_operation("op", get_for_op(get_type_info<T>().type));
+  const void* op_blob  = op_full.code.data();
+  const size_t op_size = op_full.code.size();
 
   REQUIRE(CUDA_SUCCESS == cccl_device_for_link_ltoir(&build, &op_blob, &op_size, 1));
   REQUIRE((build.payload != nullptr && build.payload_kind == CCCL_PAYLOAD_CUBIN));
@@ -437,7 +437,7 @@ C2H_TEST("For link_ltoir round-trip", "[for][serialization]")
   REQUIRE(build.library != nullptr);
   CHECK(build.static_kernel != nullptr);
 
-  cccl_op_t op_run = op_full;
+  const cccl_op_t op_run = op_full;
   REQUIRE(CUDA_SUCCESS == cccl_device_for(build, input_ptr, n, op_run, CU_STREAM_LEGACY));
 
   std::vector<T> output(n);

--- a/c/parallel/test/test_histogram.cpp
+++ b/c/parallel/test/test_histogram.cpp
@@ -106,7 +106,7 @@ void histogram_even(
       row_stride_samples,
       nullptr));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
 
   REQUIRE(
     CUDA_SUCCESS
@@ -208,27 +208,27 @@ C2H_TEST("DeviceHistogram::HistogramEven API usage", "[histogram][device]")
   using counter_t = int;
   using level_t   = float;
 
-  int num_samples = 10;
-  std::vector<float> d_samples{2.2f, 6.1f, 7.1f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f, 6.1f, 999.5f};
+  const int num_samples = 10;
+  const std::vector<float> d_samples{2.2f, 6.1f, 7.1f, 2.9f, 3.5f, 0.3f, 2.9f, 2.1f, 6.1f, 999.5f};
 
-  int num_rows = 1;
+  const int num_rows = 1;
 
-  int num_levels = 7;
-  std::vector<int> d_num_levels{num_levels};
-  std::vector<counter_t> d_single_histogram(6, 0);
+  const int num_levels = 7;
+  const std::vector<int> d_num_levels{num_levels};
+  const std::vector<counter_t> d_single_histogram(6, 0);
   pointer_t<counter_t> d_single_histogram_ptr(d_single_histogram);
 
-  level_t lower_level = 0.0;
-  level_t upper_level = 12.0;
+  const level_t lower_level = 0.0;
+  const level_t upper_level = 12.0;
 
   pointer_t<float> d_samples_ptr(d_samples);
   value_t<int> num_levels_val{num_levels};
-  pointer_t<int> d_num_levels_ptr(d_num_levels);
+  const pointer_t<int> d_num_levels_ptr(d_num_levels);
 
   value_t<level_t> lower_level_val{lower_level};
   value_t<level_t> upper_level_val{upper_level};
 
-  int64_t row_stride_samples = static_cast<int64_t>(num_samples);
+  const int64_t row_stride_samples = static_cast<int64_t>(num_samples);
 
   histogram_even(
     d_samples_ptr,
@@ -255,8 +255,8 @@ C2H_TEST("DeviceHistogram::HistogramEven basic use", "[histogram][device]", samp
   const auto max_level       = level_t{sizeof(sample_t) == 1 ? 126 : 1024};
   const auto max_level_count = (sizeof(sample_t) == 1 ? 126 : 1024) + 1;
 
-  offset_t width  = 1920;
-  offset_t height = 1080;
+  const offset_t width  = 1920;
+  const offset_t height = 1080;
 
   constexpr int channels        = 1;
   constexpr int active_channels = 1;
@@ -273,7 +273,7 @@ C2H_TEST("DeviceHistogram::HistogramEven basic use", "[histogram][device]", samp
     h_samples[i] = static_cast<sample_t>(samples_gen[i]);
   }
 
-  std::vector<counter_t> d_single_histogram(num_levels[0] - 1, 0);
+  const std::vector<counter_t> d_single_histogram(num_levels[0] - 1, 0);
 
   auto levels = setup_bin_levels_for_even<active_channels, level_t>(num_levels, max_level, max_level_count);
 
@@ -359,7 +359,7 @@ C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram][device]"
   iterator_t<sample_t, counting_iterator_state_t<sample_t>> counting_it = make_counting_iterator<sample_t>("int");
   counting_it.state.value                                               = static_cast<sample_t>(0);
 
-  std::vector<counter_t> d_single_histogram(num_levels[0] - 1, 0);
+  const std::vector<counter_t> d_single_histogram(num_levels[0] - 1, 0);
 
   // Set up levels so that values 0 to adjusted_total_samples-1 are evenly distributed
   std::vector<std::vector<level_t>> levels(2);
@@ -514,7 +514,7 @@ C2H_TEST("Histogram compile/load round-trip", "[histogram][device][serialization
       /*num_rows=*/1,
       /*row_stride_samples=*/static_cast<int64_t>(n_samples),
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_histogram_even(

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -107,9 +107,9 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge_sort]", key_types)
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
 
-  operation_t op                   = make_operation("op", get_merge_sort_op(get_type_info<key_t>().type));
-  std::vector<key_t> input_keys    = make_shuffled_sequence<key_t>(num_items);
-  std::vector<key_t> expected_keys = input_keys;
+  operation_t op                      = make_operation("op", get_merge_sort_op(get_type_info<key_t>().type));
+  const std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  std::vector<key_t> expected_keys    = input_keys;
 
   pointer_t<key_t> input_keys_it(input_keys);
   pointer_t<key_t> input_items_it;
@@ -130,9 +130,9 @@ C2H_TEST("DeviceMergeSort::SortKeys works with well-known predicate", "[merge_so
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
 
-  cccl_op_t op                     = make_well_known_less_binary_predicate();
-  std::vector<key_t> input_keys    = make_shuffled_sequence<key_t>(num_items);
-  std::vector<key_t> expected_keys = input_keys;
+  const cccl_op_t op                  = make_well_known_less_binary_predicate();
+  const std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  std::vector<key_t> expected_keys    = input_keys;
 
   pointer_t<key_t> input_keys_it(input_keys);
   pointer_t<key_t> input_items_it;
@@ -153,9 +153,9 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy works", "[merge_sort]", key_types)
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
 
-  operation_t op                = make_operation("op", get_merge_sort_op(get_type_info<key_t>().type));
-  std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
-  std::vector<key_t> output_keys(num_items);
+  operation_t op                      = make_operation("op", get_merge_sort_op(get_type_info<key_t>().type));
+  const std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  const std::vector<key_t> output_keys(num_items);
   std::vector<key_t> expected_keys = input_keys;
 
   pointer_t<key_t> input_keys_it(input_keys);
@@ -214,8 +214,8 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy works ", "[merge_sort]", key_types)
   std::transform(input_keys.begin(), input_keys.end(), input_items.begin(), [](key_t key) {
     return static_cast<item_t>(key);
   });
-  std::vector<key_t> output_keys(num_items);
-  std::vector<item_t> output_items(num_items);
+  const std::vector<key_t> output_keys(num_items);
+  const std::vector<item_t> output_items(num_items);
   std::vector<key_t> expected_keys   = input_keys;
   std::vector<item_t> expected_items = input_items;
 
@@ -370,8 +370,8 @@ C2H_TEST("DeviceMergeSort::SortKeys works with input iterators", "[merge_sort]")
   operation_t op = make_operation("op", get_merge_sort_op(get_type_info<T>().type));
   iterator_t<T, random_access_iterator_state_t<T>> input_keys_it =
     make_random_access_iterator<T>(iterator_kind::INPUT, "int");
-  std::vector<T> input_keys    = make_shuffled_sequence<T>(num_items);
-  std::vector<T> expected_keys = input_keys;
+  const std::vector<T> input_keys = make_shuffled_sequence<T>(num_items);
+  std::vector<T> expected_keys    = input_keys;
 
   pointer_t<T> input_keys_ptr(input_keys);
   input_keys_it.state.data = input_keys_ptr.ptr;
@@ -518,7 +518,7 @@ C2H_TEST("MergeSort works with C++ source operations", "[merge_sort]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
       int* ilhs = (int*)lhs;
       int* irhs = (int*)rhs;
@@ -529,7 +529,7 @@ C2H_TEST("MergeSort works with C++ source operations", "[merge_sort]")
 
   operation_t op = make_cpp_operation("op", cpp_source);
 
-  std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  const std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
   pointer_t<key_t> input_keys_ptr(input_keys);
   pointer_t<key_t> output_keys_ptr(num_items);
 
@@ -538,7 +538,7 @@ C2H_TEST("MergeSort works with C++ source operations", "[merge_sort]")
   pointer_t<int> output_items_ptr;
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
 
   auto& cache = fixture<merge_sort_build_cache_t, DeviceMergeSort_SortKeys_Fixture_Tag>::get_or_create().get_value();
   std::optional<merge_sort_build_cache_t> cache_opt = cache;
@@ -558,7 +558,7 @@ C2H_TEST("MergeSort works with C++ source operations using custom headers", "[me
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
       int* ilhs = (int*)lhs;
@@ -572,7 +572,7 @@ C2H_TEST("MergeSort works with C++ source operations using custom headers", "[me
 
   operation_t op = make_cpp_operation("op", cpp_source);
 
-  std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  const std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
   pointer_t<key_t> input_keys_ptr(input_keys);
   pointer_t<key_t> output_keys_ptr(num_items);
 
@@ -621,7 +621,7 @@ C2H_TEST("MergeSort works with C++ source operations using custom headers", "[me
       num_items,
       op,
       CU_STREAM_LEGACY));
-  pointer_t<char> temp_storage(temp_storage_bytes);
+  const pointer_t<char> temp_storage(temp_storage_bytes);
   d_temp_storage = static_cast<void*>(temp_storage.ptr);
   REQUIRE(
     CUDA_SUCCESS
@@ -711,7 +711,7 @@ C2H_TEST("MergeSort build result has serialization metadata populated", "[merge_
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> keys_in(1);
   pointer_t<T> items_in(1);
   pointer_t<T> keys_out(1);
@@ -756,7 +756,7 @@ C2H_TEST("MergeSort compile/load round-trip", "[merge_sort][serialization]")
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_less_binary_predicate();
+  const cccl_op_t op = make_well_known_less_binary_predicate();
   pointer_t<T> dummy_keys_in(1);
   pointer_t<T> dummy_items_in(1);
   pointer_t<T> dummy_keys_out(1);
@@ -806,7 +806,7 @@ C2H_TEST("MergeSort compile/load round-trip", "[merge_sort][serialization]")
   REQUIRE(CUDA_SUCCESS
           == cccl_device_merge_sort(
             build, nullptr, &temp_storage_bytes, keys_in, items_in, keys_out, items_out, n, op, null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_merge_sort(
             build, temp_storage.ptr, &temp_storage_bytes, keys_in, items_in, keys_out, items_out, n, op, null_stream));

--- a/c/parallel/test/test_radix_sort.cpp
+++ b/c/parallel/test/test_radix_sort.cpp
@@ -186,9 +186,9 @@ C2H_TEST("DeviceRadixSort::SortKeys works", "[radix_sort]", test_params_tuple)
 
   constexpr auto this_test_params = T();
   // We want a mix of small and large sizes because different implementations will be called
-  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  bool is_descending  = this_test_params.is_descending();
-  const auto order    = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
+  const int num_items      = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  const bool is_descending = this_test_params.is_descending();
+  const auto order         = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
 
   const int begin_bit          = 0;
   const int end_bit            = sizeof(KeyT) * 8;
@@ -199,8 +199,8 @@ C2H_TEST("DeviceRadixSort::SortKeys works", "[radix_sort]", test_params_tuple)
   static constexpr const char* unused_decomposer_retty = "";
 
   // problem descriptor: (order, TestType, item_t, is_overwrite_ok, items_present = false)
-  std::vector<KeyT> input_keys    = make_shuffled_sequence<KeyT>(num_items);
-  std::vector<KeyT> expected_keys = input_keys;
+  const std::vector<KeyT> input_keys = make_shuffled_sequence<KeyT>(num_items);
+  std::vector<KeyT> expected_keys    = input_keys;
 
   pointer_t<KeyT> input_keys_it(input_keys);
   pointer_t<KeyT> output_keys_it(num_items);
@@ -442,7 +442,7 @@ C2H_TEST("RadixSort compile/load round-trip", "[radix_sort][serialization]")
       /*is_overwrite_okay=*/false,
       &selector,
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_radix_sort(

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -268,7 +268,7 @@ C2H_TEST("Reduce works with integral types with well-known operations", "[reduce
   using T = c2h::get<0, TestType>;
 
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 24)));
-  cccl_op_t op                = make_well_known_binary_operation();
+  const cccl_op_t op          = make_well_known_binary_operation();
   const std::vector<T> input  = generate<T>(num_items);
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(1);
@@ -419,7 +419,7 @@ C2H_TEST("Reduce works with output iterators", "[reduce]")
     make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
   const std::vector<int> input = generate<int>(num_items);
   pointer_t<int> input_it(input);
-  pointer_t<int> inner_output_it(1);
+  const pointer_t<int> inner_output_it(1);
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
@@ -442,7 +442,7 @@ C2H_TEST("Reduce works with input and output iterators", "[reduce]")
   input_it.state.value                                     = 1;
   iterator_t<int, random_access_iterator_state_t<int>> output_it =
     make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
-  pointer_t<int> inner_output_it(1);
+  const pointer_t<int> inner_output_it(1);
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
@@ -505,7 +505,7 @@ struct invocation_counter_state_t
 C2H_TEST("Reduce works with stateful operators", "[reduce]")
 {
   const int num_items = 1 << 12;
-  pointer_t<int> counter(1);
+  const pointer_t<int> counter(1);
   stateful_operation_t<invocation_counter_state_t> op = make_operation(
     "op",
     R"(struct invocation_counter_state_t { int* d_counter; };
@@ -525,7 +525,7 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr, void* b_ptr, void* o
 
   // turn off caching, since the example is only compiled once
   std::optional<reduce_build_cache_t> build_cache = std::nullopt;
-  std::optional<std::string> test_key             = std::nullopt;
+  const std::optional<std::string> test_key       = std::nullopt;
 
   reduce(input_ptr, output_ptr, num_items, op, init, CCCL_RUN_TO_RUN, build_cache, test_key);
 
@@ -545,7 +545,7 @@ C2H_TEST("Reduce works with C++ source operations", "[reduce]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* a, void* b, void* out) {
       int* ia = (int*)a;
       int* ib = (int*)b;
@@ -562,7 +562,7 @@ C2H_TEST("Reduce works with C++ source operations", "[reduce]")
   value_t<T> init{T{0}};
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
 
   auto& cache                                   = get_cache<Reduce_IntegralTypes_Fixture_Tag>();
   std::optional<reduce_build_cache_t> cache_opt = cache;
@@ -639,7 +639,7 @@ C2H_TEST("Reduce works with C++ source operations using _ex build", "[reduce]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* a, void* b, void* out) {
       int* ia = (int*)a;
@@ -667,7 +667,7 @@ C2H_TEST("Reduce works with C++ source operations using _ex build", "[reduce]")
   const auto& build_info  = BuildInformation<device_id>::init();
 
   BuildResultT build{};
-  reduce_build_ex builder(extra_flags, 1, extra_includes, 1);
+  const reduce_build_ex builder(extra_flags, 1, extra_includes, 1);
 
   REQUIRE(
     CUDA_SUCCESS
@@ -692,7 +692,7 @@ C2H_TEST("Reduce works with C++ source operations using _ex build", "[reduce]")
           == cccl_device_reduce(
             build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, null_stream));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(
             build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, null_stream));
@@ -760,7 +760,7 @@ C2H_TEST("Reduce works with not_guaranteed determinism and plus", "[reduce][nond
   using T = float;
 
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 24)));
-  cccl_op_t op                = make_well_known_binary_operation(); // plus
+  const cccl_op_t op          = make_well_known_binary_operation(); // plus
   const std::vector<T> input(num_items, T{1});
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(1);
@@ -783,7 +783,7 @@ C2H_TEST("Reduce compile/load round-trip", "[reduce][serialization]")
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation(); // plus
+  const cccl_op_t op = make_well_known_binary_operation(); // plus
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
   value_t<T> init{T{0}};
@@ -832,7 +832,7 @@ C2H_TEST("Reduce compile/load round-trip", "[reduce][serialization]")
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(
             build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
@@ -890,9 +890,9 @@ C2H_TEST("Reduce link_ltoir round-trip", "[reduce][serialization]")
   CHECK(build.library == nullptr);
 
   // Compile the operator LTOIR separately (this is the "user-supplied" op blob).
-  operation_t op_full = make_operation("op", get_reduce_op(get_type_info<T>().type));
-  const void* op_blob = op_full.code.data();
-  size_t op_size      = op_full.code.size();
+  operation_t op_full  = make_operation("op", get_reduce_op(get_type_info<T>().type));
+  const void* op_blob  = op_full.code.data();
+  const size_t op_size = op_full.code.size();
 
   REQUIRE(CUDA_SUCCESS == cccl_device_reduce_link_ltoir(&build, &op_blob, &op_size, 1));
   REQUIRE((build.payload != nullptr && build.payload_kind == CCCL_PAYLOAD_CUBIN));
@@ -908,14 +908,14 @@ C2H_TEST("Reduce link_ltoir round-trip", "[reduce][serialization]")
   CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  cccl_op_t op_run    = op_full;
-  cccl_value_t init_v = init;
+  const cccl_op_t op_run    = op_full;
+  const cccl_value_t init_v = init;
 
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_reduce(build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init_v, null_stream));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(
             build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init_v, null_stream));
@@ -934,7 +934,7 @@ C2H_TEST("Reduce serialize/deserialize round-trip (cubin)", "[reduce][serializat
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation(); // plus
+  const cccl_op_t op = make_well_known_binary_operation(); // plus
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
   value_t<T> init{T{0}};
@@ -993,7 +993,7 @@ C2H_TEST("Reduce serialize/deserialize round-trip (cubin)", "[reduce][serializat
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_reduce(build_b, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(
             build_b, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
@@ -1055,9 +1055,9 @@ C2H_TEST("Reduce serialize/deserialize round-trip (ltoir + link_ltoir)", "[reduc
   REQUIRE(build_b.payload_kind == CCCL_PAYLOAD_LTOIR);
 
   // Link in the operator LTOIR (as user-supplied) and load.
-  operation_t op_full = make_operation("op", get_reduce_op(get_type_info<T>().type));
-  const void* op_blob = op_full.code.data();
-  size_t op_size      = op_full.code.size();
+  operation_t op_full  = make_operation("op", get_reduce_op(get_type_info<T>().type));
+  const void* op_blob  = op_full.code.data();
+  const size_t op_size = op_full.code.size();
   REQUIRE(CUDA_SUCCESS == cccl_device_reduce_link_ltoir(&build_b, &op_blob, &op_size, 1));
   REQUIRE(build_b.payload_kind == CCCL_PAYLOAD_CUBIN);
   REQUIRE(CUDA_SUCCESS == cccl_device_reduce_load(&build_b));
@@ -1069,11 +1069,11 @@ C2H_TEST("Reduce serialize/deserialize round-trip (ltoir + link_ltoir)", "[reduc
   CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  cccl_op_t op_run = op_full;
+  const cccl_op_t op_run = op_full;
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_reduce(build_b, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init, null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(
             build_b, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init, null_stream));

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -336,7 +336,7 @@ C2H_TEST("Scan works with integral types with well-known operations", "[scan][we
   using T = c2h::get<0, TestType>;
 
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
-  cccl_op_t op                = make_well_known_binary_operation();
+  const cccl_op_t op          = make_well_known_binary_operation();
   const std::vector<T> input  = generate<T>(num_items);
   const std::vector<T> output(num_items, 0);
   pointer_t<T> input_ptr(input);
@@ -409,7 +409,7 @@ extern "C" __device__ void op(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {
   const std::vector<short> a  = generate<short>(num_items);
   const std::vector<size_t> b = generate<size_t>(num_items);
   std::vector<pair> input(num_items);
-  std::vector<pair> output(num_items);
+  const std::vector<pair> output(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
     input[i] = pair{a[i], b[i]};
@@ -451,7 +451,7 @@ extern "C" __device__ void op(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {
   const std::vector<short> a  = generate<short>(num_items);
   const std::vector<size_t> b = generate<size_t>(num_items);
   std::vector<pair> input(num_items);
-  std::vector<pair> output(num_items);
+  const std::vector<pair> output(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
     input[i] = pair{a[i], b[i]};
@@ -511,7 +511,7 @@ C2H_TEST("Scan works with output iterators", "[scan]")
     make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
   const std::vector<int> input = generate<int>(num_items);
   pointer_t<int> input_it(input);
-  pointer_t<int> inner_output_it(num_items);
+  const pointer_t<int> inner_output_it(num_items);
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
@@ -540,7 +540,7 @@ C2H_TEST("Scan works with reverse input iterators", "[scan]")
   iterator_t<int, random_access_iterator_state_t<int>> input_it =
     make_reverse_iterator<int>(iterator_kind::INPUT, "int");
   std::vector<int> input = generate<int>(num_items);
-  pointer_t<int> input_ptr(input);
+  const pointer_t<int> input_ptr(input);
   input_it.state.data = input_ptr.ptr + num_items - 1;
   pointer_t<int> output_it(num_items);
   value_t<int> init{42};
@@ -567,7 +567,7 @@ C2H_TEST("Scan works with reverse output iterators", "[scan]")
     make_reverse_iterator<int>(iterator_kind::OUTPUT, "int", "out");
   const std::vector<int> input = generate<int>(num_items);
   pointer_t<int> input_it(input);
-  pointer_t<int> inner_output_it(num_items);
+  const pointer_t<int> inner_output_it(num_items);
   output_it.state.data = inner_output_it.ptr + num_items - 1;
   value_t<int> init{42};
 
@@ -594,7 +594,7 @@ C2H_TEST("Scan works with input and output iterators", "[scan]")
   input_it.state.value                                     = 1;
   iterator_t<int, random_access_iterator_state_t<int>> output_it =
     make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
-  pointer_t<int> inner_output_it(num_items);
+  const pointer_t<int> inner_output_it(num_items);
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
@@ -621,7 +621,7 @@ C2H_TEST("Scan works with C++ source operations", "[scan]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* a, void* b, void* out) {
       int* ia = (int*)a;
       int* ib = (int*)b;
@@ -638,7 +638,7 @@ C2H_TEST("Scan works with C++ source operations", "[scan]")
   value_t<T> init{T{42}};
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
 
   auto& cache                                 = get_cache<integral_types>();
   std::optional<scan_build_cache_t> cache_opt = cache;
@@ -689,7 +689,7 @@ C2H_TEST("Scan works with C++ source operations using custom headers", "[scan]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* a, void* b, void* out) {
       int* ia = (int*)a;
@@ -740,7 +740,7 @@ C2H_TEST("Scan works with C++ source operations using custom headers", "[scan]")
   REQUIRE(CUDA_SUCCESS
           == cccl_device_inclusive_scan(
             build, d_temp_storage, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, CU_STREAM_LEGACY));
-  pointer_t<char> temp_storage(temp_storage_bytes);
+  const pointer_t<char> temp_storage(temp_storage_bytes);
   d_temp_storage = static_cast<void*>(temp_storage.ptr);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_inclusive_scan(
@@ -769,7 +769,7 @@ C2H_TEST("Scan works with future init value", "[scan]")
   const std::vector<T> output(num_items, 0);
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(output);
-  T init{42};
+  const T init{42};
   pointer_t<T> init_ptr(std::vector<T>{init});
 
   auto& build_cache    = get_cache<Scan_FutureInitValue_Fixture_Tag>();
@@ -818,7 +818,7 @@ C2H_TEST("Scan build result has serialization metadata populated", "[scan][seria
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> in(1);
   pointer_t<T> out(1);
   value_t<T> init{T{0}};
@@ -861,7 +861,7 @@ C2H_TEST("Scan compile/load round-trip", "[scan][serialization]")
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
   value_t<T> init{T{0}};
@@ -907,7 +907,7 @@ C2H_TEST("Scan compile/load round-trip", "[scan][serialization]")
   REQUIRE(CUDA_SUCCESS
           == cccl_device_exclusive_scan(
             build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_exclusive_scan(
             build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op, init, null_stream));
@@ -937,7 +937,7 @@ C2H_TEST("Scan link_ltoir round-trip", "[scan][serialization]")
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
   value_t<T> init{T{0}};
-  cccl_type_info accum_ti = get_type_info<T>();
+  const cccl_type_info accum_ti = get_type_info<T>();
 
   BuildResultT build{};
   REQUIRE(
@@ -965,9 +965,9 @@ C2H_TEST("Scan link_ltoir round-trip", "[scan][serialization]")
   CHECK(build.library == nullptr);
 
   // Compile the operator LTOIR separately.
-  operation_t op_full = make_operation("op", get_reduce_op(get_type_info<T>().type));
-  const void* op_blob = op_full.code.data();
-  size_t op_size      = op_full.code.size();
+  operation_t op_full  = make_operation("op", get_reduce_op(get_type_info<T>().type));
+  const void* op_blob  = op_full.code.data();
+  const size_t op_size = op_full.code.size();
 
   REQUIRE(CUDA_SUCCESS == cccl_device_scan_link_ltoir(&build, &op_blob, &op_size, 1));
   REQUIRE((build.payload != nullptr && build.payload_kind == CCCL_PAYLOAD_CUBIN));
@@ -983,14 +983,14 @@ C2H_TEST("Scan link_ltoir round-trip", "[scan][serialization]")
   CUstream null_stream      = nullptr;
   size_t temp_storage_bytes = 0;
 
-  cccl_op_t op_run    = op_full;
-  cccl_value_t init_v = init;
+  const cccl_op_t op_run    = op_full;
+  const cccl_value_t init_v = init;
 
   REQUIRE(CUDA_SUCCESS
           == cccl_device_exclusive_scan(
             build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init_v, null_stream));
 
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(CUDA_SUCCESS
           == cccl_device_exclusive_scan(
             build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, n, op_run, init_v, null_stream));

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -260,8 +260,8 @@ C2H_TEST_LIST("segmented_reduce can sum over rows of matrix with integral type",
 
   for (std::size_t i = 0; i < n_rows; ++i)
   {
-    std::size_t row_offset = i * segment_size;
-    host_output_it[i]      = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
+    const std::size_t row_offset = i * segment_size;
+    host_output_it[i]            = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
   }
   REQUIRE(host_output == std::vector<TestType>(output_ptr));
 }
@@ -325,7 +325,7 @@ C2H_TEST_LIST("segmented_reduce can sum over rows of matrix with integral type "
   end_offset_it.state.linear_id    = 1;
   end_offset_it.state.segment_size = segment_size;
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   value_t<TestType> init{0};
 
   auto& build_cache    = get_cache<SegmentedReduce_SumOverRows_WellKnown_Fixture_Tag>();
@@ -338,8 +338,8 @@ C2H_TEST_LIST("segmented_reduce can sum over rows of matrix with integral type "
 
   for (std::size_t i = 0; i < n_rows; ++i)
   {
-    std::size_t row_offset = i * segment_size;
-    host_output_it[i]      = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
+    const std::size_t row_offset = i * segment_size;
+    host_output_it[i]            = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
   }
   REQUIRE(host_output == std::vector<TestType>(output_ptr));
 }
@@ -400,10 +400,10 @@ extern "C" __device__ void {0}(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {{
 }}
 )XXX";
 
-  std::string plus_pair_op_src = std::format(plus_pair_op_template, device_op_name);
+  const std::string plus_pair_op_src = std::format(plus_pair_op_template, device_op_name);
 
   operation_t op = make_operation(device_op_name, plus_pair_op_src);
-  pair v0        = pair{4, 2};
+  const pair v0  = pair{4, 2};
   value_t<pair> init{v0};
 
   auto& build_cache    = get_cache<SegmentedReduce_CustomTypes_Fixture_Tag>();
@@ -469,12 +469,12 @@ extern "C" __device__ void {0}(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {{
 }}
 )XXX";
 
-  std::string plus_pair_op_src = std::format(plus_pair_op_template, device_op_name);
+  const std::string plus_pair_op_src = std::format(plus_pair_op_template, device_op_name);
 
   operation_t op_state = make_operation(device_op_name, plus_pair_op_src);
   cccl_op_t op         = op_state;
   op.type              = cccl_op_kind_t::CCCL_PLUS;
-  pair v0              = pair{4, 2};
+  const pair v0        = pair{4, 2};
   value_t<pair> init{v0};
 
   auto& build_cache    = get_cache<SegmentedReduce_CustomTypes_WellKnown_Fixture_Tag>();
@@ -586,7 +586,7 @@ C2H_TEST("SegmentedReduce works with input iterators", "[segmented_reduce]")
   }
   std::vector<ValueT> host_output(n_cols, 0);
 
-  pointer_t<ValueT> input_ptr(host_input); // copy from host to device
+  const pointer_t<ValueT> input_ptr(host_input); // copy from host to device
   pointer_t<ValueT> output_ptr(host_output); // copy from host to device
 
   static constexpr std::string_view index_ty_name          = "unsigned long long";
@@ -733,8 +733,8 @@ C2H_TEST("segmented_reduce can work with floating point types", "[segmented_redu
 
   for (std::size_t i = 0; i < n_rows; ++i)
   {
-    std::size_t row_offset = i * row_size;
-    host_output_it[i]      = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
+    const std::size_t row_offset = i * row_size;
+    host_output_it[i]            = std::reduce(host_input_it + row_offset, host_input_it + (row_offset + n_cols));
   }
   REQUIRE(output == std::vector<T>(output_ptr));
 }
@@ -1041,7 +1041,7 @@ extern "C" __device__ {4} {0}({1} *functor_state, {2} n) {{
 
   pointer_t<CmpT> as_expected(1);
 
-  CmpT expected_value{1};
+  const CmpT expected_value{1};
   value_t<CmpT> _true{expected_value};
 
   static constexpr std::string_view cmp_combine_op_name = "_logical_and";
@@ -1129,8 +1129,8 @@ void run_guaranteed_max_seg_size_test(
 
   for (std::size_t i = 0; i < n_rows; ++i)
   {
-    std::size_t row_offset = i * segment_size;
-    host_output[i]         = std::reduce(host_input.begin() + row_offset, host_input.begin() + row_offset + n_cols);
+    const std::size_t row_offset = i * segment_size;
+    host_output[i] = std::reduce(host_input.begin() + row_offset, host_input.begin() + row_offset + n_cols);
   }
   REQUIRE(host_output == std::vector<TestType>(output_ptr));
 }
@@ -1196,7 +1196,7 @@ C2H_TEST("SegmentedReduce build result has serialization metadata populated", "[
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> in(1);
   pointer_t<T> out(1);
   pointer_t<T> begin_offsets(1);
@@ -1239,7 +1239,7 @@ C2H_TEST("SegmentedReduce compile/load round-trip", "[segmented_reduce][serializ
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
   pointer_t<T> dummy_begin_offsets(1);
@@ -1302,7 +1302,7 @@ C2H_TEST("SegmentedReduce compile/load round-trip", "[segmented_reduce][serializ
       init,
       /*max_segment_size=*/0,
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_segmented_reduce(

--- a/c/parallel/test/test_segmented_sort.cpp
+++ b/c/parallel/test/test_segmented_sort.cpp
@@ -216,7 +216,7 @@ C2H_TEST("segmented_sort can sort keys-only", "[segmented_sort][keys_only]", tes
   std::transform(host_keys_int.begin(), host_keys_int.end(), host_keys.begin(), [](int val) {
     return static_cast<key_t>(val);
   });
-  std::vector<key_t> host_keys_out(n_elems);
+  const std::vector<key_t> host_keys_out(n_elems);
 
   REQUIRE(host_keys.size() == n_elems);
   REQUIRE(host_keys_out.size() == n_elems);
@@ -308,8 +308,8 @@ C2H_TEST("segmented_sort can sort keys-only", "[segmented_sort][keys_only]", tes
   std::vector<key_t> expected_keys = host_keys;
   for (std::size_t i = 0; i < n_segments; ++i)
   {
-    std::size_t segment_start = i * segment_size;
-    std::size_t segment_end   = segment_start + segment_size;
+    const std::size_t segment_start = i * segment_size;
+    const std::size_t segment_end   = segment_start + segment_size;
     if (is_descending)
     {
       std::sort(expected_keys.begin() + segment_start, expected_keys.begin() + segment_end, std::greater<key_t>());
@@ -352,8 +352,8 @@ C2H_TEST("segmented_sort can sort key-value pairs", "[segmented_sort][key_value]
     return static_cast<item_t>(val);
   });
 
-  std::vector<key_t> host_keys_out(n_elems);
-  std::vector<item_t> host_values_out(n_elems);
+  const std::vector<key_t> host_keys_out(n_elems);
+  const std::vector<item_t> host_values_out(n_elems);
 
   REQUIRE(host_keys.size() == n_elems);
   REQUIRE(host_values.size() == n_elems);
@@ -417,8 +417,8 @@ C2H_TEST("segmented_sort can sort key-value pairs", "[segmented_sort][key_value]
 
   for (std::size_t i = 0; i < n_segments; ++i)
   {
-    std::size_t segment_start = i * segment_size;
-    std::size_t segment_end   = segment_start + segment_size;
+    const std::size_t segment_start = i * segment_size;
+    const std::size_t segment_end   = segment_start + segment_size;
 
     if (is_descending)
     {
@@ -617,7 +617,7 @@ C2H_TEST("SegmentedSort works with variable segment sizes", "[segmented_sort][va
   }
   REQUIRE(segment_sizes.size() == n_segments);
 
-  std::size_t n_elems = std::accumulate(segment_sizes.begin(), segment_sizes.end(), 0ULL);
+  const std::size_t n_elems = std::accumulate(segment_sizes.begin(), segment_sizes.end(), 0ULL);
 
   std::vector<int> host_keys_int = generate<int>(n_elems);
   std::vector<key_t> host_keys(n_elems);
@@ -631,8 +631,8 @@ C2H_TEST("SegmentedSort works with variable segment sizes", "[segmented_sort][va
   std::transform(host_values_int.begin(), host_values_int.end(), host_values.begin(), [](int val) {
     return static_cast<item_t>(val);
   });
-  std::vector<key_t> host_keys_out(n_elems);
-  std::vector<item_t> host_values_out(n_elems);
+  const std::vector<key_t> host_keys_out(n_elems);
+  const std::vector<item_t> host_values_out(n_elems);
 
   pointer_t<key_t> keys_in_ptr(host_keys);
   pointer_t<key_t> keys_out_ptr(host_keys_out);
@@ -690,8 +690,8 @@ C2H_TEST("SegmentedSort works with variable segment sizes", "[segmented_sort][va
 
   for (std::size_t i = 0; i < n_segments; ++i)
   {
-    std::size_t segment_start = start_offsets[i];
-    std::size_t segment_end   = end_offsets[i];
+    const std::size_t segment_start = start_offsets[i];
+    const std::size_t segment_end   = end_offsets[i];
 
     if (is_descending)
     {
@@ -851,7 +851,7 @@ C2H_TEST("SegmentedSort compile/load round-trip", "[segmented_sort][serializatio
       /*is_overwrite_okay=*/false,
       &selector,
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_segmented_sort(

--- a/c/parallel/test/test_three_way_partition.cpp
+++ b/c/parallel/test/test_three_way_partition.cpp
@@ -206,7 +206,7 @@ template <typename OperationT,
 three_way_partition_result_t<KeyT>
 c_parallel_partition(OperationT first_selector, OperationT second_selector, const std::vector<KeyT>& input)
 {
-  std::size_t num_items = input.size();
+  const std::size_t num_items = input.size();
 
   pointer_t<KeyT> input_ptr(input);
   pointer_t<KeyT> first_part_output_ptr(num_items);
@@ -311,8 +311,8 @@ C2H_TEST("ThreeWayPartition works with primitive types", "[three_way_partition]"
   using num_selected_t = T::NumSelectedT;
 
   auto [less_op_src, greater_or_equal_op_src] = get_three_way_partition_ops(get_type_info<key_t>().type, 21);
-  operation_t less_op                         = make_operation("less_op", less_op_src);
-  operation_t greater_or_equal_op             = make_operation("greater_op", greater_or_equal_op_src);
+  const operation_t less_op                   = make_operation("less_op", less_op_src);
+  const operation_t greater_or_equal_op       = make_operation("greater_op", greater_or_equal_op_src);
 
   const std::size_t num_items      = GENERATE(0, 42, take(4, random(1 << 12, 1 << 20)));
   const std::vector<int> input_int = generate<int>(num_items);
@@ -382,8 +382,8 @@ C2H_TEST("ThreeWayPartition works with stateful operations", "[three_way_partiti
   using key_t          = int;
   using num_selected_t = int;
 
-  selector_state_t op_state                      = {21};
-  stateful_operation_t<selector_state_t> less_op = make_operation(
+  const selector_state_t op_state                      = {21};
+  const stateful_operation_t<selector_state_t> less_op = make_operation(
     "less_op",
     R"(struct selector_state_t { int comparison_value; };
 extern "C" __device__ void less_op(void* state_ptr, void* x_ptr, void* out_ptr) {
@@ -392,7 +392,7 @@ extern "C" __device__ void less_op(void* state_ptr, void* x_ptr, void* out_ptr) 
   *static_cast<bool*>(out_ptr) = *static_cast<int*>(x_ptr) < state->comparison_value;
 })",
     op_state);
-  stateful_operation_t<selector_state_t> greater_or_equal_op = make_operation(
+  const stateful_operation_t<selector_state_t> greater_or_equal_op = make_operation(
     "greater_or_equal_op",
     R"(struct selector_state_t { int comparison_value; };
 extern "C" __device__ void greater_or_equal_op(void* state_ptr, void* x_ptr, void* out_ptr) {
@@ -465,7 +465,7 @@ C2H_TEST("ThreeWayPartition works with custom types", "[three_way_partition]")
 
   const int comparison_value = 21;
 
-  operation_t less_op = make_operation(
+  const operation_t less_op = make_operation(
     "less_op",
     std::format(R"(struct pair_type {{ int a; size_t b; }};
 extern "C" __device__ void less_op(void* x_ptr, void* out_ptr) {{
@@ -474,7 +474,7 @@ extern "C" __device__ void less_op(void* x_ptr, void* out_ptr) {{
   *out = x->a < {0};
 }})",
                 comparison_value));
-  operation_t greater_or_equal_op = make_operation(
+  const operation_t greater_or_equal_op = make_operation(
     "greater_or_equal_op",
     std::format(R"(struct pair_type {{ int a; size_t b; }};
 extern "C" __device__ void greater_or_equal_op(void* x_ptr, void* out_ptr) {{
@@ -508,11 +508,11 @@ C2H_TEST("ThreeWayPartition works with iterators", "[three_way_partition]")
 
   const std::size_t num_items    = GENERATE(0, 42, take(4, random(1 << 12, 1 << 20)));
   const std::vector<key_t> input = generate<key_t>(num_items);
-  pointer_t<key_t> input_ptr(input);
-  pointer_t<key_t> first_part_output_ptr(num_items);
-  pointer_t<key_t> second_part_output_ptr(num_items);
-  pointer_t<key_t> unselected_output_ptr(num_items);
-  pointer_t<num_selected_t> num_selected_output_ptr(2);
+  const pointer_t<key_t> input_ptr(input);
+  const pointer_t<key_t> first_part_output_ptr(num_items);
+  const pointer_t<key_t> second_part_output_ptr(num_items);
+  const pointer_t<key_t> unselected_output_ptr(num_items);
+  const pointer_t<num_selected_t> num_selected_output_ptr(2);
 
   iterator_t<key_t, random_access_iterator_state_t<key_t>> input_it =
     make_random_access_iterator<key_t>(iterator_kind::INPUT, "int", "in");
@@ -693,7 +693,7 @@ C2H_TEST("ThreeWayPartition compile/load round-trip", "[three_way_partition][ser
       second_op,
       n,
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_three_way_partition(

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -184,7 +184,7 @@ C2H_TEST("Transform works with misaligned input with integral types", "[transfor
   operation_t op              = make_operation("op", get_unary_op(get_type_info<T>().type));
   const std::vector<T> input  = generate<T>(num_items + 1);
   const std::vector<T> output(num_items, 0);
-  pointer_t<T> input_ptr_aligned(input);
+  const pointer_t<T> input_ptr_aligned(input);
   pointer_t<T> input_ptr = input;
   input_ptr.ptr += 1; // misalign by 1 from the guaranteed alignment of cudaMalloc, to maybe trip vectorized path
   input_ptr.size -= 1;
@@ -214,7 +214,7 @@ C2H_TEST("Transform works with misaligned output with integral types", "[transfo
   const std::vector<T> input  = generate<T>(num_items);
   const std::vector<T> output(num_items + 1, 0);
   pointer_t<T> input_ptr(input);
-  pointer_t<T> output_ptr_aligned(output);
+  const pointer_t<T> output_ptr_aligned(output);
   pointer_t<T> output_ptr = output;
   output_ptr.ptr += 1; // misalign by 1 from the guaranteed alignment of cudaMalloc, to maybe trip vectorized path
   output_ptr.size -= 1;
@@ -240,7 +240,7 @@ C2H_TEST("Transform works with integral types with well-known operations", "[tra
   using T = c2h::get<0, TestType>;
 
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
-  cccl_op_t op                = make_well_known_unary_operation();
+  const cccl_op_t op          = make_well_known_unary_operation();
   const std::vector<T> input  = generate<T>(num_items);
   const std::vector<T> output(num_items, 0);
   pointer_t<T> input_ptr(input);
@@ -363,7 +363,7 @@ extern "C" __device__ void op(void* x_ptr, void* out_ptr) {
 })");
   const std::vector<int> input = generate<int>(num_items);
   std::vector<pair> expected(num_items);
-  std::vector<pair> output(num_items);
+  const std::vector<pair> output(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
     expected[i] = {short(input[i]), size_t(input[i])};
@@ -415,7 +415,7 @@ extern "C" __device__ void op(void* x_ptr, void* out_ptr) {
 })");
 
   std::vector<unary_storage_in> input(num_items);
-  std::vector<unary_storage_out> output(num_items);
+  const std::vector<unary_storage_out> output(num_items);
   std::vector<unary_storage_out> expected(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
@@ -452,7 +452,7 @@ extern "C" __device__ void op(void* x_ptr, void* out_ptr) {
   const std::vector<short> a  = generate<short>(num_items);
   const std::vector<size_t> b = generate<size_t>(num_items);
   std::vector<pair> input(num_items);
-  std::vector<pair> output(num_items);
+  const std::vector<pair> output(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
     input[i] = pair{a[i], b[i]};
@@ -494,7 +494,7 @@ extern "C" __device__ void op(void* x_ptr, void* out_ptr) {
   const std::vector<short> a  = generate<short>(num_items);
   const std::vector<size_t> b = generate<size_t>(num_items);
   std::vector<pair> input(num_items);
-  std::vector<pair> output(num_items);
+  const std::vector<pair> output(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
     input[i] = pair{a[i], b[i]};
@@ -554,7 +554,7 @@ C2H_TEST("Transform works with output iterators", "[transform]")
     make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
   const std::vector<int> input = generate<int>(num_items);
   pointer_t<int> input_it(input);
-  pointer_t<int> inner_output_it(num_items);
+  const pointer_t<int> inner_output_it(num_items);
   output_it.state.data = inner_output_it.ptr;
 
   auto& build_cache    = get_cache<Transform_OutputIterators_Fixture_Tag>();
@@ -649,7 +649,7 @@ extern "C" __device__ void op(void* x_ptr, void* y_ptr, void* out_ptr) {
 
   std::vector<binary_storage_in1> input1(num_items);
   std::vector<binary_storage_in2> input2(num_items);
-  std::vector<binary_storage_out> output(num_items);
+  const std::vector<binary_storage_out> output(num_items);
   std::vector<binary_storage_out> expected(num_items);
   for (std::size_t i = 0; i < num_items; ++i)
   {
@@ -758,7 +758,7 @@ C2H_TEST("Transform works with C++ source operations", "[transform]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* input, void* output) {
       int* in = (int*)input;
       int* out = (int*)output;
@@ -773,7 +773,7 @@ C2H_TEST("Transform works with C++ source operations", "[transform]")
   pointer_t<T> output_ptr(num_items);
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
 
   auto& cache = fixture<transform_build_cache_t, Transform_IntegralTypes_Fixture_Tag>::get_or_create().get_value();
   std::optional<transform_build_cache_t> cache_opt = cache;
@@ -795,7 +795,7 @@ C2H_TEST("Transform works with C++ source operations using custom headers", "[tr
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* input, void* output) {
       int* in = (int*)input;
@@ -859,7 +859,7 @@ C2H_TEST("Transform works with stateful unary operators", "[transform]")
 {
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
   const std::vector<int> host_counter{0};
-  pointer_t<int> counter(host_counter);
+  const pointer_t<int> counter(host_counter);
   stateful_operation_t<transform_stateful_counter_state_t> op = make_operation(
     "op",
     R"(struct transform_stateful_counter_state_t { int* d_counter; };
@@ -877,7 +877,7 @@ extern "C" __device__ void op(void* state_ptr, void* x_ptr, void* out_ptr) {
   pointer_t<int> output_ptr(output);
 
   std::optional<transform_build_cache_t> build_cache = std::nullopt;
-  std::optional<std::string> test_key                = std::nullopt;
+  const std::optional<std::string> test_key          = std::nullopt;
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -901,7 +901,7 @@ C2H_TEST("Transform build result has serialization metadata populated", "[transf
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_unary_operation();
+  const cccl_op_t op = make_well_known_unary_operation();
   pointer_t<T> in(1);
   pointer_t<T> out(1);
 
@@ -938,7 +938,7 @@ C2H_TEST("Transform compile/load round-trip", "[transform][serialization]")
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_unary_operation();
+  const cccl_op_t op = make_well_known_unary_operation();
   pointer_t<T> dummy_in(1);
   pointer_t<T> dummy_out(1);
 

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -120,7 +120,7 @@ C2H_TEST("DeviceSelect::UniqueByKey can run with empty input", "[unique_by_key]"
   constexpr int num_items = 0;
 
   operation_t op = make_operation("op", get_unique_by_key_op(get_type_info<key_t>().type));
-  std::vector<key_t> input_keys(num_items);
+  const std::vector<key_t> input_keys(num_items);
 
   pointer_t<key_t> input_keys_it(input_keys);
   pointer_t<int> output_num_selected_it(1);
@@ -188,7 +188,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works", "[unique_by_key]", key_types)
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_it[0];
+  const int num_selected = output_num_selected_it[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -239,8 +239,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works with keys only", "[unique_by_key]", ke
     build_cache,
     test_key);
 
-  const auto boundary = std::unique(input_keys.begin(), input_keys.end());
-  int num_selected    = output_num_selected_it[0];
+  const auto boundary    = std::unique(input_keys.begin(), input_keys.end());
+  const int num_selected = output_num_selected_it[0];
   REQUIRE((boundary - input_keys.begin()) == num_selected);
 
   std::vector<key_t> host_output_keys(output_keys_it);
@@ -302,7 +302,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works with floating point types", "[unique_b
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_it[0];
+  const int num_selected = output_num_selected_it[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -327,7 +327,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works with well-known operations", "[unique_
 
   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
 
-  cccl_op_t op                     = make_well_known_unique_binary_predicate();
+  const cccl_op_t op               = make_well_known_unique_binary_predicate();
   std::vector<key_t> input_keys    = generate<key_t>(num_items);
   std::vector<item_t> input_values = generate<item_t>(num_items);
 
@@ -362,7 +362,7 @@ C2H_TEST("DeviceSelect::UniqueByKey works with well-known operations", "[unique_
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_it[0];
+  const int num_selected = output_num_selected_it[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -516,7 +516,7 @@ extern "C" __device__ void op(void* lhs_ptr, void* rhs_ptr, bool* out_ptr) {
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_it[0];
+  const int num_selected = output_num_selected_it[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -591,7 +591,7 @@ extern "C" __device__ void op(void* lhs_ptr, void* rhs_ptr, bool* out_ptr) {
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_it[0];
+  const int num_selected = output_num_selected_it[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -631,17 +631,17 @@ C2H_TEST("DeviceMergeSort::SortPairs works with input and output iterators", "[u
   std::vector<T> input_keys        = generate<T>(num_items);
   std::vector<item_t> input_values = generate<int>(num_items);
 
-  pointer_t<T> input_keys_ptr(input_keys);
+  const pointer_t<T> input_keys_ptr(input_keys);
   input_keys_it.state.data = input_keys_ptr.ptr;
-  pointer_t<item_t> input_values_ptr(input_values);
+  const pointer_t<item_t> input_values_ptr(input_values);
   input_values_it.state.data = input_values_ptr.ptr;
 
-  pointer_t<T> output_keys_ptr(num_items);
+  const pointer_t<T> output_keys_ptr(num_items);
   output_keys_it.state.data = output_keys_ptr.ptr;
-  pointer_t<item_t> output_values_ptr(num_items);
+  const pointer_t<item_t> output_values_ptr(num_items);
   output_values_it.state.data = output_values_ptr.ptr;
 
-  pointer_t<int> output_num_selected_ptr(1);
+  const pointer_t<int> output_num_selected_ptr(1);
   output_num_selected_it.state.data = output_num_selected_ptr.ptr;
 
   auto& build_cache = get_cache<UniqueByKey_Iterators_Fixture_Tag>();
@@ -670,7 +670,7 @@ C2H_TEST("DeviceMergeSort::SortPairs works with input and output iterators", "[u
     return a.first == b.first;
   });
 
-  int num_selected = output_num_selected_ptr[0];
+  const int num_selected = output_num_selected_ptr[0];
 
   REQUIRE((boundary - input_pairs.begin()) == num_selected);
 
@@ -830,7 +830,7 @@ C2H_TEST("UniqueByKey works with C++ source operations", "[unique_by_key]")
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source instead of LTO-IR
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
       int* ilhs = (int*)lhs;
       int* irhs = (int*)rhs;
@@ -857,7 +857,7 @@ C2H_TEST("UniqueByKey works with C++ source operations", "[unique_by_key]")
   pointer_t<std::size_t> output_num_selected_ptr(1);
 
   // Test key including flag that this uses C++ source
-  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
+  const std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
 
   auto& cache =
     fixture<unique_by_key_build_cache_t, UniqueByKey_AllPointerInputs_Fixture_Tag>::get_or_create().get_value();
@@ -912,7 +912,7 @@ C2H_TEST("UniqueByKey works with C++ source operations using custom headers", "[
   const std::size_t num_items = GENERATE(42, 1337, 42000);
 
   // Create operation from C++ source that uses the identity function from header
-  std::string cpp_source = R"(
+  const std::string cpp_source = R"(
     #include "test_identity.h"
     extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
       int* ilhs = (int*)lhs;
@@ -984,7 +984,7 @@ C2H_TEST("UniqueByKey works with C++ source operations using custom headers", "[
       op,
       num_items,
       CU_STREAM_LEGACY));
-  pointer_t<char> temp_storage(temp_storage_bytes);
+  const pointer_t<char> temp_storage(temp_storage_bytes);
   d_temp_storage = static_cast<void*>(temp_storage.ptr);
   REQUIRE(
     CUDA_SUCCESS
@@ -1040,7 +1040,7 @@ C2H_TEST("UniqueByKey build result has serialization metadata populated", "[uniq
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_binary_operation();
+  const cccl_op_t op = make_well_known_binary_operation();
   pointer_t<T> keys_in(1);
   pointer_t<T> values_in(1);
   pointer_t<T> keys_out(1);
@@ -1085,7 +1085,7 @@ C2H_TEST("UniqueByKey compile/load round-trip", "[unique_by_key][serialization]"
   constexpr int device_id = 0;
   const auto& build_info  = BuildInformation<device_id>::init();
 
-  cccl_op_t op = make_well_known_unique_binary_predicate();
+  const cccl_op_t op = make_well_known_unique_binary_predicate();
   pointer_t<T> dummy_keys_in(1);
   pointer_t<T> dummy_values_in(1);
   pointer_t<T> dummy_keys_out(1);
@@ -1154,7 +1154,7 @@ C2H_TEST("UniqueByKey compile/load round-trip", "[unique_by_key][serialization]"
       op,
       n,
       null_stream));
-  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  const pointer_t<uint8_t> temp_storage(temp_storage_bytes);
   REQUIRE(
     CUDA_SUCCESS
     == cccl_device_unique_by_key(

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -35,10 +35,10 @@ inline std::string inspect_sass(const void* cubin, size_t cubin_size)
 {
   namespace fs = std::filesystem;
 
-  fs::path temp_dir = fs::temp_directory_path();
+  const fs::path temp_dir = fs::temp_directory_path();
 
-  fs::path temp_in_filename  = temp_dir / "temp_in_file.cubin";
-  fs::path temp_out_filename = temp_dir / "temp_out_file.sass";
+  const fs::path temp_in_filename  = temp_dir / "temp_in_file.cubin";
+  const fs::path temp_out_filename = temp_dir / "temp_out_file.sass";
 
   std::ofstream temp_in_file(temp_in_filename, std::ios::binary);
   if (!temp_in_file)
@@ -54,7 +54,7 @@ inline std::string inspect_sass(const void* cubin, size_t cubin_size)
   command += " > ";
   command += temp_out_filename.string();
 
-  int exec_code = std::system(command.c_str());
+  const int exec_code = std::system(command.c_str());
 
   if (!fs::remove(temp_in_filename))
   {
@@ -89,7 +89,8 @@ inline std::string compile(const std::string& source)
   REQUIRE(NVRTC_SUCCESS == nvrtcCreateProgram(&prog, source.c_str(), "op.cu", 0, nullptr, nullptr));
 
   // TEST_CTK_PATH needed to include cuda_fp16.h
-  const char* options[] = {"--std=c++17", "-rdc=true", "-dlto", "-D__NV_NO_VECTOR_DEPRECATION_DIAG", TEST_CTK_PATH};
+  const char* const options[] = {
+    "--std=c++17", "-rdc=true", "-dlto", "-D__NV_NO_VECTOR_DEPRECATION_DIAG", TEST_CTK_PATH};
 
   if (nvrtcCompileProgram(prog, 5, options) != NVRTC_SUCCESS)
   {
@@ -1051,8 +1052,8 @@ inline std::tuple<std::string, std::string, std::string> make_random_access_iter
   std::string_view dereference_fn_name,
   std::string_view transform = "")
 {
-  std::string state_def_src      = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
-  std::string advance_fn_def_src = std::format(
+  const std::string state_def_src      = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
+  const std::string advance_fn_def_src = std::format(
     "extern \"C\" __device__ void {0}(void* state, const void* offset) {{\n"
     "  auto* typed_state = static_cast<{1}*>(state);\n"
     "  auto offset_val = *static_cast<const unsigned long long*>(offset);\n"
@@ -1095,17 +1096,17 @@ template <class ValueT>
 iterator_t<ValueT, random_access_iterator_state_t<ValueT>> make_random_access_iterator(
   iterator_kind kind, std::string_view value_type, std::string prefix = "", std::string transform = "")
 {
-  std::string iterator_state_name = std::format("{0}state_t", prefix);
-  std::string advance_fn_name     = std::format("{0}advance", prefix);
-  std::string dereference_fn_name = std::format("{0}dereference", prefix);
+  const std::string iterator_state_name = std::format("{0}state_t", prefix);
+  const std::string advance_fn_name     = std::format("{0}advance", prefix);
+  const std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
   const auto& [iterator_state_def_src, advance_fn_def_src, dereference_fn_def_src] =
     make_random_access_iterator_sources(
       kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name, transform);
 
-  name_source_t iterator_state = {iterator_state_name, iterator_state_def_src};
-  operation_t advance          = {advance_fn_name, advance_fn_def_src};
-  operation_t dereference      = {dereference_fn_name, dereference_fn_def_src};
+  const name_source_t iterator_state = {iterator_state_name, iterator_state_def_src};
+  const operation_t advance          = {advance_fn_name, advance_fn_def_src};
+  const operation_t dereference      = {dereference_fn_name, dereference_fn_def_src};
 
   return make_iterator<ValueT, random_access_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }
@@ -1116,8 +1117,9 @@ inline std::tuple<std::string, std::string, std::string> make_counting_iterator_
   std::string_view advance_fn_name,
   std::string_view dereference_fn_name)
 {
-  std::string iterator_state_def_src = std::format("struct {0} {{ {1} value; }};\n", iterator_state_name, value_type);
-  std::string advance_fn_def_src     = std::format(
+  const std::string iterator_state_def_src =
+    std::format("struct {0} {{ {1} value; }};\n", iterator_state_name, value_type);
+  const std::string advance_fn_def_src = std::format(
     "extern \"C\" __device__ void {0}(void* state, const void* offset) {{\n"
     "  auto* typed_state = static_cast<{1}*>(state);\n"
     "  auto offset_val = *static_cast<const unsigned long long*>(offset);\n"
@@ -1126,7 +1128,7 @@ inline std::tuple<std::string, std::string, std::string> make_counting_iterator_
     advance_fn_name,
     iterator_state_name);
 
-  std::string dereference_fn_def_src = std::format(
+  const std::string dereference_fn_def_src = std::format(
     "extern \"C\" __device__ void {0}(const void* state, {2}* result) {{ \n"
     "  auto* typed_state = static_cast<const {1}*>(state);\n"
     "  *result = typed_state->value;\n"
@@ -1142,16 +1144,16 @@ template <class ValueT>
 iterator_t<ValueT, counting_iterator_state_t<ValueT>>
 make_counting_iterator(std::string_view value_type, std::string_view prefix = "")
 {
-  std::string iterator_state_name = std::format("{0}state_t", prefix);
-  std::string advance_fn_name     = std::format("{0}advance", prefix);
-  std::string dereference_fn_name = std::format("{0}dereference", prefix);
+  const std::string iterator_state_name = std::format("{0}state_t", prefix);
+  const std::string advance_fn_name     = std::format("{0}advance", prefix);
+  const std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
   const auto& [iterator_state_src, advance_fn_def_src, dereference_fn_def_src] =
     make_counting_iterator_sources(value_type, iterator_state_name, advance_fn_name, dereference_fn_name);
 
-  name_source_t iterator_state = {iterator_state_name, iterator_state_src};
-  operation_t advance          = {advance_fn_name, advance_fn_def_src};
-  operation_t dereference      = {dereference_fn_name, dereference_fn_def_src};
+  const name_source_t iterator_state = {iterator_state_name, iterator_state_src};
+  const operation_t advance          = {advance_fn_name, advance_fn_def_src};
+  const operation_t dereference      = {dereference_fn_name, dereference_fn_def_src};
 
   return make_iterator<ValueT, counting_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }
@@ -1162,10 +1164,10 @@ inline std::tuple<std::string, std::string, std::string> make_constant_iterator_
   std::string_view advance_fn_name,
   std::string_view dereference_fn_name)
 {
-  std::string iterator_state_src = std::format("struct {0} {{ {1} value; }};\n", iterator_state_name, value_type);
-  std::string advance_fn_src =
+  const std::string iterator_state_src = std::format("struct {0} {{ {1} value; }};\n", iterator_state_name, value_type);
+  const std::string advance_fn_src =
     std::format("extern \"C\" __device__ void {0}(void* state, const void* offset) {{ }}", advance_fn_name);
-  std::string dereference_fn_src = std::format(
+  const std::string dereference_fn_src = std::format(
     "extern \"C\" __device__ void {0}(const void* state, {1}* result) {{ \n"
     "  auto* typed_state = static_cast<const {2}*>(state);\n"
     "  *result = typed_state->value;\n"
@@ -1181,16 +1183,16 @@ template <class ValueT>
 iterator_t<ValueT, constant_iterator_state_t<ValueT>>
 make_constant_iterator(std::string_view value_type, std::string_view prefix = "")
 {
-  std::string iterator_state_name = std::format("{0}struct_t", prefix);
-  std::string advance_fn_name     = std::format("{0}advance", prefix);
-  std::string dereference_fn_name = std::format("{0}dereference", prefix);
+  const std::string iterator_state_name = std::format("{0}struct_t", prefix);
+  const std::string advance_fn_name     = std::format("{0}advance", prefix);
+  const std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
   const auto& [iterator_state_src, advance_fn_src, dereference_fn_src] =
     make_constant_iterator_sources(value_type, iterator_state_name, advance_fn_name, dereference_fn_name);
 
-  name_source_t iterator_state = {iterator_state_name, iterator_state_src};
-  operation_t advance          = {advance_fn_name, advance_fn_src};
-  operation_t dereference      = {dereference_fn_name, dereference_fn_src};
+  const name_source_t iterator_state = {iterator_state_name, iterator_state_src};
+  const operation_t advance          = {advance_fn_name, advance_fn_src};
+  const operation_t dereference      = {dereference_fn_name, dereference_fn_src};
 
   return make_iterator<ValueT, constant_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }
@@ -1203,8 +1205,8 @@ inline std::tuple<std::string, std::string, std::string> make_reverse_iterator_s
   std::string_view dereference_fn_name,
   std::string_view transform = "")
 {
-  std::string iterator_state_src = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
-  std::string advance_fn_src     = std::format(
+  const std::string iterator_state_src = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
+  const std::string advance_fn_src     = std::format(
     "extern \"C\" __device__ void {0}(void* state, const void* offset) {{\n"
     "  auto* typed_state = static_cast<{1}*>(state);\n"
     "  auto offset_val = *static_cast<const unsigned long long*>(offset);\n"
@@ -1319,16 +1321,16 @@ template <class ValueT>
 iterator_t<ValueT, random_access_iterator_state_t<ValueT>> make_reverse_iterator(
   iterator_kind kind, std::string_view value_type, std::string_view prefix = "", std::string_view transform = "")
 {
-  std::string iterator_state_name = std::format("{0}struct_t", prefix);
-  std::string advance_fn_name     = std::format("{0}advance", prefix);
-  std::string dereference_fn_name = std::format("{0}dereference", prefix);
+  const std::string iterator_state_name = std::format("{0}struct_t", prefix);
+  const std::string advance_fn_name     = std::format("{0}advance", prefix);
+  const std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
   const auto& [iterator_state_src, advance_fn_src, dereference_fn_src] = make_reverse_iterator_sources(
     kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name, transform);
 
-  name_source_t iterator_state = {iterator_state_name, iterator_state_src};
-  operation_t advance          = {advance_fn_name, advance_fn_src};
-  operation_t dereference      = {dereference_fn_name, dereference_fn_src};
+  const name_source_t iterator_state = {iterator_state_name, iterator_state_src};
+  const operation_t advance          = {advance_fn_name, advance_fn_src};
+  const operation_t dereference      = {dereference_fn_name, dereference_fn_src};
 
   return make_iterator<ValueT, random_access_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }
@@ -1549,8 +1551,8 @@ inline std::tuple<std::string, std::string, std::string> make_discard_iterator_s
   std::string_view advance_fn_name,
   std::string_view dereference_fn_name)
 {
-  std::string state_def_src      = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
-  std::string advance_fn_def_src = std::format(
+  const std::string state_def_src      = std::format("struct {0} {{ {1}* data; }};\n", iterator_state_name, value_type);
+  const std::string advance_fn_def_src = std::format(
     "extern \"C\" __device__ void {0}(void* /*state*/, const void* /*offset*/) {{\n"
     "}}",
     advance_fn_name,
@@ -1582,15 +1584,15 @@ inline std::tuple<std::string, std::string, std::string> make_discard_iterator_s
 template <typename ValueT>
 auto make_discard_iterator(iterator_kind kind, std::string_view value_type, std::string prefix = "")
 {
-  std::string iterator_state_name = std::format("{0}struct_t", prefix);
-  std::string advance_fn_name     = std::format("{0}advance", prefix);
-  std::string dereference_fn_name = std::format("{0}dereference", prefix);
+  const std::string iterator_state_name = std::format("{0}struct_t", prefix);
+  const std::string advance_fn_name     = std::format("{0}advance", prefix);
+  const std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
   const auto& [iterator_state_src, advance_fn_src, dereference_fn_src] =
     make_discard_iterator_sources(kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name);
-  name_source_t iterator_state = {iterator_state_name, iterator_state_src};
-  operation_t advance          = {advance_fn_name, advance_fn_src};
-  operation_t dereference      = {dereference_fn_name, dereference_fn_src};
+  const name_source_t iterator_state = {iterator_state_name, iterator_state_src};
+  const operation_t advance          = {advance_fn_name, advance_fn_src};
+  const operation_t dereference      = {dereference_fn_name, dereference_fn_src};
 
   return make_iterator<ValueT, random_access_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }

--- a/c2h/include/c2h/bfloat16.cuh
+++ b/c2h/include/c2h/bfloat16.cuh
@@ -90,9 +90,9 @@ struct bfloat16_t
         float F32;
       };
 
-      F32                    = a;
-      uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
-      ir                     = static_cast<uint16_t>((U32 + rounding_bias) >> 16);
+      F32                          = a;
+      const uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
+      ir                           = static_cast<uint16_t>((U32 + rounding_bias) >> 16);
     }
     this->__x = ir;
   }

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -401,7 +401,7 @@ auto compare_host_ranges(const LhsRange& actual, const RhsRange& expected) -> ve
   result.total_mismatches = mismatches.size();
 
   // Handle first mismatches
-  size_t first_count = cuda::std::min<size_t>(mismatches.size(), first_mismatches_count);
+  const size_t first_count = cuda::std::min<size_t>(mismatches.size(), first_mismatches_count);
   result.first_mismatches.assign(mismatches.begin(), mismatches.begin() + first_count);
 
   // Handle last mismatches
@@ -662,7 +662,7 @@ inline std::size_t get_override_seed_count()
 
 inline std::size_t adjust_seed_count(std::size_t requested)
 {
-  static std::size_t override_seeds = get_override_seed_count();
+  static const std::size_t override_seeds = get_override_seed_count();
   return override_seeds != 0 ? override_seeds : requested;
 }
 } // namespace c2h

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -90,7 +90,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
 template <typename T>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
-  c2h::host_vector<T> test_results_host = test_results;
+  const c2h::host_vector<T> test_results_host = test_results;
   verify_results(expected_data, test_results_host);
 }
 
@@ -108,7 +108,7 @@ void verify_results_exact(const c2h::host_vector<T>& expected_data, const c2h::h
   CubDebugExit(cudaGetDevice(&device_id));
   CubDebugExit(cudaDeviceGetAttribute(&compute_capability_major, cudaDevAttrComputeCapabilityMajor, device_id));
   CubDebugExit(cudaDeviceGetAttribute(&compute_capability_minor, cudaDevAttrComputeCapabilityMinor, device_id));
-  int compute_capability = 10 * compute_capability_major + compute_capability_minor;
+  const int compute_capability = 10 * compute_capability_major + compute_capability_minor;
   if (compute_capability < 80 && is_any_bfloat16_v<T>)
   {
     return;
@@ -142,7 +142,7 @@ void verify_results_exact(const c2h::host_vector<T>& expected_data, const c2h::h
 template <typename T>
 void verify_results_exact(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
-  c2h::host_vector<T> test_results_host = test_results;
+  const c2h::host_vector<T> test_results_host = test_results;
   if constexpr (is_vector2_type_v<T> || cuda::is_floating_point_v<T>)
   {
     verify_results_exact(expected_data, test_results_host);

--- a/c2h/include/c2h/checked_allocator.cuh
+++ b/c2h/include/c2h/checked_allocator.cuh
@@ -54,7 +54,7 @@ struct memory_info
 inline std::size_t get_device_memory_limit()
 {
   static std::optional<std::string> override_str = get_env("C2H_DEVICE_MEMORY_LIMIT");
-  static std::size_t result =
+  static const std::size_t result =
     override_str ? static_cast<std::size_t>(std::strtoll(override_str->c_str(), nullptr, 10)) : 0;
   return result;
 }
@@ -62,15 +62,15 @@ inline std::size_t get_device_memory_limit()
 inline bool get_debug_checked_allocs()
 {
   static std::optional<std::string> debug_checked_allocs = get_env("C2H_DEBUG_CHECKED_ALLOC_FAILURES");
-  static bool result = debug_checked_allocs && (std::strtol(debug_checked_allocs->c_str(), nullptr, 10) != 0);
+  static const bool result = debug_checked_allocs && (std::strtol(debug_checked_allocs->c_str(), nullptr, 10) != 0);
   return result;
 }
 
 inline cudaError_t get_device_memory(memory_info& info)
 {
-  static std::size_t device_memory_limit = get_device_memory_limit();
+  static const std::size_t device_memory_limit = get_device_memory_limit();
 
-  cudaError_t status = cudaMemGetInfo(&info.free, &info.total);
+  const cudaError_t status = cudaMemGetInfo(&info.free, &info.total);
   if (status != cudaSuccess)
   {
     return status;
@@ -89,7 +89,7 @@ inline cudaError_t get_device_memory(memory_info& info)
 inline cudaError_t check_free_device_memory(std::size_t bytes)
 {
   memory_info info;
-  cudaError_t status = get_device_memory(info);
+  const cudaError_t status = get_device_memory(info);
   if (status != cudaSuccess)
   {
     return status;

--- a/c2h/include/c2h/fill_striped.h
+++ b/c2h/include/c2h/fill_striped.h
@@ -51,7 +51,7 @@ void fill_striped(IteratorT it)
 
   constexpr int warps_in_block = ThreadsPerBlock / LogicalWarpThreads;
   constexpr int items_per_warp = LogicalWarpThreads * ItemsPerThread;
-  scalar_to_vec_t<T> convert;
+  const scalar_to_vec_t<T> convert;
 
   for (int warp_id = 0; warp_id < warps_in_block; warp_id++)
   {

--- a/c2h/include/c2h/half.cuh
+++ b/c2h/include/c2h/half.cuh
@@ -97,7 +97,7 @@ struct half_t
     }
     else if ((ia & 0x7f800000) >= 0x33000000)
     {
-      int32_t shift = static_cast<int32_t>((ia >> 23) & 0xff) - 127;
+      const int32_t shift = static_cast<int32_t>((ia >> 23) & 0xff) - 127;
       if (shift > 15)
       {
         ir |= 0x7c00; /* infinity */
@@ -138,7 +138,7 @@ struct half_t
   {
     // Stolen from Andrew Kerr
 
-    int sign        = ((this->__x >> 15) & 1);
+    const int sign  = ((this->__x >> 15) & 1);
     int exp         = ((this->__x >> 10) & 0x1f);
     int mantissa    = (this->__x & 0x3ff);
     std::uint32_t f = 0;

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -267,7 +267,7 @@ struct generator_base_t
   thrust::device_vector<T> generate(T min, T max)
   {
     thrust::device_vector<T> vec(m_elements);
-    cuda::std::span<T> span(thrust::raw_pointer_cast(vec.data()), m_elements);
+    const cuda::std::span<T> span(thrust::raw_pointer_cast(vec.data()), m_elements);
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     gen_device(m_seed, span, m_entropy, min, max);
 #else
@@ -324,7 +324,7 @@ struct uniform_key_segments_generator_t
   operator thrust::device_vector<KeyT>()
   {
     thrust::device_vector<KeyT> keys_vec(m_total_elements);
-    cuda::std::span<KeyT> keys(thrust::raw_pointer_cast(keys_vec.data()), keys_vec.size());
+    const cuda::std::span<KeyT> keys(thrust::raw_pointer_cast(keys_vec.data()), keys_vec.size());
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     gen_uniform_key_segments_device(m_seed, keys, m_min_segment_size, m_max_segment_size);
 #else
@@ -346,7 +346,7 @@ struct uniform_segment_offsets_generator_t
   operator thrust::device_vector<OffsetT>()
   {
     thrust::device_vector<OffsetT> offsets_vec(m_total_elements + 2);
-    cuda::std::span<OffsetT> offsets(thrust::raw_pointer_cast(offsets_vec.data()), offsets_vec.size());
+    const cuda::std::span<OffsetT> offsets(thrust::raw_pointer_cast(offsets_vec.data()), offsets_vec.size());
     const std::size_t offsets_size =
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
       gen_uniform_segment_offsets_device(m_seed, offsets, m_min_segment_size, m_max_segment_size);
@@ -370,7 +370,7 @@ struct power_law_segment_offsets_generator_t
   operator thrust::device_vector<OffsetT>()
   {
     thrust::device_vector<OffsetT> offsets_vec(m_segments + 1);
-    cuda::std::span<OffsetT> offsets(thrust::raw_pointer_cast(offsets_vec.data()), offsets_vec.size());
+    const cuda::std::span<OffsetT> offsets(thrust::raw_pointer_cast(offsets_vec.data()), offsets_vec.size());
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     gen_power_law_segment_offsets_device(m_seed, offsets, m_elements);
 #else
@@ -508,7 +508,7 @@ struct max_t
   template <typename DataType>
   __host__ __device__ DataType operator()(const DataType& lhs, const DataType& rhs) const
   {
-    less_t less{};
+    const less_t less{};
     return less(lhs, rhs) ? rhs : lhs;
   }
 
@@ -599,7 +599,7 @@ struct caching_allocator_t
       throw std::runtime_error("Memory was not allocated by this allocator");
     }
 
-    std::ptrdiff_t num_bytes = iter->second;
+    const std::ptrdiff_t num_bytes = iter->second;
     allocated_blocks.erase(iter);
     free_blocks.insert(std::make_pair(num_bytes, ptr));
   }

--- a/test/cuda_smoke/cuda_runtime_smoke.cu
+++ b/test/cuda_smoke/cuda_runtime_smoke.cu
@@ -15,7 +15,7 @@
 
 __global__ void increment_kernel(int* p, int n)
 {
-  int idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
   if (idx < n)
   {
     p[idx] += 1;


### PR DESCRIPTION
Part of the `misc-const-correctness` split of the umbrella branch `jacobf/2026-09-02/misc-const-correctness`.

This PR adds `const` to local variables under:
  - `c2h/`
  - `nvbench_helper/`
  - `c/`
  - `test/`

It does **not** enable the check. `misc-const-correctness` stays disabled in `.clang-tidy` until the final PR of the series.