### PR TITLE
Define Catch2 serialization for cuda::hierarchy_query_result to fix NVHPC compilation failure

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
@@ -14,6 +14,7 @@
 #include <cuda/std/detail/__config>
 
 #include <cuda/__driver/driver_api.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
 
 #include <nv/target>
 
@@ -54,6 +55,17 @@ struct StringMaker<dim3>
   {
     std::ostringstream oss;
     oss << "(" << dims.x << ", " << dims.y << ", " << dims.z << ")";
+    return oss.str();
+  }
+};
+
+template <typename T>
+struct StringMaker<cuda::hierarchy_query_result<T>>
+{
+  static std::string convert(cuda::hierarchy_query_result<T> const& result)
+  {
+    std::ostringstream oss;
+    oss << "(" << result.x << ", " << result.y << ", " << result.z << ")";
     return oss.str();
   }
 };


### PR DESCRIPTION
Define Catch::StringMaker<cuda::hierarchy_query_result<T>> to resolve #11301

## Description

Catch2 determines how to format assertion operands using its `IsStreamInsertable_v<T>` detection. If that check succeeds, `Catch2` selects its generic `StringMaker<T>` and eventually evaluates `stream << value;`.

`cuda::hierarchy_query_result<unsigned>` has implicit conversions to CUDA vector types such as `uint3`, but it does not have its own stream insertion operator. 

The `c2h` test infrastructure also introduces formatting overloads for CUDA types, creating a nontrivial overload-resolution context (causing build failure in #10898).

With NVHPC, Catch2’s SFINAE-based detection incorrectly classifies `hierarchy_query_result<unsigned>` as stream-insertable. Catch2 therefore selects the stream-based formatter, but the actual insertion subsequently fails because no viable `std::ostream& operator<<(std::ostream&, hierarchy_query_result<unsigned> const&)` exists.

In other words, NVHPC reaches inconsistent conclusions between the detection expression and the expression instantiated in Catch2’s formatter. This appears to be an NVHPC overload-resolution or two-phase-lookup issue
 involving the conversion operators and surrounding overload set. Catch2 has encountered related streamability-detection issues involving conversions before (catchorg/Catch2#872).
 
 The specialization added in this PR bypasses the faulty generic streamability detection and formats the three components directly. 
 
This is also the appropriate Catch2 customization mechanism, preserves assertion diagnostics, and has no effect on the production API or runtime behavior.

The standalone reproducer in #11301 demonstrates that NVHPC fails without the specialization and compiles successfully when it is enabled. 

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #11301

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
