### PR TITLE
Correct cuda compute cmake list script to fix incremental build of cuda_cccl package

### DIFF
--- a/python/cuda_cccl/CMakeLists.txt
+++ b/python/cuda_cccl/CMakeLists.txt
@@ -113,8 +113,7 @@ endif()
 
 # -3 generates source for Python 3
 # -M generates depfile
-# -w sets working directory
-set(CYTHON_FLAGS -3 -M -w "${cuda_cccl_SOURCE_DIR}")
+set(CYTHON_FLAGS -3 -M)
 
 message(STATUS "Using Cython ${CYTHON_VERSION}")
 set(pyx_source_file "${cuda_cccl_SOURCE_DIR}/cuda/compute/_bindings_impl.pyx")

--- a/python/cuda_cccl/CMakeLists.txt
+++ b/python/cuda_cccl/CMakeLists.txt
@@ -14,6 +14,14 @@ set(
   "CUDA architectures for CCCL"
 )
 
+# cuda_cccl adds CCCL as a developer sub-build, which requires the global CXX
+# and CUDA dialects to match. Use the package's C++17 baseline for both while
+# allowing callers to override the cache entries explicitly.
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard for cuda_cccl")
+set(CMAKE_CUDA_STANDARD 17 CACHE STRING "CUDA C++ standard for cuda_cccl")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
 project(cuda_cccl DESCRIPTION "Python package cuda_cccl" LANGUAGES CUDA CXX C)
 
 find_package(CUDAToolkit REQUIRED)
@@ -105,16 +113,8 @@ endif()
 
 # -3 generates source for Python 3
 # -M generates depfile
-# -t cythonizes if PYX is newer than preexisting output
 # -w sets working directory
-set(
-  CYTHON_FLAGS
-  -3
-  -M
-  -t
-  -w
-  "${cuda_cccl_SOURCE_DIR}"
-)
+set(CYTHON_FLAGS -3 -M -w "${cuda_cccl_SOURCE_DIR}")
 
 message(STATUS "Using Cython ${CYTHON_VERSION}")
 set(pyx_source_file "${cuda_cccl_SOURCE_DIR}/cuda/compute/_bindings_impl.pyx")
@@ -131,6 +131,7 @@ if (CCCL_PYTHON_USE_V2)
 else()
   set(_backend_suffix "v1")
 endif()
+set(_bindings_backend_pxi_files)
 foreach (
   _pxi_stem
   segmented_reduce_backend
@@ -139,11 +140,16 @@ foreach (
   serialization
   build_config
 )
+  set(
+    _configured_backend_pxi
+    "${CMAKE_CURRENT_BINARY_DIR}/_bindings_${_pxi_stem}.pxi"
+  )
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cuda/compute/_bindings_${_pxi_stem}_${_backend_suffix}.pxi"
-    "${CMAKE_CURRENT_BINARY_DIR}/_bindings_${_pxi_stem}.pxi"
+    "${_configured_backend_pxi}"
     COPYONLY
   )
+  list(APPEND _bindings_backend_pxi_files "${_configured_backend_pxi}")
 endforeach()
 
 # Custom Cython compilation command. `-I ${BINARY_DIR}` lets the .pyx's
@@ -159,7 +165,7 @@ add_custom_command(
     "${pyx_source_file}"
     --output-file "${_generated_extension_src}"
   # gersemi: on
-  DEPENDS "${pyx_source_file}"
+  DEPENDS "${pyx_source_file}" ${_bindings_backend_pxi_files}
   DEPFILE "${_depfile}"
   COMMENT "Cythonizing ${pyx_source_file} for CUDA ${CUDA_VERSION_MAJOR}"
 )

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -6,7 +6,7 @@
 # cmake>=3.30 is needed for FindCUDAToolkit's CUDA::nvfatbin /
 # CUDA::nvfatbin_static imported targets, which the v2 (HostJIT) backend links
 # against. Listed here so isolated builds (pip's default) pick it up.
-requires = ["scikit-build-core>=0.10", "setuptools_scm", "cython>=3.1.0", "cmake>=3.30"]
+requires = ["scikit-build-core>=0.10", "setuptools_scm", "cython>=3.1.0"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Description

python/cuda_cccl/CMakeLists.txt should be setting `CMAKE_CUDA_STANDARD`.

Furthermore, Cythonization target added dependency on PXI input files. Dependency files should be generated into cmake binary folder, not source folder to enable correct dependency tracking working.

With this change repeated build of the project no longer recythonizes the extension and no longer rebuilding the extension saving developer's time.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #11310 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
