### PR TITLE
Fix `DeviceBatchedTopK` launch failure (`cudaErrorInvalidDeviceFunction`) on CUDA 12.4 to 12.6

### DIFF
--- a/cub/cub/detail/segmented_params.cuh
+++ b/cub/cub/detail/segmented_params.cuh
@@ -273,6 +273,8 @@ using bounded_offset_t =
   detail::choose_offset_for_max_t<static_cast<::cuda::std::uint64_t>(::cuda::args::__traits<_ParamT>::highest)>;
 
 // =====================================================================
+// TODO(gevtushenko): drop this once we drop support for CTK 12.6
+//
 // Kernel-identity normalization of annotated parameters
 // =====================================================================
 // nvcc 12.4 to 12.6 re-emit the host translation unit with a defect: the argument of an `auto` non-type template
@@ -326,6 +328,7 @@ normalize_param([[maybe_unused]] ::cuda::args::constant<_Value, _Tp> __arg) noex
 {
   if constexpr (::cuda::std::__cccl_is_integer_v<::cuda::std::remove_cv_t<decltype(_Value)>>)
   {
+    // For integral types, we discard the `_Tp` type and normalize the type based on the `_Value`'s value
     return ::cuda::args::constant<static_cast<__static_value_type_t<_Value>>(_Value)>{};
   }
   else

--- a/cub/cub/detail/segmented_params.cuh
+++ b/cub/cub/detail/segmented_params.cuh
@@ -24,6 +24,7 @@
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/cmp.h> // cmp_greater_equal, cmp_less_equal
 #include <cuda/std/__utility/forward.h>
@@ -270,6 +271,109 @@ __get_and_clamp_param_to_nonnegative(const _Arg& __arg, _SegmentIndexT __index) 
 template <typename _ParamT>
 using bounded_offset_t =
   detail::choose_offset_for_max_t<static_cast<::cuda::std::uint64_t>(::cuda::args::__traits<_ParamT>::highest)>;
+
+// =====================================================================
+// Kernel-identity normalization of annotated parameters
+// =====================================================================
+// nvcc 12.4 to 12.6 re-emit the host translation unit with a defect: the argument of an `auto` non-type template
+// parameter is printed as the untyped initializer of the variable that first named the specialization in the TU. With
+// `constexpr int64_t n = 384;`, `cuda::args::constant<n>` reaches the host compiler as `constant<384>` and deduces
+// `int`, while the device pass deduced `long`. A kernel whose identity contains such a type then has a host stub
+// without device code and fails to launch with cudaErrorInvalidDeviceFunction. The *value* of the argument and all
+// *type* template arguments survive the re-emission intact. The overloads below rebuild every wrapper that may reach a
+// kernel or policy-selector type from that surviving information only:
+//   * a `constant`'s element type is chosen from its value (the smallest of int32_t, int64_t, uint64_t that holds it),
+//     never from the deduced type of the argument,
+//   * static bounds are re-typed with the element type of the wrapped argument, which is a type argument.
+// Both compilation passes then name the same kernel. On unaffected toolkits this only makes `constant<int64_t{384}>`
+// and `constant<384>` select the same 32-bit kernel instead of two different ones.
+
+template <auto _Value>
+using __static_value_type_t = ::cuda::std::conditional_t<
+  ::cuda::std::in_range<::cuda::std::int32_t>(_Value),
+  ::cuda::std::int32_t,
+  ::cuda::std::
+    conditional_t<::cuda::std::in_range<::cuda::std::int64_t>(_Value), ::cuda::std::int64_t, ::cuda::std::uint64_t>>;
+
+template <class _ElementT, class _StaticBounds>
+struct __retype_static_bounds
+{
+  using type = _StaticBounds; // no_bounds
+};
+
+template <class _ElementT, auto _Lowest, auto _Highest>
+struct __retype_static_bounds<_ElementT, ::cuda::args::static_bounds<_Lowest, _Highest>>
+{
+  using type = ::cuda::args::static_bounds<static_cast<_ElementT>(_Lowest), static_cast<_ElementT>(_Highest)>;
+};
+
+template <class _ElementT, class _StaticBounds>
+using __retype_static_bounds_t = typename __retype_static_bounds<_ElementT, _StaticBounds>::type;
+
+//! @brief Plain values carry no `auto` NTTP and pass through unchanged.
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES((!::cuda::args::__is_wrapper_v<::cuda::std::remove_cvref_t<_Tp>>) )
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr ::cuda::std::remove_cvref_t<_Tp> normalize_param(_Tp&& __arg) noexcept
+{
+  return ::cuda::std::forward<_Tp>(__arg);
+}
+
+//! @brief Compile-time constants: integer values are re-wrapped with a value-chosen element type. Everything else
+//! (enumerators, pointers) already spells its type in any constant expression and is kept as is.
+template <auto _Value, class _Tp>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto
+normalize_param([[maybe_unused]] ::cuda::args::constant<_Value, _Tp> __arg) noexcept
+{
+  if constexpr (::cuda::std::__cccl_is_integer_v<::cuda::std::remove_cv_t<decltype(_Value)>>)
+  {
+    return ::cuda::args::constant<static_cast<__static_value_type_t<_Value>>(_Value)>{};
+  }
+  else
+  {
+    return __arg;
+  }
+}
+
+template <auto _Value>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto normalize_param(::cuda::args::__constant_sequence<_Value> __arg) noexcept
+{
+  return __arg;
+}
+
+template <class _Arg, class _StaticBounds>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto
+normalize_param(const ::cuda::args::immediate<_Arg, _StaticBounds>& __arg) noexcept
+{
+  using __bounds_t = __retype_static_bounds_t<::cuda::args::__element_type_of_t<_Arg>, _StaticBounds>;
+  return ::cuda::args::immediate<_Arg, __bounds_t>{::cuda::args::__access::__arg(__arg)};
+}
+
+template <class _Arg, class _StaticBounds>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto
+normalize_param(const ::cuda::args::__immediate_sequence<_Arg, _StaticBounds>& __arg) noexcept
+{
+  using __bounds_t = __retype_static_bounds_t<::cuda::args::__element_type_of_t<_Arg>, _StaticBounds>;
+  return ::cuda::args::__immediate_sequence<_Arg, __bounds_t>{
+    ::cuda::args::__access::__arg(__arg), ::cuda::args::__access::__runtime_bounds(__arg)};
+}
+
+template <class _Arg, class _StaticBounds>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto
+normalize_param(const ::cuda::args::deferred<_Arg, _StaticBounds>& __arg) noexcept
+{
+  using __bounds_t = __retype_static_bounds_t<::cuda::args::__element_type_of_t<_Arg>, _StaticBounds>;
+  return ::cuda::args::deferred<_Arg, __bounds_t>{
+    ::cuda::args::__access::__arg(__arg), ::cuda::args::__access::__runtime_bounds(__arg)};
+}
+
+template <class _Arg, class _StaticBounds>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr auto
+normalize_param(const ::cuda::args::deferred_sequence<_Arg, _StaticBounds>& __arg) noexcept
+{
+  using __bounds_t = __retype_static_bounds_t<::cuda::args::__element_type_of_t<_Arg>, _StaticBounds>;
+  return ::cuda::args::deferred_sequence<_Arg, __bounds_t>{
+    ::cuda::args::__access::__arg(__arg), ::cuda::args::__access::__runtime_bounds(__arg)};
+}
 
 // =====================================================================
 // Discrete parameter support

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -922,11 +922,11 @@ template <
   typename KeyOutputItItT,
   typename ValueInputItItT,
   typename ValueOutputItItT,
-  typename SegmentSizeParameterT,
-  typename KParameterT,
+  typename SegmentSizeArgT,
+  typename KArgT,
   typename SelectDirectionT,
-  typename NumSegmentsParameterT,
-  typename TotalNumItemsGuaranteeT,
+  typename NumSegmentsArgT,
+  typename TotalNumItemsGuaranteeArgT,
   typename TuningEnvT            = ::cuda::std::execution::env<>,
   typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
 _CCCL_HOST_API cudaError_t dispatch(
@@ -936,15 +936,28 @@ _CCCL_HOST_API cudaError_t dispatch(
   KeyOutputItItT d_key_segments_out_it,
   ValueInputItItT d_value_segments_it,
   ValueOutputItItT d_value_segments_out_it,
-  SegmentSizeParameterT segment_sizes,
-  KParameterT k,
+  SegmentSizeArgT segment_sizes_arg,
+  KArgT k_arg,
   SelectDirectionT select_direction,
-  NumSegmentsParameterT num_segments,
-  [[maybe_unused]] TotalNumItemsGuaranteeT total_num_items_guarantee,
+  NumSegmentsArgT num_segments_arg,
+  [[maybe_unused]] TotalNumItemsGuaranteeArgT total_num_items_guarantee_arg,
   cudaStream_t stream,
   const TuningEnvT&                      = {},
   KernelLauncherFactory launcher_factory = {})
 {
+  // Rebuild the annotated parameters from the information that survives nvcc's host re-emission (see
+  // params::normalize_param) *before* any kernel or policy-selector type is named: from here on only the normalized
+  // parameters and their types take part in a kernel's identity. Types are derived through declval rather than from
+  // the variables so they can feed the constant initializers below (GCC 7, see the select-direction note).
+  using SegmentSizeParameterT = decltype(detail::params::normalize_param(::cuda::std::declval<SegmentSizeArgT>()));
+  using KParameterT           = decltype(detail::params::normalize_param(::cuda::std::declval<KArgT>()));
+  using NumSegmentsParameterT = decltype(detail::params::normalize_param(::cuda::std::declval<NumSegmentsArgT>()));
+  using TotalNumItemsGuaranteeT =
+    decltype(detail::params::normalize_param(::cuda::std::declval<TotalNumItemsGuaranteeArgT>()));
+  const SegmentSizeParameterT segment_sizes = detail::params::normalize_param(segment_sizes_arg);
+  const KParameterT k                       = detail::params::normalize_param(k_arg);
+  const NumSegmentsParameterT num_segments  = detail::params::normalize_param(num_segments_arg);
+
   // Both arms resolve `num_segments` on the host (allocation sizing, grid extent, empty-batch guard), so it must be a
   // host-known single value; device-resident counts are future work. Defensive: the public entry checks this too, but
   // `dispatch` is also called directly (tests / benchmarks).

--- a/cub/test/catch2_test_segmented_params.cu
+++ b/cub/test/catch2_test_segmented_params.cu
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/detail/segmented_params.cuh>
+
+#include <thrust/detail/raw_pointer_cast.h>
+
+#include <cuda/argument>
+#include <cuda/std/__utility/cmp.h> // cmp_equal
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "cub_test_macros.h"
+#include <c2h/vector.h>
+
+// The type an argument annotation is rewritten to before it may appear in a kernel or policy-selector type. Spelled the
+// way the dispatch spells it, so these tests break if the dispatch-facing signature changes.
+template <class ParamT>
+using normalized_t = decltype(cub::detail::params::normalize_param(cuda::std::declval<ParamT>()));
+
+// Whether `constant<Value>` normalizes to `constant<ExpectedValue>` while still holding `Value`. The expectation is
+// spelled as a value rather than a type so that the expected element type is visible at the call site; comparing the
+// whole type pins both the non-type template argument and its type, which is what kernel identity depends on.
+//
+// Keep this body free of `typename normalized_param_t::value_type` and of a `static_cast` in a template argument:
+// cudafe++ in nvcc 12.4 to 12.6 fails to re-emit either construct when it is spelled on a dependent `decltype` alias,
+// which is the same host-pass regeneration defect these tests cover.
+template <auto Value, auto ExpectedValue>
+[[nodiscard]] constexpr bool constant_normalizes_to() noexcept
+{
+  using normalized_param_t = normalized_t<cuda::args::constant<Value>>;
+
+  return cuda::std::is_same_v<normalized_param_t, cuda::args::constant<ExpectedValue>>
+      && cuda::std::cmp_equal(normalized_param_t::__get_value(), Value);
+}
+
+template <class T>
+inline constexpr T lowest_v = cuda::std::numeric_limits<T>::lowest();
+
+template <class T>
+inline constexpr T highest_v = cuda::std::numeric_limits<T>::max();
+
+using i32 = cuda::std::int32_t;
+using i64 = cuda::std::int64_t;
+using u64 = cuda::std::uint64_t;
+
+CUB_TEST("cub::detail::params::normalize_param derives a constant's element type from its value",
+         "[params][utils]",
+         CUB_SMALL)
+{
+  // The same value spelled with different integer types must select the same kernel. This is the property the
+  // normalization exists for: nvcc 12.4 to 12.6 re-emit `constant<i64{384}>` as `constant<384>` in the host pass.
+  STATIC_REQUIRE(!cuda::std::is_same_v<cuda::args::constant<384>, cuda::args::constant<i64{384}>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::constant<384>>, //
+                                      normalized_t<cuda::args::constant<i64{384}>>>);
+
+  // The element type is the narrowest of int32_t, int64_t, uint64_t that holds the value...
+  STATIC_REQUIRE(constant_normalizes_to<384, i32{384}>());
+  STATIC_REQUIRE(constant_normalizes_to<i64{384}, i32{384}>());
+  STATIC_REQUIRE(constant_normalizes_to<u64{384}, i32{384}>());
+  STATIC_REQUIRE(constant_normalizes_to<0, i32{0}>());
+  STATIC_REQUIRE(constant_normalizes_to<-1, i32{-1}>());
+  STATIC_REQUIRE(constant_normalizes_to<highest_v<i32>, highest_v<i32>>());
+  STATIC_REQUIRE(constant_normalizes_to<lowest_v<i32>, lowest_v<i32>>());
+
+  STATIC_REQUIRE(constant_normalizes_to<i64{highest_v<i32>} + 1, i64{highest_v<i32>} + 1>());
+  STATIC_REQUIRE(constant_normalizes_to<i64{lowest_v<i32>} - 1, i64{lowest_v<i32>} - 1>());
+  STATIC_REQUIRE(constant_normalizes_to<highest_v<i64>, highest_v<i64>>());
+  STATIC_REQUIRE(constant_normalizes_to<lowest_v<i64>, lowest_v<i64>>());
+
+  STATIC_REQUIRE(constant_normalizes_to<u64{highest_v<i64>} + 1, u64{highest_v<i64>} + 1>());
+  STATIC_REQUIRE(constant_normalizes_to<highest_v<u64>, highest_v<u64>>());
+
+  // ... and never the type the argument was spelled with, including the explicit second template argument.
+  STATIC_REQUIRE(constant_normalizes_to<static_cast<signed char>(3), i32{3}>());
+  STATIC_REQUIRE(constant_normalizes_to<static_cast<unsigned char>(3), i32{3}>());
+  STATIC_REQUIRE(constant_normalizes_to<static_cast<short>(3), i32{3}>());
+  STATIC_REQUIRE(constant_normalizes_to<3u, i32{3}>());
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::constant<384, short>>, cuda::args::constant<i32{384}>>);
+
+  // Normalizing an already normalized argument is a no-op, so a dispatch may normalize defensively.
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<normalized_t<cuda::args::constant<i64{384}>>>,
+                                      normalized_t<cuda::args::constant<i64{384}>>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<normalized_t<cuda::args::constant<highest_v<u64>>>>,
+                                      normalized_t<cuda::args::constant<highest_v<u64>>>>);
+}
+
+CUB_TEST("cub::detail::params::normalize_param leaves non-integer constants unchanged", "[params][utils]", CUB_SMALL)
+{
+  // Enumerators and pointers spell their type in any constant expression, so they survive the host re-emission and are
+  // kept as is. `char` and `bool` are not `__cccl_is_integer` types and take the same path.
+  enum class direction
+  {
+    forward = 1
+  };
+
+  using enum_constant_t    = cuda::args::constant<direction::forward>;
+  using pointer_constant_t = cuda::args::constant<(static_cast<const int*>(nullptr))>;
+  using char_constant_t    = cuda::args::constant<'a'>;
+  using bool_constant_t    = cuda::args::constant<true>;
+
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<enum_constant_t>, enum_constant_t>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<pointer_constant_t>, pointer_constant_t>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<char_constant_t>, char_constant_t>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<bool_constant_t>, bool_constant_t>);
+
+  // Constant sequences carry no `auto` non-type template parameter of their own to rewrite.
+  using constant_sequence_t = cuda::args::__constant_sequence<(static_cast<const int*>(nullptr))>;
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<constant_sequence_t>, constant_sequence_t>);
+}
+
+CUB_TEST("cub::detail::params::normalize_param re-types static bounds with the wrapped element type",
+         "[params][utils]",
+         CUB_SMALL)
+{
+  // Same bounds, two spellings: `static_bounds` deduces its endpoint type from the non-type template parameters, so
+  // the wide spelling and the plain one are distinct types until they are re-typed with the element type of the
+  // wrapped argument (`int` for both wrappers below).
+  using wide_bounds_t  = cuda::args::static_bounds<i64{0}, i64{100}>;
+  using plain_bounds_t = cuda::args::static_bounds<0, 100>;
+  STATIC_REQUIRE(!cuda::std::is_same_v<wide_bounds_t, plain_bounds_t>);
+
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::immediate<int, wide_bounds_t>>,
+                                      cuda::args::immediate<int, plain_bounds_t>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::__immediate_sequence<const int*, wide_bounds_t>>,
+                                      cuda::args::__immediate_sequence<const int*, plain_bounds_t>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::deferred<const int*, wide_bounds_t>>,
+                                      cuda::args::deferred<const int*, plain_bounds_t>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::deferred_sequence<const int*, wide_bounds_t>>,
+                                      cuda::args::deferred_sequence<const int*, plain_bounds_t>>);
+
+  // The element type drives the re-typing, not the wrapped handle type.
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::deferred_sequence<const i64*, wide_bounds_t>>,
+                                      cuda::args::deferred_sequence<const i64*, wide_bounds_t>>);
+
+  // `no_bounds` has no endpoints to re-type and passes through.
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::immediate<int>>, cuda::args::immediate<int>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::deferred<const int*>>, //
+                                      cuda::args::deferred<const int*>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<cuda::args::deferred_sequence<const int*>>,
+                                      cuda::args::deferred_sequence<const int*>>);
+
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<normalized_t<cuda::args::immediate<int, wide_bounds_t>>>,
+                                      normalized_t<cuda::args::immediate<int, wide_bounds_t>>>);
+}
+
+CUB_TEST("cub::detail::params::normalize_param passes plain values through", "[params][utils]", CUB_SMALL)
+{
+  // Plain values carry no `auto` non-type template parameter, so their type is kept verbatim -- in particular a
+  // runtime `int64_t` count is never narrowed the way `constant<int64_t{...}>` is.
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<int>, int>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<i64>, i64>);
+  STATIC_REQUIRE(cuda::std::is_same_v<normalized_t<const i64&>, i64>);
+
+  CHECK(cub::detail::params::normalize_param(i64{384}) == 384);
+}
+
+CUB_TEST("cub::detail::params::normalize_param preserves runtime arguments and bounds", "[params][utils]", CUB_SMALL)
+{
+  const auto immediate_arg        = cuda::args::immediate{7, cuda::args::static_bounds<i64{0}, i64{100}>{}};
+  const auto normalized_immediate = cub::detail::params::normalize_param(immediate_arg);
+
+  STATIC_REQUIRE(cuda::std::is_same_v<cuda::std::remove_const_t<decltype(normalized_immediate)>,
+                                      cuda::args::immediate<int, cuda::args::static_bounds<0, 100>>>);
+  CHECK(cuda::args::__access::__arg(normalized_immediate) == 7);
+
+  const int values[]      = {1, 2, 3};
+  const auto sequence_arg = cuda::args::deferred_sequence{
+    +values, cuda::args::static_bounds<i64{1}, i64{3}>{}, cuda::args::runtime_bounds{1, 3}};
+  const auto normalized_sequence = cub::detail::params::normalize_param(sequence_arg);
+
+  STATIC_REQUIRE(cuda::std::is_same_v<cuda::std::remove_const_t<decltype(normalized_sequence)>,
+                                      cuda::args::deferred_sequence<const int*, cuda::args::static_bounds<1, 3>>>);
+  CHECK(cuda::args::__access::__arg(normalized_sequence) == +values);
+  CHECK(cuda::args::__access::__runtime_bounds(normalized_sequence).lower() == 1);
+  CHECK(cuda::args::__access::__runtime_bounds(normalized_sequence).upper() == 3);
+}
+
+// The wrapper reaches the kernel both as a template argument and as a kernel parameter, the way DeviceBatchedTopK
+// passes it. Both are needed to expose the defect below; a kernel that only takes the wrapper as a template argument
+// is re-emitted correctly.
+template <class ParamT>
+__global__ void write_param_value(ParamT param, i64* d_result)
+{
+  *d_result = static_cast<i64>(decltype(param)::__get_value());
+}
+
+template <class ParamT>
+[[nodiscard]] cudaError_t launch_with_param(ParamT param, i64* d_result)
+{
+  write_param_value<<<1, 1>>>(param, d_result);
+  return cudaGetLastError();
+}
+
+// Two functions must name the same specialization from a local `constexpr` int64_t, and they must stay separate
+// functions: cudafe++ re-emits the argument correctly for the function that *first* names the specialization and as
+// the untyped initializer for every other one, so a single call site never fails. Keep both.
+[[nodiscard]] cudaError_t launch_from_first_naming(i64* d_result)
+{
+  constexpr i64 segment_size = 384;
+  return launch_with_param(cub::detail::params::normalize_param(cuda::args::constant<segment_size>{}), d_result);
+}
+
+[[nodiscard]] cudaError_t launch_from_second_naming(i64* d_result)
+{
+  constexpr i64 segment_size = 384;
+  return launch_with_param(cub::detail::params::normalize_param(cuda::args::constant<segment_size>{}), d_result);
+}
+
+CUB_TEST("cub::detail::params::normalize_param names the same kernel in both compilation passes",
+         "[params][utils]",
+         CUB_SMALL)
+{
+  // Regression test for nvcc 12.4 to 12.6: cudafe++ re-emits the host translation unit with the argument of an `auto`
+  // non-type template parameter printed as the untyped initializer of the variable that first named the
+  // specialization, so `constant<segment_size>` reaches the host compiler as `constant<384>` and deduces `int` while
+  // the device pass deduced `long`. The host then instantiates a kernel stub that has no device code and the launch
+  // fails with cudaErrorInvalidDeviceFunction, undiagnosed at compile or link time. Normalizing rebuilds the wrapper
+  // from the value alone, so both passes name the same kernel. Verified to fail on nvcc 12.6 without the
+  // normalization (second launch only) and to pass with it.
+  constexpr i64 segment_size = 384;
+
+  c2h::device_vector<i64> result(1, 0);
+  i64* d_result = thrust::raw_pointer_cast(result.data());
+
+  REQUIRE_CUDART(launch_from_first_naming(d_result));
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  CHECK(result[0] == segment_size);
+
+  result[0] = 0;
+  REQUIRE_CUDART(launch_from_second_naming(d_result));
+  REQUIRE_CUDART(cudaDeviceSynchronize());
+  CHECK(result[0] == segment_size);
+}


### PR DESCRIPTION
Addresses https://github.com/NVIDIA-dev/cccl_private/issues/890

nvcc 12.4 to 12.6 (cudafe++) regenerate the host translation unit with the argument of an `auto` non-type template parameter printed as the untyped initializer of the variable that first named the specialization. With `constexpr int64_t n = 384;`, `cuda::args::constant<n>` reaches the host compiler as `constant<384>` in every other function and deduces `int`, while the device pass deduced `long`. DeviceBatchedTopK threads the wrapper types into the kernel's template arguments and parameter list, so the host instantiates a kernel stub that has no device code and the launch fails with cudaErrorInvalidDeviceFunction (98). Nothing is diagnosed at compile or link time. 12.0 to 12.3 and 12.8 onwards are not affected.

Rebuild every annotated argument in the dispatch from the information that survives the regeneration, the value and the type template arguments, before any kernel or policy-selector type is named: a `constant`'s element type is chosen from its value (int32_t, int64_t or uint64_t, never wider than needed), static bounds are re-typed with the wrapped argument's element type, everything else passes through. Both passes then name the same kernel. On unaffected toolkits the only change is that `constant<int64_t{384}>` and `constant<384>` now select the same 32-bit kernel.
