### PR TITLE
Fix NVHPC compilation break with 128-bit integrals within Catch2 REQUIRE

### DIFF
--- a/cub/test/catch2_test_printing.cu
+++ b/cub/test/catch2_test_printing.cu
@@ -31,6 +31,12 @@ CUB_TEST_CASE("Test utils can print __uint128", "[test][utils]", CUB_SMALL)
   REQUIRE(print(__uint128_t{42}) == "42");
   REQUIRE(print(__uint128_t{1} << 120) == "1329227995784915872903807060280344576");
 }
+
+CUB_TEST_CASE("Catch2 can stringify 128-bit integers", "[test][utils]", CUB_SMALL)
+{
+  REQUIRE(Catch::StringMaker<__int128_t>::convert(__int128_t{-42}) == "-42");
+  REQUIRE(Catch::StringMaker<__uint128_t>::convert(__uint128_t{1} << 120) == "1329227995784915872903807060280344576");
+}
 #endif
 
 CUB_TEST_CASE("Test utils can print KeyValuePair", "[test][utils]", CUB_SMALL)

--- a/cub/test/catch2_test_printing.cu
+++ b/cub/test/catch2_test_printing.cu
@@ -34,8 +34,15 @@ CUB_TEST_CASE("Test utils can print __uint128", "[test][utils]", CUB_SMALL)
 
 CUB_TEST_CASE("Catch2 can stringify 128-bit integers", "[test][utils]", CUB_SMALL)
 {
-  REQUIRE(Catch::StringMaker<__int128_t>::convert(__int128_t{-42}) == "-42");
-  REQUIRE(Catch::StringMaker<__uint128_t>::convert(__uint128_t{1} << 120) == "1329227995784915872903807060280344576");
+  const __int128_t signed_value    = -42;
+  const __int128_t signed_expected = -42;
+  REQUIRE(signed_value == signed_expected);
+  REQUIRE(Catch::StringMaker<__int128_t>::convert(signed_value) == "-42");
+
+  const __uint128_t unsigned_value    = __uint128_t{1} << 120;
+  const __uint128_t unsigned_expected = __uint128_t{1} << 120;
+  REQUIRE(unsigned_value == unsigned_expected);
+  REQUIRE(Catch::StringMaker<__uint128_t>::convert(unsigned_value) == "1329227995784915872903807060280344576");
 }
 #endif
 

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -673,6 +673,30 @@ inline std::ostream& operator<<(std::ostream& os, __int128_t val)
 
   return os;
 }
+
+// NVHPC incorrectly identifies 128-bit integers as stream-insertable in Catch2's detection trait, but then fails to
+// select the global stream insertion overloads above. Explicit string makers bypass the faulty detection.
+template <>
+struct Catch::StringMaker<__uint128_t>
+{
+  static std::string convert(__uint128_t val)
+  {
+    std::ostringstream os;
+    ::operator<<(os, val);
+    return os.str();
+  }
+};
+
+template <>
+struct Catch::StringMaker<__int128_t>
+{
+  static std::string convert(__int128_t val)
+  {
+    std::ostringstream os;
+    ::operator<<(os, val);
+    return os.str();
+  }
+};
 #endif
 
 /******************************************************************************


### PR DESCRIPTION
## Description

Add test first, confirm that it breaks in TOT main (#11365).

Add the fix by providing explicit Catch::StringMaker specializations for signed and unsigned 128-bit integers in 'cub/test/test_util.h:680'



<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #11365

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

<!--
Note: CodeRabbit is enabled on this repository as a convenience for maintainers
and contributors. Use your best judgment when considering its review comments and
suggestions — a suggested change may be inadequate, unnecessary, or safe to ignore.
Contributors are not expected to address every comment. Human reviews are what
ultimately matter for merging.
-->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
