### PR TITLE
[infra]: pin CTK in TSAN CI

### DIFF
--- a/ci/test_cuda_compute_minimal_python_tsan.sh
+++ b/ci/test_cuda_compute_minimal_python_tsan.sh
@@ -34,7 +34,15 @@ fi
 # export is harmless there.
 export CCCL_C_PARALLEL_SANITIZE_THREAD=1
 
-cuda_major_version=$(nvcc --version | grep release | awk '{print $6}' | tr -d ',' | cut -d '.' -f 1 | cut -d 'V' -f 2)
+# Pin the pip cuda-toolkit wheels to the container's CTK minor (this also sets
+# cuda_major_version), like every other Python lane. This lane in particular
+# cannot run unpinned: the pip libnvrtc finds its libnvrtc-builtins through its
+# own RUNPATH, but under the preloaded TSan runtime dlopen is intercepted and
+# that RUNPATH is not honored, so the builtins are only found via the system
+# toolkit on LD_LIBRARY_PATH -- which only works when the pip NVRTC minor
+# matches the container's. Unpinned, a newer 13.x wheel on PyPI breaks every
+# compile with "failed to open libnvrtc-builtins.so.<minor>".
+pin_cuda_toolkit "${ctk_mode}"
 
 # Setup Python environment
 setup_python_env "${py_version}"


### PR DESCRIPTION
After the CTK 13.4 release, this lane started installing NVRTC 13.4 through pip. TSan intercepts dlopen, so libnvrtc.so’s RUNPATH is not honored when loading libnvrtc-builtins.so. The lookup falls back to the system toolkit, but the container has CTK 13.3, causing the lane to fail.

This PR calls pin_cuda_toolkit to pin the pip-installed CUDA toolkit to the container’s major/minor version, matching the other Python lanes.