### PR TITLE
[cudax] Implement `cudax::coalesced_group`

### DIFF
--- a/cudax/include/cuda/experimental/__group/coalesced_group.cuh
+++ b/cudax/include/cuda/experimental/__group/coalesced_group.cuh
@@ -98,7 +98,7 @@ public:
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
   {
-    return false;
+    return true;
   }
 
   [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_contiguous() noexcept

--- a/cudax/include/cuda/experimental/__group/coalesced_group.cuh
+++ b/cudax/include/cuda/experimental/__group/coalesced_group.cuh
@@ -1,0 +1,245 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_EXPERIMENTAL___GROUP_COALESCED_GROUP_CUH
+#define _CUDA_EXPERIMENTAL___GROUP_COALESCED_GROUP_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__warp/lane_mask.h>
+#include <cuda/hierarchy>
+#include <cuda/std/__bit/popcount.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__fwd/span.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/experimental/__group/fwd.cuh>
+#include <cuda/experimental/__group/mapping/mapping_result.cuh>
+#include <cuda/experimental/__group/synchronizer/lane_synchronizer.cuh>
+#include <cuda/experimental/__group/traits.cuh>
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if !defined(_CCCL_DOXYGEN_INVOKED)
+
+namespace cuda::experimental
+{
+class __coalesced_mapping_result
+{
+  ::cuda::device::lane_mask __lane_mask_;
+  ::cuda::std::uint32_t __unit_count_;
+  ::cuda::std::uint32_t __unit_rank_;
+
+public:
+  _CCCL_DEVICE_API __coalesced_mapping_result() noexcept
+      : __lane_mask_{::cuda::device::lane_mask::all_active()}
+      , __unit_count_{static_cast<::cuda::std::uint32_t>(::cuda::std::popcount(__lane_mask_.value()))}
+      , __unit_rank_{static_cast<::cuda::std::uint32_t>(
+          ::cuda::std::popcount((__lane_mask_ & ::cuda::device::lane_mask::all_less()).value()))}
+  {}
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_group_count() noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_count() const noexcept
+  {
+    return 1;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t group_rank() const noexcept
+  {
+    return 0;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_unit_count() noexcept
+  {
+    return ::cuda::std::dynamic_extent;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_count() const noexcept
+  {
+    return __unit_count_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint32_t unit_rank() const noexcept
+  {
+    return __unit_rank_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::device::lane_mask lane_mask() const noexcept
+  {
+    return __lane_mask_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API bool is_valid() const noexcept
+  {
+    return true;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_exhaustive() noexcept
+  {
+    return false;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr bool is_always_contiguous() noexcept
+  {
+    return false;
+  }
+};
+
+template <class _Hierarchy>
+class coalesced_group
+{
+  using _MappingResult _CCCL_NODEBUG        = __coalesced_mapping_result;
+  using _SynchronizerInstance _CCCL_NODEBUG = lane_synchronizer::__synchronizer_instance;
+
+  _Hierarchy __hier_;
+  _MappingResult __mapping_result_{};
+  _SynchronizerInstance __synchronizer_instance_{};
+
+public:
+  using unit_type             = thread_level;
+  using level_type            = warp_level;
+  using hierarchy_type        = _Hierarchy;
+  using __mapping_result_type = _MappingResult;
+
+  _CCCL_TEMPLATE(class _HierarchyLike)
+  _CCCL_REQUIRES(::cuda::std::is_same_v<_Hierarchy, __hierarchy_type_of<_HierarchyLike>>)
+  _CCCL_DEVICE_API explicit coalesced_group(const _HierarchyLike& __hier_like) noexcept
+      : __hier_{::cuda::__unpack_hierarchy_if_needed(__hier_like)}
+  {}
+
+  // Groups can't be copied, moved nor assigned.
+  coalesced_group(const coalesced_group&)            = delete;
+  coalesced_group(coalesced_group&&)                 = delete;
+  coalesced_group& operator=(const coalesced_group&) = delete;
+  coalesced_group& operator=(coalesced_group&&)      = delete;
+
+  [[nodiscard]] _CCCL_DEVICE_API const hierarchy_type& hierarchy() const noexcept
+  {
+    return __hier_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API _MappingResult __mapping_result() const noexcept
+  {
+    return __mapping_result_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API const _SynchronizerInstance& __synchronizer_instance() const noexcept
+  {
+    return __synchronizer_instance_;
+  }
+
+  // todo(dabayer): Do we want to expose .arrive() and .wait()? Do we want to implement .sync() using them? Do we want
+  //                aligned/unaligned variants?
+  _CCCL_DEVICE_API void sync() const noexcept
+  {
+    __synchronizer_instance_.do_sync(__mapping_result_, __hier_);
+  }
+
+  _CCCL_DEVICE_API void sync_aligned() const noexcept
+  {
+    __synchronizer_instance_.do_sync_aligned(__mapping_result_, __hier_);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t static_count(const _InLevel& __in_level) noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_InLevel, level_type>)
+    {
+      return 1;
+    }
+    else
+    {
+      return level_type::static_count(__in_level, _Hierarchy{});
+    }
+  }
+
+  template <class _Tp, class _MappingResult, class _InLevel>
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr _Tp
+  __count_as_impl(const _MappingResult&, const _Hierarchy& __hier, const _InLevel& __in_level) noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_InLevel, level_type>)
+    {
+      return _Tp{1};
+    }
+    else
+    {
+      return level_type::template count_as<_Tp>(__in_level, __hier);
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Tp, class _InLevel)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND __is_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Tp count_as(const _InLevel& __in_level) const noexcept
+  {
+    return __count_as_impl<_Tp>(__mapping_result_, __hier_, __in_level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API constexpr auto count(const _InLevel& __in_level) const noexcept
+  {
+    return __count_as_impl<typename _InLevel::__product_type>(__mapping_result_, __hier_, __in_level);
+  }
+
+  template <class _Tp, class _MappingResult, class _InLevel>
+  [[nodiscard]] _CCCL_DEVICE_API static _Tp
+  __rank_as_impl(const _MappingResult&, const _Hierarchy& __hier, const _InLevel& __in_level) noexcept
+  {
+    if constexpr (::cuda::std::is_same_v<_InLevel, level_type>)
+    {
+      return _Tp{0};
+    }
+    else
+    {
+      return level_type::template rank_as<_Tp>(__in_level, __hier);
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Tp, class _InLevel)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND __is_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API _Tp rank_as(const _InLevel& __in_level) const noexcept
+  {
+    return __rank_as_impl<_Tp>(__mapping_result_, __hier_, __in_level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API auto rank(const _InLevel& __in_level) const noexcept
+  {
+    return __rank_as_impl<typename _InLevel::__product_type>(__mapping_result_, __hier_, __in_level);
+  }
+};
+
+_CCCL_TEMPLATE(class _Hierarchy)
+_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES coalesced_group(const _Hierarchy&) -> coalesced_group<__hierarchy_type_of<_Hierarchy>>;
+} // namespace cuda::experimental
+
+#endif // !_CCCL_DOXYGEN_INVOKED
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___GROUP_COALESCED_GROUP_CUH

--- a/cudax/include/cuda/experimental/__group/fwd.cuh
+++ b/cudax/include/cuda/experimental/__group/fwd.cuh
@@ -79,6 +79,9 @@ class group;
 template <class _Unit, class _ParentGroup, class _MappingResult>
 class virtual_group;
 
+template <class _Hierarchy>
+class coalesced_group;
+
 template <class _Unit, class _Group>
 class group_view;
 

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -32,6 +32,7 @@
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/implicit_hierarchy.cuh>
 #include <cuda/experimental/__group/synchronizer/level_synchronizer.cuh>
+#include <cuda/experimental/__group/traits.cuh>
 
 #if _CCCL_HAS_COOPERATIVE_GROUPS()
 #  include <cooperative_groups.h>
@@ -43,10 +44,6 @@
 
 namespace cuda::experimental
 {
-template <class _HierarchyLike>
-using __hierarchy_type_of =
-  ::cuda::std::remove_cvref_t<decltype(::cuda::__unpack_hierarchy_if_needed(::cuda::std::declval<_HierarchyLike>()))>;
-
 template <class _Level>
 struct __this_mapping_result
 {

--- a/cudax/include/cuda/experimental/__group/traits.cuh
+++ b/cudax/include/cuda/experimental/__group/traits.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/hierarchy>
+#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/span>
@@ -50,6 +51,10 @@ template <class _Level>
 inline constexpr bool __unit_same_as_or_below_v<_Level, _Level> = true;
 template <>
 inline constexpr bool __unit_same_as_or_below_v<thread_level, warp_level> = true;
+
+template <class _HierarchyLike>
+using __hierarchy_type_of =
+  ::cuda::std::remove_cvref_t<decltype(::cuda::__unpack_hierarchy_if_needed(::cuda::std::declval<_HierarchyLike>()))>;
 } // namespace cuda::experimental
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cudax/include/cuda/experimental/__group/traits.cuh
+++ b/cudax/include/cuda/experimental/__group/traits.cuh
@@ -40,10 +40,10 @@ inline constexpr bool
   __is_spannable<_Tp, ::cuda::std::void_t<decltype(::cuda::std::span(::cuda::std::declval<_Tp>()))>> = true;
 
 template <class _Span>
-using _SpanElementType = typename _Span::element_type;
+using _SpanElementType _CCCL_NODEBUG = typename _Span::element_type;
 
 template <class _Span>
-using _SpanValueType = typename _Span::value_type;
+using _SpanValueType _CCCL_NODEBUG = typename _Span::value_type;
 
 template <class _Unit, class _Level>
 inline constexpr bool __unit_same_as_or_below_v = __is_natively_reachable_hierarchy_level_v<_Unit, _Level>;
@@ -53,7 +53,7 @@ template <>
 inline constexpr bool __unit_same_as_or_below_v<thread_level, warp_level> = true;
 
 template <class _HierarchyLike>
-using __hierarchy_type_of =
+using __hierarchy_type_of _CCCL_NODEBUG =
   ::cuda::std::remove_cvref_t<decltype(::cuda::__unpack_hierarchy_if_needed(::cuda::std::declval<_HierarchyLike>()))>;
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/group.cuh
+++ b/cudax/include/cuda/experimental/group.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/experimental/__group/coalesced_group.cuh>
 #include <cuda/experimental/__group/concepts.cuh>
 #include <cuda/experimental/__group/fwd.cuh>
 #include <cuda/experimental/__group/group.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -192,6 +192,9 @@ cudax_add_catch2_test(test_target group.segmented_algorithm
 cudax_add_catch2_test(test_target group.this_group
     group/this_group.cu
 )
+cudax_add_catch2_test(test_target group.coalesced_group
+    group/coalesced_group.cu
+)
 cudax_add_catch2_test(test_target group.invoke_one
     group/invoke_one.cu
 )

--- a/cudax/test/group/coalesced_group.cu
+++ b/cudax/test/group/coalesced_group.cu
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/atomic>
+#include <cuda/devices>
+#include <cuda/hierarchy>
+#include <cuda/launch>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+#include <cuda/stream>
+
+#include <cuda/experimental/group.cuh>
+
+#include "group_testing.cuh"
+
+template <class Config>
+__device__ void test_coalesced_group(Config config)
+{
+  const auto rank = cuda::gpu_thread.rank(cuda::warp);
+
+  // Test coalesced group constructoed by all threads in a warp.
+  {
+    cudax::coalesced_group group{config};
+    using Group = decltype(group);
+
+    static_assert(cudax::is_group<Group>);
+
+    static_assert(cuda::std::is_same_v<cuda::thread_level, typename Group::unit_type>);
+    static_assert(cuda::std::is_same_v<cuda::warp_level, typename Group::level_type>);
+
+    // Test that the group can be queried for it's hierarchy.
+    {
+      decltype(auto) hierarchy = cuda::std::as_const(group).hierarchy();
+      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
+    }
+
+    group.sync();
+    group.sync_aligned();
+
+    static_assert(cuda::gpu_thread.static_count(group) == cuda::std::dynamic_extent);
+    REQUIRE(cuda::gpu_thread.count(group) == 32);
+    REQUIRE(cuda::gpu_thread.rank(group) == rank);
+
+    static_assert(group.static_count(cuda::warp) == 1);
+    // todo(dabayer): Refactor static_count query and uncomment these.
+    // static_assert(group.static_count(cuda::block) == cuda::warp.static_count(cuda::block, config));
+    // static_assert(group.static_count(cuda::cluster) == cuda::warp.static_count(cuda::cluster, config));
+    // static_assert(group.static_count(cuda::grid) == cuda::warp.static_count(cuda::grid, config));
+
+    REQUIRE(group.count(cuda::warp) == 1);
+    REQUIRE(group.count(cuda::block) == cuda::warp.count(cuda::block));
+    REQUIRE(group.count(cuda::cluster) == cuda::warp.count(cuda::cluster));
+    REQUIRE(group.count(cuda::grid) == cuda::warp.count(cuda::grid));
+
+    REQUIRE(group.rank(cuda::warp) == 0);
+    REQUIRE(group.rank(cuda::block) == cuda::warp.rank(cuda::block));
+    REQUIRE(group.rank(cuda::cluster) == cuda::warp.rank(cuda::cluster));
+    REQUIRE(group.rank(cuda::grid) == cuda::warp.rank(cuda::grid));
+  }
+
+  // Test coalesced group constructoed by first half threads in a warp.
+  if (rank < 16)
+  {
+    cudax::coalesced_group group{config};
+    using Group = decltype(group);
+
+    static_assert(cudax::is_group<Group>);
+
+    static_assert(cuda::std::is_same_v<cuda::thread_level, typename Group::unit_type>);
+    static_assert(cuda::std::is_same_v<cuda::warp_level, typename Group::level_type>);
+
+    // Test that the group can be queried for it's hierarchy.
+    {
+      decltype(auto) hierarchy = cuda::std::as_const(group).hierarchy();
+      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
+    }
+
+    group.sync();
+    group.sync_aligned();
+
+    static_assert(cuda::gpu_thread.static_count(group) == cuda::std::dynamic_extent);
+    REQUIRE(cuda::gpu_thread.count(group) == 16);
+    REQUIRE(cuda::gpu_thread.rank(group) == rank);
+
+    static_assert(group.static_count(cuda::warp) == 1);
+    // todo(dabayer): Refactor static_count query and uncomment these.
+    // static_assert(group.static_count(cuda::block) == cuda::warp.static_count(cuda::block, config));
+    // static_assert(group.static_count(cuda::cluster) == cuda::warp.static_count(cuda::cluster, config));
+    // static_assert(group.static_count(cuda::grid) == cuda::warp.static_count(cuda::grid, config));
+
+    REQUIRE(group.count(cuda::warp) == 1);
+    REQUIRE(group.count(cuda::block) == cuda::warp.count(cuda::block));
+    REQUIRE(group.count(cuda::cluster) == cuda::warp.count(cuda::cluster));
+    REQUIRE(group.count(cuda::grid) == cuda::warp.count(cuda::grid));
+
+    REQUIRE(group.rank(cuda::warp) == 0);
+    REQUIRE(group.rank(cuda::block) == cuda::warp.rank(cuda::block));
+    REQUIRE(group.rank(cuda::cluster) == cuda::warp.rank(cuda::cluster));
+    REQUIRE(group.rank(cuda::grid) == cuda::warp.rank(cuda::grid));
+  }
+
+  // Test coalesced group constructoed by all even threads in a warp.
+  if (rank % 2 == 0)
+  {
+    cudax::coalesced_group group{config};
+    using Group = decltype(group);
+
+    static_assert(cudax::is_group<Group>);
+
+    static_assert(cuda::std::is_same_v<cuda::thread_level, typename Group::unit_type>);
+    static_assert(cuda::std::is_same_v<cuda::warp_level, typename Group::level_type>);
+
+    // Test that the group can be queried for it's hierarchy.
+    {
+      decltype(auto) hierarchy = cuda::std::as_const(group).hierarchy();
+      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
+    }
+
+    group.sync();
+    group.sync_aligned();
+
+    static_assert(cuda::gpu_thread.static_count(group) == cuda::std::dynamic_extent);
+    REQUIRE(cuda::gpu_thread.count(group) == 16);
+    REQUIRE(cuda::gpu_thread.rank(group) == rank / 2);
+
+    static_assert(group.static_count(cuda::warp) == 1);
+    // todo(dabayer): Refactor static_count query and uncomment these.
+    // static_assert(group.static_count(cuda::block) == cuda::warp.static_count(cuda::block, config));
+    // static_assert(group.static_count(cuda::cluster) == cuda::warp.static_count(cuda::cluster, config));
+    // static_assert(group.static_count(cuda::grid) == cuda::warp.static_count(cuda::grid, config));
+
+    REQUIRE(group.count(cuda::warp) == 1);
+    REQUIRE(group.count(cuda::block) == cuda::warp.count(cuda::block));
+    REQUIRE(group.count(cuda::cluster) == cuda::warp.count(cuda::cluster));
+    REQUIRE(group.count(cuda::grid) == cuda::warp.count(cuda::grid));
+
+    REQUIRE(group.rank(cuda::warp) == 0);
+    REQUIRE(group.rank(cuda::block) == cuda::warp.rank(cuda::block));
+    REQUIRE(group.rank(cuda::cluster) == cuda::warp.rank(cuda::cluster));
+    REQUIRE(group.rank(cuda::grid) == cuda::warp.rank(cuda::grid));
+  }
+}
+
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(Config config) const
+  {
+    test_coalesced_group(config);
+  }
+};
+
+C2H_TEST("Coalesced Group", "[coalesced_group]")
+{
+  const auto device = cuda::devices[0];
+
+  const cuda::stream stream{device};
+
+  const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+  cuda::launch(stream, config, TestKernel{});
+
+  stream.sync();
+}


### PR DESCRIPTION
This PR implements `cudax::coalesced_group` that groups all threads within the warp that are currently active. It is an equivalent to `cooperative_groups::coalesced_group`. I want to treat this group similarly to _this_ groups - it's a predefined group with no parent, thus can be queried for rank/count within hierarchy levels.