### PR TITLE
[cudax] Don't require mapping's and synchronizer's special funcs to be `const`

### DIFF
--- a/cudax/include/cuda/experimental/__group/group.cuh
+++ b/cudax/include/cuda/experimental/__group/group.cuh
@@ -54,7 +54,7 @@ template <class _Unit, class _ParentGroup, class _MappingResult, class _Synchron
   const _Unit& __unit,
   const _ParentGroup& __parent,
   const _MappingResult& __mapping_result,
-  const _Synchronizer& __synchronizer) noexcept
+  _Synchronizer&& __synchronizer) noexcept
 {
   using _ParentMappingResult  = typename _ParentGroup::__mapping_result_type;
   using _SynchronizerInstance = decltype(__synchronizer.make_instance(__unit, __parent, __mapping_result));
@@ -77,7 +77,7 @@ using __group_synchronizer_instance_t = decltype(::cuda::experimental::__make_sy
   ::cuda::std::declval<const _Unit&>(),
   ::cuda::std::declval<const _ParentGroup&>(),
   ::cuda::std::declval<const _MappingResult&>(),
-  ::cuda::std::declval<const _Synchronizer&>()));
+  ::cuda::std::declval<_Synchronizer>()));
 
 template <class _Unit, class _ParentGroup, class _MappingResult, class _SynchronizerInstance>
 class group
@@ -107,14 +107,12 @@ public:
       std::is_same_v<_SynchronizerInstance,
                      __group_synchronizer_instance_t<_Unit, _ParentGroup, _MappingResult, _Synchronizer>>)
   _CCCL_DEVICE_API explicit group(
-    const _Unit& __unit,
-    const _ParentGroup& __parent,
-    const _Mapping& __mapping,
-    const _Synchronizer& __synchronizer) noexcept
+    const _Unit& __unit, const _ParentGroup& __parent, _Mapping&& __mapping, _Synchronizer&& __synchronizer) noexcept
       : __hier_{__parent.hierarchy()}
-      , __mapping_result_{::cuda::experimental::__do_group_mapping(__unit, __parent, __mapping)}
-      , __synchronizer_instance_{
-          ::cuda::experimental::__make_synchronizer_instance(__unit, __parent, __mapping_result_, __synchronizer)}
+      , __mapping_result_{::cuda::experimental::__do_group_mapping(
+          __unit, __parent, ::cuda::std::forward<_Mapping>(__mapping))}
+      , __synchronizer_instance_{::cuda::experimental::__make_synchronizer_instance(
+          __unit, __parent, __mapping_result_, ::cuda::std::forward<_Synchronizer>(__synchronizer))}
   {}
 
   // Groups can't be copied, moved nor assigned.
@@ -237,7 +235,7 @@ _CCCL_TEMPLATE(
   class _SynchronizerInstance = __group_synchronizer_instance_t<_Unit, _ParentGroup, _MappingResult, _Synchronizer>)
 _CCCL_REQUIRES(__is_hierarchy_level_v<_Unit> _CCCL_AND is_group<_ParentGroup> _CCCL_AND
                  __unit_same_as_or_below_v<_Unit, typename _ParentGroup::unit_type>)
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group(const _Unit&, const _ParentGroup&, const _Mapping&, const _Synchronizer&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES group(const _Unit&, const _ParentGroup&, _Mapping&&, _Synchronizer&&)
   -> group<_Unit, _ParentGroup, _MappingResult, _SynchronizerInstance>;
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/binary_partition.cuh
@@ -46,7 +46,7 @@ class binary_partition
 {
   static_assert(::cuda::std::is_move_constructible_v<_Fn>, "_Fn must be move constructible");
 
-  mutable _Fn __fn_;
+  _Fn __fn_;
 
 public:
   _CCCL_DEVICE_API explicit binary_partition(_Fn __fn) noexcept(::cuda::std::is_nothrow_move_constructible_v<_Fn>)
@@ -55,8 +55,8 @@ public:
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
   [[nodiscard]] _CCCL_DEVICE_API auto
-  map(const _Unit&, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const
-    noexcept(::cuda::std::is_nothrow_invocable_v<_Fn, const _PrevMappingResult&>)
+  map(const _Unit&, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept(
+    ::cuda::std::is_nothrow_invocable_v<_Fn&, const _PrevMappingResult&>)
   {
     static_assert(::cuda::std::is_same_v<_Unit, thread_level>, "binary_partition can only group threads");
     static_assert(::cuda::std::is_same_v<typename _ParentGroup::level_type, warp_level>,

--- a/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
@@ -44,7 +44,7 @@ class composite_mapping
 
   template <::cuda::std::size_t _Ip = 0, class _Unit, class _ParentGroup, class _PrevMappingResult>
   [[nodiscard]] _CCCL_DEVICE_API auto __map_impl(
-    const _Unit& __unit, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const noexcept
+    const _Unit& __unit, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept
   {
     const auto __result = ::cuda::std::get<_Ip>(__mappings_).map(__unit, __parent, __prev_mapping_result);
     if constexpr (_Ip + 1 < sizeof...(_Mappings))
@@ -70,7 +70,7 @@ public:
 
   template <class _Unit, class _ParentGroup, class _PrevMappingResult>
   [[nodiscard]] _CCCL_DEVICE_API auto
-  map(const _Unit& __unit, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) const noexcept
+  map(const _Unit& __unit, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept
   {
     return __map_impl(__unit, __parent, __prev_mapping_result);
   }

--- a/cudax/include/cuda/experimental/__group/virtual_group.cuh
+++ b/cudax/include/cuda/experimental/__group/virtual_group.cuh
@@ -51,7 +51,7 @@ namespace cuda::experimental
 {
 template <class _Unit, class _ParentGroup, class _Mapping>
 [[nodiscard]] _CCCL_DEVICE_API constexpr auto
-__do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
+__do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, _Mapping&& __mapping) noexcept
 {
   using _ParentMappingResult = typename _ParentGroup::__mapping_result_type;
   using _InitMappingResult =
@@ -92,9 +92,7 @@ __do_group_mapping(const _Unit& __unit, const _ParentGroup& __parent, const _Map
 
 template <class _Unit, class _ParentGroup, class _Mapping>
 using __group_mapping_result_t = decltype(::cuda::experimental::__do_group_mapping(
-  ::cuda::std::declval<const _Unit&>(),
-  ::cuda::std::declval<const _ParentGroup&>(),
-  ::cuda::std::declval<const _Mapping&>()));
+  ::cuda::std::declval<const _Unit&>(), ::cuda::std::declval<const _ParentGroup&>(), ::cuda::std::declval<_Mapping>()));
 
 template <class _Unit, class _ParentGroup, class _MappingResult>
 class virtual_group
@@ -122,9 +120,10 @@ public:
   _CCCL_TEMPLATE(class _Mapping)
   _CCCL_REQUIRES(::cuda::std::is_same_v<_MappingResult, __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>>)
   _CCCL_DEVICE_API explicit virtual_group(
-    const _Unit& __unit, const _ParentGroup& __parent, const _Mapping& __mapping) noexcept
+    const _Unit& __unit, const _ParentGroup& __parent, _Mapping&& __mapping) noexcept
       : __hier_{__parent.hierarchy()}
-      , __mapping_result_{::cuda::experimental::__do_group_mapping(__unit, __parent, __mapping)}
+      , __mapping_result_{::cuda::experimental::__do_group_mapping(
+          __unit, __parent, ::cuda::std::forward<_Mapping>(__mapping))}
       , __synchronizer_instance_{__parent.__synchronizer_instance().view()}
   {
     // todo(dabayer): Remove this if we allow non-exhaustive virtual groups.
@@ -214,7 +213,7 @@ _CCCL_TEMPLATE(class _Unit,
                class _MappingResult = __group_mapping_result_t<_Unit, _ParentGroup, _Mapping>)
 _CCCL_REQUIRES(__is_hierarchy_level_v<_Unit> _CCCL_AND is_group<_ParentGroup> _CCCL_AND
                  __unit_same_as_or_below_v<_Unit, typename _ParentGroup::unit_type>)
-_CCCL_DEDUCTION_GUIDE_ATTRIBUTES virtual_group(const _Unit&, const _ParentGroup&, const _Mapping&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES virtual_group(const _Unit&, const _ParentGroup&, _Mapping&&)
   -> virtual_group<_Unit, _ParentGroup, _MappingResult>;
 } // namespace cuda::experimental
 

--- a/cudax/test/group/mapping/binary_partition.cu
+++ b/cudax/test/group/mapping/binary_partition.cu
@@ -68,12 +68,11 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(
-        !noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(!noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      const Mapping mapping{Pred{}};
+      Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 
@@ -109,12 +108,11 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(
-        noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      const Mapping mapping{Pred{}};
+      Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 
@@ -150,12 +148,11 @@ __device__ void test_binary_partition(Config config)
       const cudax::this_warp parent_group{config};
       const ThreadsInWarpMappingResult prev_mapping_result;
 
-      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<const Mapping>().map(
+      static_assert(cudax::__group_mapping_result<decltype(cuda::std::declval<Mapping>().map(
                       cuda::gpu_thread, parent_group, prev_mapping_result))>);
-      static_assert(
-        !noexcept(cuda::std::declval<const Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
+      static_assert(!noexcept(cuda::std::declval<Mapping>().map(cuda::gpu_thread, parent_group, prev_mapping_result)));
 
-      const Mapping mapping{Pred{}};
+      Mapping mapping{Pred{}};
       auto result  = mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result);
       using Result = decltype(result);
 

--- a/cudax/test/group/mapping/composite_mapping.cu
+++ b/cudax/test/group/mapping/composite_mapping.cu
@@ -58,7 +58,7 @@ __device__ void test_composite_mapping(const Mapping1& mapping1, const Mapping2&
   {
     const cudax::this_warp parent_group{config};
     const ThreadsInWarpMappingResult prev_mapping_result;
-    const cudax::composite_mapping mapping{mapping1, mapping2};
+    cudax::composite_mapping mapping{mapping1, mapping2};
 
     static_assert(
       cudax::__group_mapping_result<decltype(mapping.map(cuda::gpu_thread, parent_group, prev_mapping_result))>);


### PR DESCRIPTION
Previously, all mapping's and synchronizer's special functions were required to be `const`, because we stored the object directly in the group. However, this is no longer the case, because we only store the mapping result/synchronizer instance, thus we can allow them to be non-const and we can get rid of some of the `mutable` members.