### PR TITLE
Optimize `WarpReduce` for bitwise operators

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -16,7 +16,6 @@
 #include <cub/detail/strong_store.cuh>
 #include <cub/detail/warpspeed/special_registers.cuh>
 #include <cub/thread/thread_store.cuh>
-#include <cub/warp/specializations/warp_redux.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
 #include <cuda/__cmath/pow2.h>
@@ -186,8 +185,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   ScanOpT& scan_op,
   const int num_tiles)
 {
-  const int laneIdx                                       = static_cast<int>(specialRegisters.laneIdx);
-  [[maybe_unused]] const ::cuda::std::uint32_t lanemaskEq = ::cuda::ptx::get_sreg_lanemask_eq();
+  const int laneIdx = static_cast<int>(specialRegisters.laneIdx);
 
   int idxTileCur             = idxTilePrev;
   AccumT aggrExclusiveCtaCur = aggrExclusiveCtaPrev;
@@ -195,7 +193,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   using warp_reduce_t = WarpReduce<AccumT>;
   static_assert(::cuda::std::is_same_v<typename warp_reduce_t::TempStorage, Uninitialized<NullType>>,
                 "WarpReduce for a full warp must not require temporary storage");
-  [[maybe_unused]] typename warp_reduce_t::TempStorage temp_storage;
+  typename warp_reduce_t::TempStorage temp_storage;
 
   while (idxTileCur < idxTileNext)
   {
@@ -220,25 +218,8 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
       const ::cuda::std::uint32_t warp_right_aggregates_count = ::cuda::std::popcount(warp_right_aggregates_mask);
 
       // Accumulate the rightmost tile aggregates
-      AccumT local_aggr;
-      NV_IF_ELSE_TARGET(
-        NV_PROVIDES_SM_80,
-        ({ // NOTE: Inlined from warp_reduce_shfl
-          if constexpr (is_warp_redux_op_supported_sm80<ScanOpT, AccumT>)
-          {
-            const bool use_value = lanemaskEq & warp_right_aggregates_mask;
-            const AccumT value   = use_value ? regTmpStates[idx].value : cuda::identity_element<ScanOpT, AccumT>();
-            local_aggr           = cub::detail::warp_redux_sm80(value, ~0, scan_op);
-          }
-          else
-          {
-            // TODO(bgruber): this generates a LOT of SASS. I think it can do better.
-            local_aggr =
-              warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);
-          }
-        }),
-        (local_aggr =
-           warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);))
+      const AccumT local_aggr =
+        warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);
 
       // We never initialized aggrExclusiveCtaCur when starting look ahead at tile 0
       aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);

--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -16,6 +16,7 @@
 #include <cub/detail/strong_store.cuh>
 #include <cub/detail/warpspeed/special_registers.cuh>
 #include <cub/thread/thread_store.cuh>
+#include <cub/warp/specializations/warp_redux.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
 #include <cuda/__cmath/pow2.h>
@@ -185,7 +186,8 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   ScanOpT& scan_op,
   const int num_tiles)
 {
-  const int laneIdx = static_cast<int>(specialRegisters.laneIdx);
+  const int laneIdx                                       = static_cast<int>(specialRegisters.laneIdx);
+  [[maybe_unused]] const ::cuda::std::uint32_t lanemaskEq = ::cuda::ptx::get_sreg_lanemask_eq();
 
   int idxTileCur             = idxTilePrev;
   AccumT aggrExclusiveCtaCur = aggrExclusiveCtaPrev;
@@ -193,7 +195,7 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
   using warp_reduce_t = WarpReduce<AccumT>;
   static_assert(::cuda::std::is_same_v<typename warp_reduce_t::TempStorage, Uninitialized<NullType>>,
                 "WarpReduce for a full warp must not require temporary storage");
-  typename warp_reduce_t::TempStorage temp_storage;
+  [[maybe_unused]] typename warp_reduce_t::TempStorage temp_storage;
 
   while (idxTileCur < idxTileNext)
   {
@@ -218,8 +220,25 @@ template <int numTileStatesPerThread, typename AccumT, typename ScanOpT>
       const ::cuda::std::uint32_t warp_right_aggregates_count = ::cuda::std::popcount(warp_right_aggregates_mask);
 
       // Accumulate the rightmost tile aggregates
-      const AccumT local_aggr =
-        warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);
+      AccumT local_aggr;
+      NV_IF_ELSE_TARGET(
+        NV_PROVIDES_SM_80,
+        ({ // NOTE: Inlined from warp_reduce_shfl
+          if constexpr (is_warp_redux_op_supported_sm80<ScanOpT, AccumT>)
+          {
+            const bool use_value = lanemaskEq & warp_right_aggregates_mask;
+            const AccumT value   = use_value ? regTmpStates[idx].value : cuda::identity_element<ScanOpT, AccumT>();
+            local_aggr           = cub::detail::warp_redux_sm80(value, ~0, scan_op);
+          }
+          else
+          {
+            // TODO(bgruber): this generates a LOT of SASS. I think it can do better.
+            local_aggr =
+              warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);
+          }
+        }),
+        (local_aggr =
+           warp_reduce_t{temp_storage}.Reduce(regTmpStates[idx].value, scan_op, warp_right_aggregates_count);))
 
       // We never initialized aggrExclusiveCtaCur when starting look ahead at tile 0
       aggrExclusiveCtaCur = idxTileCur == 0 ? local_aggr : scan_op(aggrExclusiveCtaCur, local_aggr);

--- a/cub/cub/warp/specializations/warp_redux.cuh
+++ b/cub/cub/warp/specializations/warp_redux.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/cstdint>
 
@@ -43,13 +44,18 @@ inline constexpr bool is_warp_redux_op_supported_sm80 =
   && (is_cuda_minimum_maximum_v<ReduceOp, T> || is_cuda_std_plus_v<ReduceOp, T> || is_cuda_std_bitwise_v<ReduceOp, T>);
 
 template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
+inline constexpr bool is_warp_redux_bitwise_large_supported =
+  ::cuda::std::is_unsigned_v<T> && sizeof(T) > sizeof(unsigned) && is_cuda_std_bitwise_v<ReduceOp, T>;
+
+template <typename Op, typename T, typename ReduceOp = ::cuda::std::remove_cvref_t<Op>>
 inline constexpr bool is_warp_redux_min_max_f32_supported =
   __cccl_ptx_isa >= 860 && (::cuda::std::is_same_v<T, float> || is_half_v<T> || is_bfloat16_v<T>)
   && is_cuda_minimum_maximum_v<ReduceOp, T>;
 
 template <typename Op, typename T>
 inline constexpr bool is_warp_redux_op_supported =
-  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_min_max_f32_supported<Op, T>;
+  is_warp_redux_op_supported_sm80<Op, T> || is_warp_redux_bitwise_large_supported<Op, T>
+  || is_warp_redux_min_max_f32_supported<Op, T>;
 
 //----------------------------------------------------------------------------------------------------------------------
 // SM80 Redux
@@ -92,6 +98,27 @@ warp_redux_sm80(const T input, const ::cuda::std::uint32_t mask, ReductionOp)
     _CCCL_UNREACHABLE();
     return T{};
   }
+}
+
+template <typename T, typename ReductionOp>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE T
+warp_redux_bitwise_large(const T input, const ::cuda::std::uint32_t mask, ReductionOp reduction_op)
+{
+  static_assert(is_warp_redux_bitwise_large_supported<ReductionOp, T>, "Reduction operator not supported");
+  constexpr int chunk_bits  = 32; // 32 bits
+  constexpr int num_chunks  = sizeof(T) / sizeof(unsigned);
+  const auto generalized_op = cub::detail::generalize_operator(reduction_op); // map bit_and<uint64_t> to bit_and<>
+  // do not use bit_cast/memcpy to avoid potential performance issues
+  T output{};
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int chunk = 0; chunk < num_chunks; ++chunk)
+  {
+    const int shift    = chunk * chunk_bits;
+    const auto value   = static_cast<unsigned>(input >> shift);
+    const auto reduced = cub::detail::warp_redux_sm80(value, mask, generalized_op);
+    output |= static_cast<T>(reduced) << shift;
+  }
+  return output;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -154,6 +181,10 @@ warp_redux(const T input, const ::cuda::std::uint32_t mask, ReductionOp reductio
   if constexpr (is_warp_redux_op_supported_sm80<ReductionOp, T>)
   { // NOLINT(bugprone-branch-clone)
     NV_IF_TARGET(NV_PROVIDES_SM_80, (return cub::detail::warp_redux_sm80(input, mask, reduction_op);))
+  }
+  else if constexpr (is_warp_redux_bitwise_large_supported<ReductionOp, T>)
+  {
+    NV_IF_TARGET(NV_PROVIDES_SM_80, (return cub::detail::warp_redux_bitwise_large(input, mask, reduction_op);))
   }
   else if constexpr (is_warp_redux_min_max_f32_supported<ReductionOp, T>)
   {

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2011, Duane Merrill. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2011-2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2011-2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3
 
 //! @file
@@ -62,6 +62,21 @@ CUB_NAMESPACE_BEGIN
 //!
 //!   - Summation (**vs.** generic reduction)
 //!   - The architecture's warp size is a whole multiple of ``LogicalWarpThreads``
+//!
+//! Hardware Warp Redux Optimizations
+//! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//!
+//! For full 32-thread logical warps, ``WarpReduce`` uses PTX ``redux.sync`` instructions for the following operator and
+//! type combinations when the target architecture supports them:
+//!
+//! - On SM80 and later:
+//!
+//!   - ``cuda::std::plus``, ``cuda::minimum``, and ``cuda::maximum`` for integral types up to 32 bits.
+//!   - ``cuda::std::bit_and``, ``cuda::std::bit_or``, and ``cuda::std::bit_xor`` for integral types of any size.
+//!
+//! - On SM100f and later in the same architecture family:
+//!
+//!   - ``cuda::minimum`` and ``cuda::maximum`` for ``float``, ``__half``, and ``__nv_bfloat16``.
 //!
 //! Simple Examples
 //! +++++++++++++++

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -190,6 +190,18 @@ using predefined_op_list = c2h::type_list<cuda::std::plus<>, cuda::maximum<>, cu
 
 using predefined_min_max_op_list = c2h::type_list<cuda::maximum<>, cuda::minimum<>>;
 
+// clang-format off
+using unsigned_type_list = c2h::type_list<
+  uint32_t,
+  uint64_t
+#if TEST_INT128()
+  , __uint128_t
+#endif // TEST_INT128()
+>;
+// clang-format on
+
+using bitwise_op_list = c2h::type_list<cuda::std::bit_and<>, cuda::std::bit_or<>, cuda::std::bit_xor<>>;
+
 using logical_warp_threads = c2h::enum_type_list<unsigned, 32, 16, 9, 7, 1>;
 
 /***********************************************************************************************************************
@@ -313,6 +325,29 @@ CUB_TEST("WarpReduce::Max/Min, floating-point redux types",
   }
 }
 
+CUB_TEST("WarpReduce::Reduce, unsigned bitwise types",
+         "[reduce][warp][predefined_op][redux]",
+         CUB_SMALL,
+         unsigned_type_list,
+         bitwise_op_list,
+         logical_warp_threads)
+{
+  using T                                       = c2h::get<0, TestType>;
+  using predefined_op                           = c2h::get<1, TestType>;
+  constexpr auto logical_warp_threads           = c2h::get<2, TestType>::value;
+  auto [input_size, output_size, logical_warps] = get_test_config(logical_warp_threads);
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<predefined_op>(), logical_warp_threads);
+  c2h::device_vector<T> d_in(input_size);
+  c2h::device_vector<T> d_out(output_size);
+  c2h::gen(C2H_SEED(10), d_in);
+  warp_reduce_launch<logical_warp_threads>(d_in, d_out, warp_reduce_t<predefined_op, T>{});
+
+  const c2h::host_vector<T> h_in = d_in;
+  c2h::host_vector<T> h_out(output_size);
+  compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads);
+  verify_results_exact(h_out, d_out);
+}
+
 CUB_TEST("WarpReduce::CustomSum", "[reduce][warp][generic][full]", CUB_SMALL, full_type_list, logical_warp_threads)
 {
   using T                                       = c2h::get<0, TestType>;
@@ -355,6 +390,30 @@ CUB_TEST("WarpReduce::Sum/Max/Min Partial",
   c2h::host_vector<T> h_out(output_size);
   compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads, valid_items);
   verify_results(h_out, d_out);
+}
+
+CUB_TEST("WarpReduce::Reduce, unsigned bitwise types, partial",
+         "[reduce][warp][predefined_op][redux][partial]",
+         CUB_SMALL,
+         unsigned_type_list,
+         bitwise_op_list,
+         logical_warp_threads)
+{
+  using T                                       = c2h::get<0, TestType>;
+  using predefined_op                           = c2h::get<1, TestType>;
+  constexpr auto logical_warp_threads           = c2h::get<2, TestType>::value;
+  auto [input_size, output_size, logical_warps] = get_test_config(logical_warp_threads);
+  const int valid_items                         = GENERATE_COPY(take(2, random(1u, logical_warp_threads)));
+  CAPTURE(c2h::type_name<T>(), c2h::type_name<predefined_op>(), logical_warp_threads, valid_items);
+  c2h::device_vector<T> d_in(input_size);
+  c2h::device_vector<T> d_out(output_size);
+  c2h::gen(C2H_SEED(10), d_in);
+  warp_reduce_launch<logical_warp_threads, true>(d_in, d_out, warp_reduce_t<predefined_op, T>{}, valid_items);
+
+  const c2h::host_vector<T> h_in = d_in;
+  c2h::host_vector<T> h_out(output_size);
+  compute_host_reference<predefined_op>(h_in, h_out, logical_warps, logical_warp_threads, valid_items);
+  verify_results_exact(h_out, d_out);
 }
 
 CUB_TEST("WarpReduce::Sum", "[reduce][warp][generic][partial]", CUB_SMALL, full_type_list, logical_warp_threads)


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cccl/pull/10768 remembered me that there is still low-hanging fruit to optimize `WarpReduce`.

The PR optimizes bitwise operators for unsigned types > 4B by applying `warp_redux` to 32-bit chunks. This leads to **4x** better perf for 64-bit, and **25x** for 128-bit integers.

I also realized that `warpspeed` is using the internal `warp_redux` function for a smaller set of types. The original concern was related to the large number of SASS instructions. Instead, switching to the top-level API reduced the number of SASS instructions. The simplification decreases the code fragmentation and potentially the suboptimal paths (@bernhardmgruber for visibility)