### PR TITLE
[libcu++] Improve the implementation of tuple_cat

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -59,20 +59,42 @@ struct __make_tuple_types_flat<_Tuple<_Types...>, __tuple_indices<_Idx...>>
 template <class _Vt, size_t _Np, size_t... _Idx>
 struct __make_tuple_types_flat<array<_Vt, _Np>, __tuple_indices<_Idx...>>
 {
+  // MSVC eagerly substitutes an alias template that discards its index argument and then no longer
+  // sees a pack to expand in `__apply_quals`.
+#if _CCCL_COMPILER(MSVC)
+  template <size_t>
+  struct __value_type
+  {
+    using type _CCCL_NODEBUG = _Vt;
+  };
+  template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
+  using __apply_quals _CCCL_NODEBUG = __tuple_types<__type_call<_ApplyFn, typename __value_type<_Idx>::type>...>;
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
   template <size_t>
   using __value_type _CCCL_NODEBUG = _Vt;
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
   using __apply_quals _CCCL_NODEBUG = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
+#endif // !_CCCL_COMPILER(MSVC)
 };
 
 #if _CCCL_HAS_HOST_STD_LIB()
 template <class _Vt, size_t _Np, size_t... _Idx>
 struct __make_tuple_types_flat<::std::array<_Vt, _Np>, __tuple_indices<_Idx...>>
 {
+#  if _CCCL_COMPILER(MSVC)
+  template <size_t>
+  struct __value_type
+  {
+    using type _CCCL_NODEBUG = _Vt;
+  };
+  template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
+  using __apply_quals _CCCL_NODEBUG = __tuple_types<__type_call<_ApplyFn, typename __value_type<_Idx>::type>...>;
+#  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
   template <size_t>
   using __value_type _CCCL_NODEBUG = _Vt;
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
   using __apply_quals _CCCL_NODEBUG = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
+#  endif // !_CCCL_COMPILER(MSVC)
 };
 #endif // _CCCL_HAS_HOST_STD_LIB()
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
@@ -59,6 +59,11 @@ template <class... _Tuples>
 using __tuple_cat_return_t = decltype(::cuda::std::__tuple_cat_return_type(
   ::cuda::std::__tuple_cat_return_impl(__make_tuple_types_t<remove_cvref_t<_Tuples>>{}...)));
 
+// clang-tidy incorrectly reports "'__t0' used after it was forwarded".
+// Each expansion forwards the tuple only to select get<I>'s cvref-qualified
+// overload for a distinct element.
+// NOLINTBEGIN(bugprone-use-after-move)
+
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tuple, size_t... _Indices>
 [[nodiscard]] _CCCL_API constexpr auto __tuple_cat_impl(__tuple_indices<_Indices...>, _Tuple&& __tuple) noexcept
@@ -119,6 +124,8 @@ _CCCL_REQUIRES(__all_tuple_like<_Tuples...>)
     return ::cuda::std::__tuple_cat_impl(_TupleSize0{}, _TupleSize1{}, ::cuda::std::forward<_Tuples>(__tuples)...);
   }
 }
+
+// NOLINTEND(bugprone-use-after-move)
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_cat.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__tuple_dir/get.h>
 #include <cuda/std/__tuple_dir/make_tuple_types.h>
 #include <cuda/std/__tuple_dir/tie.h>
@@ -29,7 +30,6 @@
 #include <cuda/std/__tuple_dir/tuple_like.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
-#include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 #include <cuda/std/__utility/forward.h>
@@ -38,126 +38,86 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <class _Tp, class _Up>
-struct __tuple_cat_type;
-
-template <class... _Ttypes, class... _Utypes>
-struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...>>
+template <class... _Types>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __tuple_cat_return_impl(__tuple_types<_Types...>) noexcept
+  -> __tuple_types<_Types...>
 {
-  using type _CCCL_NODEBUG = tuple<_Ttypes..., _Utypes...>;
-};
+  return {};
+}
 
-template <class _ResultTuple, bool _Is_Tuple0TupleLike, class... _Tuples>
-struct __tuple_cat_return_1
-{};
-
-template <class... _Types, class _Tuple0>
-struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0>
+template <class... _Types1, class... _Types2, class... _TupleTypes>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto
+__tuple_cat_return_impl(__tuple_types<_Types1...>, __tuple_types<_Types2...>, _TupleTypes... __tail) noexcept
 {
-  using type _CCCL_NODEBUG =
-    typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type;
-};
+  return ::cuda::std::__tuple_cat_return_impl(__tuple_types<_Types1..., _Types2...>{}, __tail...);
+}
 
-template <class... _Types, class _Tuple0, class _Tuple1, class... _Tuples>
-struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0, _Tuple1, _Tuples...>
-    : public __tuple_cat_return_1<
-        typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type,
-        __tuple_like_ext<remove_reference_t<_Tuple1>>,
-        _Tuple1,
-        _Tuples...>
-{};
+template <class... _Types>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL tuple<_Types...> __tuple_cat_return_type(__tuple_types<_Types...>) noexcept;
 
 template <class... _Tuples>
-struct __tuple_cat_return;
+using __tuple_cat_return_t = decltype(::cuda::std::__tuple_cat_return_type(
+  ::cuda::std::__tuple_cat_return_impl(__make_tuple_types_t<remove_cvref_t<_Tuples>>{}...)));
 
-template <class _Tuple0, class... _Tuples>
-struct __tuple_cat_return<_Tuple0, _Tuples...>
-    : public __tuple_cat_return_1<tuple<>, __tuple_like_ext<remove_reference_t<_Tuple0>>, _Tuple0, _Tuples...>
-{};
-
-template <>
-struct __tuple_cat_return<>
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Tuple, size_t... _Indices>
+[[nodiscard]] _CCCL_API constexpr auto __tuple_cat_impl(__tuple_indices<_Indices...>, _Tuple&& __tuple) noexcept
 {
-  using type _CCCL_NODEBUG = tuple<>;
-};
+  using ::cuda::std::get;
+  return ::cuda::std::forward_as_tuple(get<_Indices>(::cuda::std::forward<_Tuple>(__tuple))...);
+}
 
-_CCCL_API constexpr tuple<> tuple_cat()
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Tuple1, class _Tuple2, size_t... _Indices1, size_t... _Indices2, class... _Tuples>
+[[nodiscard]] _CCCL_API constexpr auto __tuple_cat_impl(
+  __tuple_indices<_Indices1...>,
+  __tuple_indices<_Indices2...>,
+  _Tuple1&& __tuple1,
+  _Tuple2&& __tuple2,
+  _Tuples&&... __tuples)
+{
+  using ::cuda::std::get;
+  if constexpr (sizeof...(_Tuples) != 0)
+  {
+    using _TupleSize0 = __make_tuple_indices_t<sizeof...(_Indices1) + sizeof...(_Indices2)>;
+    using _TupleSize1 = __make_tuple_indices_t<tuple_size<remove_reference_t<__type_index_c<0, _Tuples...>>>::value>;
+    return ::cuda::std::__tuple_cat_impl(
+      _TupleSize0{},
+      _TupleSize1{},
+      ::cuda::std::forward_as_tuple(get<_Indices1>(::cuda::std::forward<_Tuple1>(__tuple1))...,
+                                    get<_Indices2>(::cuda::std::forward<_Tuple2>(__tuple2))...),
+      ::cuda::std::forward<_Tuples>(__tuples)...);
+  }
+  else
+  {
+    return ::cuda::std::forward_as_tuple(get<_Indices1>(::cuda::std::forward<_Tuple1>(__tuple1))...,
+                                         get<_Indices2>(::cuda::std::forward<_Tuple2>(__tuple2))...);
+  }
+}
+
+template <class... _Tuples>
+_CCCL_CONCEPT __all_tuple_like = (__tuple_like<_Tuples> && ...);
+
+[[nodiscard]] _CCCL_API constexpr tuple<> tuple_cat()
 {
   return tuple<>();
 }
 
-template <class _Rp, class _Indices, class _Tuple0, class... _Tuples>
-struct __tuple_cat_return_ref_imp;
-
-template <class... _Types, size_t... _I0, class _Tuple0>
-struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0>
+_CCCL_TEMPLATE(class... _Tuples)
+_CCCL_REQUIRES(__all_tuple_like<_Tuples...>)
+[[nodiscard]] _CCCL_API constexpr __tuple_cat_return_t<_Tuples...> tuple_cat(_Tuples&&... __tuples)
 {
-  using _T0 _CCCL_NODEBUG = remove_reference_t<_Tuple0>;
-  using type              = tuple<_Types..., __copy_cvref_t<_Tuple0, tuple_element_t<_I0, _T0>>&&...>;
-};
-
-template <class... _Types, size_t... _I0, class _Tuple0, class _Tuple1, class... _Tuples>
-struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0, _Tuple1, _Tuples...>
-    : public __tuple_cat_return_ref_imp<
-        tuple<_Types..., __copy_cvref_t<_Tuple0, tuple_element_t<_I0, remove_reference_t<_Tuple0>>>&&...>,
-        __make_tuple_indices_t<tuple_size<remove_reference_t<_Tuple1>>::value>,
-        _Tuple1,
-        _Tuples...>
-{};
-
-template <class _Tuple0, class... _Tuples>
-struct __tuple_cat_return_ref
-    : public __tuple_cat_return_ref_imp<tuple<>,
-                                        __make_tuple_indices_t<tuple_size<remove_reference_t<_Tuple0>>::value>,
-                                        _Tuple0,
-                                        _Tuples...>
-{};
-
-template <class _Types, class _I0, class _J0>
-struct __tuple_cat;
-
-template <class... _Types, size_t... _I0, size_t... _J0>
-struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J0...>>
-{
-  template <class _Tuple0>
-  _CCCL_API constexpr typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&>::type
-  _CCCL_STATIC_CALL_OPERATOR([[maybe_unused]] tuple<_Types...> __t, _Tuple0&& __t0)
+  if constexpr (sizeof...(_Tuples) <= 2)
   {
-    return ::cuda::std::forward_as_tuple(
-      ::cuda::std::forward<_Types>(::cuda::std::get<_I0>(__t))...,
-      // clang-tidy incorrectly reports "'__t0' used after it was forwarded".
-      // Each expansion forwards the tuple only to select get<I>'s cvref-qualified
-      // overload for a distinct element.
-      // NOLINTNEXTLINE(bugprone-use-after-move)
-      ::cuda::std::get<_J0>(::cuda::std::forward<_Tuple0>(__t0))...);
+    return ::cuda::std::__tuple_cat_impl(__make_tuple_indices_t<tuple_size<remove_reference_t<_Tuples>>::value>{}...,
+                                         ::cuda::std::forward<_Tuples>(__tuples)...);
   }
-
-  template <class _Tuple0, class _Tuple1, class... _Tuples>
-  _CCCL_API constexpr typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&, _Tuple1&&, _Tuples&&...>::type
-  _CCCL_STATIC_CALL_OPERATOR([[maybe_unused]] tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls)
+  else
   {
-    using _T0 _CCCL_NODEBUG = remove_reference_t<_Tuple0>;
-    using _T1 _CCCL_NODEBUG = remove_reference_t<_Tuple1>;
-    return __tuple_cat<tuple<_Types..., __copy_cvref_t<_Tuple0, tuple_element_t<_J0, _T0>>&&...>,
-                       __make_tuple_indices_t<sizeof...(_Types) + tuple_size<_T0>::value>,
-                       __make_tuple_indices_t<tuple_size<_T1>::value>>()(
-      ::cuda::std::forward_as_tuple(::cuda::std::forward<_Types>(::cuda::std::get<_I0>(__t))...,
-                                    // clang-tidy incorrectly reports "'__t0' used after it was forwarded".
-                                    // Each expansion forwards the tuple only to select get<I>'s cvref-qualified
-                                    // overload for a distinct element.
-                                    // NOLINTNEXTLINE(bugprone-use-after-move)
-                                    ::cuda::std::get<_J0>(::cuda::std::forward<_Tuple0>(__t0))...),
-      ::cuda::std::forward<_Tuple1>(__t1),
-      ::cuda::std::forward<_Tuples>(__tpls)...);
+    using _TupleSize0 = __make_tuple_indices_t<tuple_size<remove_reference_t<__type_index_c<0, _Tuples...>>>::value>;
+    using _TupleSize1 = __make_tuple_indices_t<tuple_size<remove_reference_t<__type_index_c<1, _Tuples...>>>::value>;
+    return ::cuda::std::__tuple_cat_impl(_TupleSize0{}, _TupleSize1{}, ::cuda::std::forward<_Tuples>(__tuples)...);
   }
-};
-
-template <class _Tuple0, class... _Tuples>
-_CCCL_API constexpr typename __tuple_cat_return<_Tuple0, _Tuples...>::type tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)
-{
-  using _T0 _CCCL_NODEBUG = remove_reference_t<_Tuple0>;
-  return __tuple_cat<tuple<>, __tuple_indices<>, __make_tuple_indices_t<tuple_size<_T0>::value>>()(
-    tuple<>(), ::cuda::std::forward<_Tuple0>(__t0), ::cuda::std::forward<_Tuples>(__tpls)...);
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -12,129 +12,126 @@
 
 // template <class... Tuples> tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/complex>
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
-// cuda::std::string not supported
-// #include <cuda/std/array>
-// cuda::std::array not supported
-// #include <cuda/std/string>
-#include <cuda/std/cassert>
+
+#if _CCCL_HAS_HOST_STD_LIB()
+#  include <array>
+#  include <tuple>
+#  include <utility>
+#endif // _CCCL_HAS_HOST_STD_LIB()
 
 #include "MoveOnly.h"
 #include "test_macros.h"
 
-int main(int, char**)
+TEST_FUNC constexpr bool test()
 {
   {
-    cuda::std::tuple<> t = cuda::std::tuple_cat();
-    unused(t); // Prevent unused warning
+    [[maybe_unused]] cuda::std::tuple<> t = cuda::std::tuple_cat();
   }
   {
-    cuda::std::tuple<> t1;
-    cuda::std::tuple<> t2 = cuda::std::tuple_cat(t1);
-    unused(t2); // Prevent unused warning
+    cuda::std::tuple<> t1{};
+    [[maybe_unused]] cuda::std::tuple<> t2 = cuda::std::tuple_cat(t1);
   }
   {
-    cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::tuple<>());
-    unused(t); // Prevent unused warning
+    [[maybe_unused]] cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::tuple<>());
   }
-  // cuda::std::array not supported
-  /*
   {
-      cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::array<int, 0>());
-      unused(t); // Prevent unused warning
+    [[maybe_unused]] cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::array<int, 0>());
   }
-  */
+#if _CCCL_HAS_HOST_STD_LIB()
+  NV_IF_TARGET(NV_IS_HOST,
+               (
+                 { [[maybe_unused]] cuda::std::tuple<> t = cuda::std::tuple_cat(std::tuple<>()); } {
+                   [[maybe_unused]] cuda::std::tuple<> t = cuda::std::tuple_cat(std::array<int, 0>());
+                 }))
+#endif // _CCCL_HAS_HOST_STD_LIB()
   {
     cuda::std::tuple<int> t1(1);
     cuda::std::tuple<int> t = cuda::std::tuple_cat(t1);
     assert(cuda::std::get<0>(t) == 1);
-  }
-
-  {
-    constexpr cuda::std::tuple<> t = cuda::std::tuple_cat();
-    unused(t); // Prevent unused warning
-  }
-  {
-    constexpr cuda::std::tuple<> t1;
-    constexpr cuda::std::tuple<> t2 = cuda::std::tuple_cat(t1);
-    unused(t2); // Prevent unused warning
-  }
-  {
-    constexpr cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::tuple<>());
-    unused(t); // Prevent unused warning
-  }
-  // cuda::std::array not supported
-  /*
-  {
-      constexpr cuda::std::tuple<> t = cuda::std::tuple_cat(cuda::std::array<int, 0>());
-      unused(t); // Prevent unused warning
-  }
-  */
-  {
-    constexpr cuda::std::tuple<int> t1(1);
-    constexpr cuda::std::tuple<int> t = cuda::std::tuple_cat(t1);
-    static_assert(cuda::std::get<0>(t) == 1);
-  }
-  {
-    constexpr cuda::std::tuple<int> t1(1);
-    constexpr cuda::std::tuple<int, int> t = cuda::std::tuple_cat(t1, t1);
-    static_assert(cuda::std::get<0>(t) == 1);
-    static_assert(cuda::std::get<1>(t) == 1);
   }
   {
     cuda::std::tuple<int, MoveOnly> t = cuda::std::tuple_cat(cuda::std::tuple<int, MoveOnly>(1, 2));
     assert(cuda::std::get<0>(t) == 1);
     assert(cuda::std::get<1>(t) == 2);
   }
-  // cuda::std::array not supported
-  /*
   {
-      cuda::std::tuple<int, int, int> t = cuda::std::tuple_cat(cuda::std::array<int, 3>());
-      assert(cuda::std::get<0>(t) == 0);
-      assert(cuda::std::get<1>(t) == 0);
-      assert(cuda::std::get<2>(t) == 0);
+    cuda::std::tuple<int, int, int> t = cuda::std::tuple_cat(cuda::std::array<int, 3>());
+    assert(cuda::std::get<0>(t) == 0);
+    assert(cuda::std::get<1>(t) == 0);
+    assert(cuda::std::get<2>(t) == 0);
   }
-  */
   {
     cuda::std::tuple<int, MoveOnly> t = cuda::std::tuple_cat(cuda::std::pair<int, MoveOnly>(2, 1));
     assert(cuda::std::get<0>(t) == 2);
     assert(cuda::std::get<1>(t) == 1);
   }
   {
-    cuda::std::tuple<> t1;
-    cuda::std::tuple<> t2;
+    cuda::std::tuple<float, float> t = cuda::std::tuple_cat(cuda::std::complex<float>(42.0f, 1337.0f));
+    assert(cuda::std::get<0>(t) == 42.0f);
+    assert(cuda::std::get<1>(t) == 1337.0f);
+  }
+#if _CCCL_HAS_HOST_STD_LIB()
+  NV_IF_TARGET(
+    NV_IS_HOST,
+    (
+      {
+        std::tuple<int> t1(1);
+        cuda::std::tuple<int> t = cuda::std::tuple_cat(t1);
+        assert(cuda::std::get<0>(t) == 1);
+      } {
+        cuda::std::tuple<int, MoveOnly> t = cuda::std::tuple_cat(std::tuple<int, MoveOnly>(1, 2));
+        assert(cuda::std::get<0>(t) == 1);
+        assert(cuda::std::get<1>(t) == 2);
+      } {
+        cuda::std::tuple<int, int, int> t = cuda::std::tuple_cat(std::array<int, 3>());
+        assert(cuda::std::get<0>(t) == 0);
+        assert(cuda::std::get<1>(t) == 0);
+        assert(cuda::std::get<2>(t) == 0);
+      } {
+        cuda::std::tuple<int, MoveOnly> t = cuda::std::tuple_cat(std::pair<int, MoveOnly>(2, 1));
+        assert(cuda::std::get<0>(t) == 2);
+        assert(cuda::std::get<1>(t) == 1);
+      }))
+#endif // _CCCL_HAS_HOST_STD_LIB()
+  {
+    cuda::std::tuple<> t1{};
+    cuda::std::tuple<> t2{};
     cuda::std::tuple<> t3 = cuda::std::tuple_cat(t1, t2);
     unused(t3); // Prevent unused warning
   }
   {
-    cuda::std::tuple<> t1;
+    cuda::std::tuple<> t1{};
     cuda::std::tuple<int> t2(2);
     cuda::std::tuple<int> t3 = cuda::std::tuple_cat(t1, t2);
     assert(cuda::std::get<0>(t3) == 2);
   }
   {
-    cuda::std::tuple<> t1;
+    cuda::std::tuple<> t1{};
     cuda::std::tuple<int> t2(2);
     cuda::std::tuple<int> t3 = cuda::std::tuple_cat(t2, t1);
     assert(cuda::std::get<0>(t3) == 2);
   }
   {
-    cuda::std::tuple<int*> t1;
+    cuda::std::tuple<int*> t1{};
     cuda::std::tuple<int> t2(2);
     cuda::std::tuple<int*, int> t3 = cuda::std::tuple_cat(t1, t2);
     assert(cuda::std::get<0>(t3) == nullptr);
     assert(cuda::std::get<1>(t3) == 2);
   }
   {
-    cuda::std::tuple<int*> t1;
+    cuda::std::tuple<int*> t1{};
     cuda::std::tuple<int> t2(2);
     cuda::std::tuple<int, int*> t3 = cuda::std::tuple_cat(t2, t1);
     assert(cuda::std::get<0>(t3) == 2);
     assert(cuda::std::get<1>(t3) == nullptr);
   }
   {
-    cuda::std::tuple<int*> t1;
+    cuda::std::tuple<int*> t1{};
     cuda::std::tuple<int, double> t2(2, 3.5);
     cuda::std::tuple<int*, int, double> t3 = cuda::std::tuple_cat(t1, t2);
     assert(cuda::std::get<0>(t3) == nullptr);
@@ -142,7 +139,7 @@ int main(int, char**)
     assert(cuda::std::get<2>(t3) == 3.5);
   }
   {
-    cuda::std::tuple<int*> t1;
+    cuda::std::tuple<int*> t1{};
     cuda::std::tuple<int, double> t2(2, 3.5);
     cuda::std::tuple<int, double, int*> t3 = cuda::std::tuple_cat(t2, t1);
     assert(cuda::std::get<0>(t3) == 2);
@@ -219,6 +216,22 @@ int main(int, char**)
     assert(cuda::std::get<3>(t3) == 4);
     assert(cuda::std::get<4>(t3) == 5);
   }
+#if _CCCL_HAS_HOST_STD_LIB()
+  NV_IF_TARGET(NV_IS_HOST,
+               ({
+                 std::pair<MoveOnly, MoveOnly> t1(1, 2);
+                 cuda::std::tuple<int*, MoveOnly> t2(nullptr, 4);
+                 cuda::std::tuple<MoveOnly, MoveOnly, int*, MoveOnly, int> t3 =
+                   cuda::std::tuple_cat(cuda::std::move(t1), cuda::std::move(t2), std::tuple<int>(5));
+                 assert(cuda::std::get<0>(t3) == 1);
+                 assert(cuda::std::get<1>(t3) == 2);
+                 assert(cuda::std::get<2>(t3) == nullptr);
+                 assert(cuda::std::get<3>(t3) == 4);
+                 assert(cuda::std::get<4>(t3) == 5);
+               }
+
+                ))
+#endif // _CCCL_HAS_HOST_STD_LIB()
   {
     // See bug #19616.
     auto t1 = cuda::std::tuple_cat(cuda::std::make_tuple(cuda::std::make_tuple(1)), cuda::std::make_tuple());
@@ -260,5 +273,14 @@ int main(int, char**)
                          const int&>>);
     unused(r);
   }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
   return 0;
 }


### PR DESCRIPTION
It relied on recursive types. Rather than that use recursive functions and type aliases.


### Every event matching `tuple_cat` when compiling MatX

`tuple_cat` were some of the more costly templates in Matx

Inclusive duration, grouped by NVCC primary template / header / function. 506 distinct specializations collapse into these six keys.

| Event | Primary key | Baseline (s) | Current (s) | Δ (s) | Count (base → cur) |
| --- | --- | ---: | ---: | ---: | ---: |
| Instantiating Template Class | `__tuple_cat_return_1` | 195.694 | 0.000 | −195.694 | 39180 → 0 |
| Instantiating Template Function | `__tuple_cat_return_impl` | 0.000 | 171.677 | +171.677 | 0 → 38708 |
| Instantiating Template Class | `__tuple_cat_return` | 41.981 | 0.000 | −41.981 | 7082 → 0 |
| Instantiating Template Class | `__tuple_cat_type` | 3.069 | 0.000 | −3.069 | 25492 → 0 |
| Processing Header File | `tuple_cat.h` | 3.660 | 1.530 | −2.130 | 626 → 626 |
| Scanning Function Body | `tuple_cat()` | 0.047 | 0.046 | −0.002 | 626 → 626 |

Old recursive class helpers (`__tuple_cat_return_1`, `__tuple_cat_return`, `__tuple_cat_type`) drop to zero. They are replaced by `__tuple_cat_return_impl` at 171.7 s inclusive — cheaper than the 195.7 s class it replaces, plus the extra ~45 s of the other two helpers.