### PR TITLE
Discuss AI and change ownership in review docs

### DIFF
--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -198,6 +198,18 @@ Further recommended reading for successful PR reviews:
 - `How to Do Code Reviews Like a Human (Part One) <https://mtlynch.io/human-code-reviews-1/>`_
 - `How to Do Code Reviews Like a Human (Part Two) <https://mtlynch.io/human-code-reviews-2/>`_
 
+We welcome the use of AI tools to assist in code authoring and code review.
+However, at the end of the day, the (human) CCCL maintainers need to understand a contribution
+and its impact in order to maintain it.
+Effectively, we meed to own the change.
+Therefore, it is the responsibility of the author to motivate the change
+and help the (human) reviewer build a mental model of the proposed change.
+This may include additional resources, such as drawings, charts, benchmarks, slides, or talks,
+as well as more tests or documentation.
+We want to ship stable code of high quality and performance.
+The CUDA community relies on us.
+The review is our best chance to maintain a high bar long-term.
+
 Thank You
 -----------
 

--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -201,7 +201,7 @@ Further recommended reading for successful PR reviews:
 We welcome the use of AI tools to assist in code authoring and code review.
 However, at the end of the day, the (human) CCCL maintainers need to understand a contribution
 and its impact in order to maintain it.
-Effectively, we meed to own the change.
+Effectively, we need to own the change.
 Therefore, it is the responsibility of the author to motivate the change
 and help the (human) reviewer build a mental model of the proposed change.
 This may include additional resources, such as drawings, charts, benchmarks, slides, or talks,


### PR DESCRIPTION
I talked to @gevtushenko a few days ago about the increase of AI-assisted contributions and how we cope as maintainers/reviewers. He reassured me, that we should not aim to increase our developer velocity by stepping down on the quality. We need to continue to own the changes we merge into CCCL, despite the increase of incoming PRs. Our users rely on our quality.

So I drafted a few sentences into the review documentation to catch that.

Please let me know if you don't agree with any wording, I am happy to change it!