### PR TITLE
[cudax] Fix `.map(...)` for empty `composite_mapping`

### DIFF
--- a/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
+++ b/cudax/include/cuda/experimental/__group/mapping/composite_mapping.cuh
@@ -72,7 +72,14 @@ public:
   [[nodiscard]] _CCCL_DEVICE_API auto
   map(const _Unit& __unit, const _ParentGroup& __parent, const _PrevMappingResult& __prev_mapping_result) noexcept
   {
-    return __map_impl(__unit, __parent, __prev_mapping_result);
+    if constexpr (sizeof...(_Mappings) > 0)
+    {
+      return __map_impl(__unit, __parent, __prev_mapping_result);
+    }
+    else
+    {
+      return __prev_mapping_result;
+    }
   }
 };
 


### PR DESCRIPTION
We need to make sure the number of stored mappings is at least 1.