### PR TITLE
Add BlockScan::Sum benchmark covering extended floating-point types

### DIFF
--- a/cub/benchmarks/bench/scan/block_scan_base.cuh
+++ b/cub/benchmarks/bench/scan/block_scan_base.cuh
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/block/block_scan.cuh>
+
+#include <cuda_runtime_api.h>
+#include <device_side_benchmark.cuh>
+#include <nvbench_helper.cuh>
+
+template <int BlockSize>
+struct benchmark_op_t
+{
+  template <typename T>
+  __device__ __forceinline__ T operator()(T thread_data) const
+  {
+    using BlockScan   = cub::BlockScan<T, BlockSize>;
+    using TempStorage = typename BlockScan::TempStorage;
+    __shared__ TempStorage temp_storage;
+    T inclusive_output;
+    BlockScan{temp_storage}.InclusiveScan(thread_data, inclusive_output, op_t{});
+    // BlockScan::TempStorage is real shared memory, unlike WarpScanShfl's empty type, so the
+    // chained calls in benchmark_kernel all reuse one instance of it. BlockScan documents that
+    // "a subsequent __syncthreads() threadblock barrier should be invoked after calling this
+    // method if the collective's temporary storage is to be reused or repurposed", so the
+    // barrier is required here for correctness, not as a precaution. It therefore falls inside
+    // the timed region, which is the honest place for it: any caller that reuses one
+    // TempStorage in a loop pays the same barrier every iteration.
+    __syncthreads();
+    return inclusive_output;
+  }
+};
+
+template <typename T>
+void block_scan(nvbench::state& state, nvbench::type_list<T>)
+{
+  constexpr int block_size    = 256;
+  constexpr int unroll_factor = 128; // compromise between compile time and noise
+  const auto& kernel          = benchmark_kernel<block_size, unroll_factor, benchmark_op_t<block_size>, T>;
+  const int num_SMs     = state.get_device().value().get_number_of_sms(); // NOLINT(bugprone-unchecked-optional-access)
+  int max_blocks_per_SM = 0;
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_SM, kernel, block_size, 0));
+  const int grid_size = max_blocks_per_SM * num_SMs;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch&) {
+    kernel<<<grid_size, block_size>>>(benchmark_op_t<block_size>{});
+  });
+}
+
+NVBENCH_BENCH_TYPES(block_scan, NVBENCH_TYPE_AXES(value_types)).set_name("base").set_type_axes_names({"T{ct}"});

--- a/cub/benchmarks/bench/scan/block_scan_base.cuh
+++ b/cub/benchmarks/bench/scan/block_scan_base.cuh
@@ -41,6 +41,13 @@ void block_scan(nvbench::state& state, nvbench::type_list<T>)
   const int num_SMs     = state.get_device().value().get_number_of_sms(); // NOLINT(bugprone-unchecked-optional-access)
   int max_blocks_per_SM = 0;
   NVBENCH_CUDA_CALL_NOEXCEPT(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_SM, kernel, block_size, 0));
+  // NVBENCH_CUDA_CALL_NOEXCEPT swallows a failed occupancy query, which would leave
+  // max_blocks_per_SM at 0 and turn the launch into a bare cudaErrorInvalidConfiguration.
+  if (max_blocks_per_SM == 0)
+  {
+    state.skip("Skipping: no resident blocks for this type on this device.");
+    return;
+  }
   const int grid_size = max_blocks_per_SM * num_SMs;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch&) {
     kernel<<<grid_size, block_size>>>(benchmark_op_t<block_size>{});

--- a/cub/benchmarks/bench/scan/block_scan_sum.cu
+++ b/cub/benchmarks/bench/scan/block_scan_sum.cu
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <nvbench_helper.cuh>
+
+using value_types = nvbench::type_list<
+  int8_t,
+  int16_t,
+  int32_t,
+  int64_t,
+#if _CCCL_HAS_INT128()
+  int128_t,
+#endif
+#if _CCCL_HAS_NVFP16() && _CCCL_CTK_AT_LEAST(12, 2)
+  __half,
+#endif
+#if _CCCL_HAS_NVBF16() && _CCCL_CTK_AT_LEAST(12, 2)
+  __nv_bfloat16,
+#endif
+  float,
+  double
+#if _CCCL_HAS_FLOAT128()
+  ,
+  __float128
+#endif
+  >;
+
+using op_t = ::cuda::std::plus<>;
+#include "block_scan_base.cuh"


### PR DESCRIPTION
Block-level counterpart to #10768, covering the block-level half of item 2 in #9587. Same type axis, including `__half` and `__nv_bfloat16`, plus a `BlockSize` axis over 64 to 1024. One new file, no CMake change since the benchmark directory is globbed.

`BlockScan::TempStorage` is shared memory, so the chained calls in `benchmark_kernel` reuse one instance with a `__syncthreads()` before each reuse, as discussed on #10768. It stays inside the timed region to mimic realistic workloads.

`BlockSize` is a template parameter of `BlockScan`, so each axis value dispatches to its own instantiation.

`benchmark_kernel` takes an `Unroll` parameter so the workload and the unrolling vary independently: the action runs `UnrollFactor` times either way, and `Unroll` only chooses `#pragma unroll UnrollFactor` or `#pragma unroll 1`. It defaults to true, and the generated code for the warp benchmarks is unchanged (same registers, spills and shared memory on all nine kernels; only the mangled name gains the new parameter). This one passes false. At a fixed workload of 128, registers move by at most 2 across all 45 configurations and spills are identical, so the `__syncthreads()` in each iteration appears to block cross-iteration scheduling either way, but unrolling inflates the large block sizes: normalised for clock, rolling is 0.98-0.99x at 64 to 256 and 0.72-0.84x at 512 and 1024. Compile time for this file drops from 118 s to 20 s.

## Results

GPU time per launch in µs. This is an sm_86 laptop GPU with `--throttle-threshold 0`. The card throttles under sustained load, so each sweep is taken from an idle card after a short warmup; three such sweeps agree to 0.4% median. The first configuration measured, I8 at 64, still carries a GPU wake-up cost and reads a few percent high. The numbers are only meaningful compared to each other, and the grid size comes from occupancy, so columns aren't normalized per element.

| T | 64 | 128 | 256 | 512 | 1024 |
|---|---|---|---|---|---|
| I8 | 55.7 | 56.6 | 53.2 | 63.1 | 67.3 |
| I16 | 50.0 | 56.3 | 54.0 | 59.5 | 68.5 |
| I32 | 44.1 | 55.5 | 53.6 | 57.6 | 69.4 |
| I64 | 63.6 | 76.7 | 71.0 | 65.9 | 75.8 |
| I128 | 193.4 | 174.4 | 121.0 | 132.1 | 138.9 |
| F16 | 50.0 | 60.5 | 58.6 | 63.5 | 75.8 |
| BF16 | 49.3 | 60.1 | 58.2 | 63.1 | 75.8 |
| F32 | 47.4 | 59.6 | 56.0 | 59.4 | 73.0 |
| F64 | 186.5 | 197.7 | 170.0 | 186.9 | 286.1 |

Narrow types are fastest at 64, while I128 and F64 are fastest at 256.

<details>
<summary>Full nvbench output</summary>

| T{ct} |  BlockSize  | Samples |  CPU Time  | Noise |  GPU Time  | Noise |
|-------|-------------|---------|------------|-------|------------|-------|
|    I8 |    2^6 = 64 |   8976x |  75.301 us | 19.86% |  55.733 us | 19.86% |
|    I8 |   2^7 = 128 |   8848x |  76.488 us | 4.16% |  56.584 us | 4.16% |
|    I8 |   2^8 = 256 |   9408x |  72.201 us | 4.29% |  53.157 us | 4.29% |
|    I8 |   2^9 = 512 |   7936x |  82.549 us | 3.33% |  63.132 us | 3.33% |
|    I8 | 2^10 = 1024 |   7440x |  85.776 us | 3.18% |  67.270 us | 3.18% |
|   I16 |    2^6 = 64 |  10000x |  69.714 us | 4.07% |  50.042 us | 4.07% |
|   I16 |   2^7 = 128 |   8880x |  75.327 us | 3.69% |  56.349 us | 3.69% |
|   I16 |   2^8 = 256 |   9280x |  73.163 us | 3.70% |  53.971 us | 3.70% |
|   I16 |   2^9 = 512 |   8416x |  78.680 us | 3.36% |  59.471 us | 3.36% |
|   I16 | 2^10 = 1024 |   7312x |  87.511 us | 2.89% |  68.477 us | 2.89% |
|   I32 |    2^6 = 64 |  11360x |  63.155 us | 4.70% |  44.051 us | 4.70% |
|   I32 |   2^7 = 128 |   9024x |  74.387 us | 3.76% |  55.461 us | 3.76% |
|   I32 |   2^8 = 256 |   9344x |  72.494 us | 3.87% |  53.556 us | 3.87% |
|   I32 |   2^9 = 512 |   8688x |  77.818 us | 3.04% |  57.636 us | 3.04% |
|   I32 | 2^10 = 1024 |   7216x |  89.174 us | 2.75% |  69.414 us | 2.75% |
|   I64 |    2^6 = 64 |   7872x |  83.357 us | 2.89% |  63.611 us | 2.89% |
|   I64 |   2^7 = 128 |   6528x |  96.444 us | 2.50% |  76.662 us | 2.50% |
|   I64 |   2^8 = 256 |   7056x |  90.502 us | 2.01% |  71.000 us | 2.01% |
|   I64 |   2^9 = 512 |   7600x |  85.688 us | 1.71% |  65.917 us | 1.71% |
|   I64 | 2^10 = 1024 |   6608x |  95.476 us | 1.15% |  75.816 us | 1.15% |
|  I128 |    2^6 = 64 |   2592x | 213.328 us | 1.31% | 193.367 us | 1.31% |
|  I128 |   2^7 = 128 |   2880x | 194.531 us | 0.69% | 174.407 us | 0.69% |
|  I128 |   2^8 = 256 |   4144x | 141.065 us | 0.91% | 121.021 us | 0.91% |
|  I128 |   2^9 = 512 |   3792x | 152.028 us | 1.35% | 132.059 us | 1.35% |
|  I128 | 2^10 = 1024 |   3600x | 158.861 us | 0.78% | 138.924 us | 0.78% |
|   F16 |    2^6 = 64 |  10016x |  69.844 us | 2.34% |  49.978 us | 2.34% |
|   F16 |   2^7 = 128 |   8272x |  80.335 us | 1.77% |  60.471 us | 1.77% |
|   F16 |   2^8 = 256 |   8544x |  78.298 us | 1.82% |  58.553 us | 1.82% |
|   F16 |   2^9 = 512 |   7888x |  83.216 us | 1.57% |  63.479 us | 1.57% |
|   F16 | 2^10 = 1024 |   6608x |  95.542 us | 1.56% |  75.760 us | 1.56% |
|  BF16 |    2^6 = 64 |  10144x |  69.173 us | 3.39% |  49.336 us | 3.39% |
|  BF16 |   2^7 = 128 |   8320x |  79.764 us | 1.78% |  60.108 us | 1.78% |
|  BF16 |   2^8 = 256 |   8592x |  77.925 us | 1.90% |  58.203 us | 1.90% |
|  BF16 |   2^9 = 512 |   7936x |  82.860 us | 1.68% |  63.097 us | 1.68% |
|  BF16 | 2^10 = 1024 |   6608x |  95.578 us | 1.36% |  75.760 us | 1.36% |
|   F32 |    2^6 = 64 |  10560x |  67.167 us | 2.03% |  47.386 us | 2.03% |
|   F32 |   2^7 = 128 |   8400x |  79.446 us | 1.64% |  59.580 us | 1.64% |
|   F32 |   2^8 = 256 |   8944x |  75.780 us | 2.12% |  55.967 us | 2.12% |
|   F32 |   2^9 = 512 |   8416x |  79.189 us | 1.64% |  59.417 us | 1.64% |
|   F32 | 2^10 = 1024 |   6848x |  92.709 us | 1.44% |  73.018 us | 1.44% |
|   F64 |    2^6 = 64 |   2681x | 206.289 us | 0.50% | 186.507 us | 0.50% |
|   F64 |   2^7 = 128 |   2544x | 217.507 us | 0.59% | 197.673 us | 0.59% |
|   F64 |   2^8 = 256 |   2944x | 189.774 us | 0.65% | 169.962 us | 0.65% |
|   F64 |   2^9 = 512 |   2676x | 206.670 us | 0.42% | 186.874 us | 0.42% |
|   F64 | 2^10 = 1024 |   1748x | 306.096 us | 0.37% | 286.116 us | 0.37% |

</details>

## BlockReduce

Not included. `Sum` is only defined in thread 0, and `benchmark_kernel` chains the result across all threads. Broadcasting it through shared memory would put a second barrier in the timed region. Is that acceptable, or would you rather the reduce benchmark break the chain some other way?
