### PR TITLE
Move RTX2080 PR coverage to T4 and L4 runners

### DIFF
--- a/ci/compile_time/README.md
+++ b/ci/compile_time/README.md
@@ -12,7 +12,7 @@ compile_time:
   pull_request:
     - id: public-headers-gcc13
       name: Public headers compile-time bench
-      gpu: rtx2080
+      gpu: t4
       launch_args: "--cuda 13.3 --host gcc13"
       baseline_ref: origin/main
       preset: all-dev

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -81,7 +81,6 @@ workflows:
   override:
 
   pull_request:
-    # Use T4 for SM75 PR coverage; reserve RTX2080 coverage for scheduled workflows.
     # Old CTK: Oldest/newest supported host compilers:
     - {jobs: ['build'],                     project: ['libcudacxx', 'thrust'], std: 'minmax', ctk: '12.0', cxx: ['gcc12', 'clang14',            'msvc2019', 'msvc14.39']}
     - {jobs: ['build'],                     project: ['libcudacxx', 'thrust'], std: 'minmax', ctk: '12.0', cxx: 'gcc7'}
@@ -160,7 +159,6 @@ workflows:
     # Eventually v2 will replace v1 as the default and run across the
     # entire matrix. Currently blocked on libnvfatbin availability for CUDA <12.4.
     - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: 'gcc13', gpu: 't4'}
-    # Use the established Windows L4 pool for the MSVC lane.
     - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: 'msvc', gpu: 'l4'}
     # Python against c.parallel v2 (HostJIT-based). Single point of coverage
     # for the v2 Python path; the main `python` matrix continues to test
@@ -340,7 +338,6 @@ workflows:
     - {jobs: ['limited'], project: 'cub', std: 17, gpu: 'rtx2080'}
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
-    # Retain the latest-host-compiler RTX2080 NVRTC coverage moved out of PRs.
     - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # libcu++ Codegen FileCheck: nightly covers the GCC and Clang host compilers
@@ -358,7 +355,6 @@ workflows:
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
-    # Keep HostJIT-based c.parallel v2 RTX2080 coverage in nightly.
     - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: ['gcc13', 'msvc'], gpu: 'rtx2080'}
     # RTX PRO 6000 coverage (limited due to small number of runners):
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13'], gpu: ['rtxpro6000']}
@@ -938,7 +934,7 @@ tags:
   ctk: { default: '13.X' }
   # CPU architecture
   cpu: { default: 'amd64' }
-  # GPU model: implicit PR jobs must not use the scheduled-only RTX2080 pool.
+  # GPU model
   gpu: { default: 't4' }
   # Host compiler {name, version, exe}
   # See the `host_compilers` map.

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -2,7 +2,7 @@ compile_time:
   pull_request:
     - id: public-headers-gcc13
       name: Public headers compile-time bench
-      gpu: rtx2080
+      gpu: t4
       launch_args: "--cuda 13.3 --host gcc13"
       baseline_ref: origin/main
       preset: all-dev
@@ -74,13 +74,14 @@ workflows:
   #       args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
   #   - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
   #       args: '--preset libcudacxx --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
-  #   - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtx2080',
+  #   - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 't4',
   #       args: '--preset libcudacxx --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   # IMPORTANT: Do NOT delete or remove the `override:` key below, even when it is empty.
   override:
 
   pull_request:
+    # Use T4 for SM75 PR coverage; reserve RTX2080 coverage for scheduled workflows.
     # Old CTK: Oldest/newest supported host compilers:
     - {jobs: ['build'],                     project: ['libcudacxx', 'thrust'], std: 'minmax', ctk: '12.0', cxx: ['gcc12', 'clang14',            'msvc2019', 'msvc14.39']}
     - {jobs: ['build'],                     project: ['libcudacxx', 'thrust'], std: 'minmax', ctk: '12.0', cxx: 'gcc7'}
@@ -134,7 +135,7 @@ workflows:
     - {jobs: ['build'],                     cpu: 'arm64', project: ['libcudacxx', 'thrust', 'cudax'], std: 'max', cxx: ['gcc', 'clang']}
     - {jobs: ['build_nolid', 'build_lid0'], cpu: 'arm64', project: 'cub', std: 'max', cxx: ['gcc', 'clang']}
     - {jobs: ['test_gpu'], project: 'thrust', cmake_options: '-DTHRUST_DISPATCH_TYPE=Force32bit', gpu: 'rtx4090'}
-    - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
+    - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 't4', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # libcu++ Codegen FileCheck: PRs use one GCC host compiler per CTK.
     # Suite-specific architectures are added separately.
@@ -150,16 +151,17 @@ workflows:
     - {jobs: ['codegen_filecheck'], project: 'libcudacxx', std: 'max', cxx: 'gcc15', codegen_target: 'simd-sass', sm: [103, '120f']}
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
-    - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
+    - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4', 'l4', 'h100']}
     # RTX PRO 6000 coverage (limited due to small number of runners):
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13'], gpu: ['rtxpro6000']}
     # c.parallel v2 (HostJIT-based)
     #
-    # For now, this is a separate job run for Linux/CUDA13.
+    # For now, this is a separate job run for CUDA13.
     # Eventually v2 will replace v1 as the default and run across the
-    # entire matrix. Currently blocked on libnvfatbin availability on
-    # Windows containers, and for CUDA <12.4.
-    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: ['gcc13', 'msvc'], gpu: 'rtx2080'}
+    # entire matrix. Currently blocked on libnvfatbin availability for CUDA <12.4.
+    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: 'gcc13', gpu: 't4'}
+    # Use the established Windows L4 pool for the MSVC lane.
+    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: 'msvc', gpu: 'l4'}
     # Python against c.parallel v2 (HostJIT-based). Single point of coverage
     # for the v2 Python path; the main `python` matrix continues to test
     # against v1 until v2 replaces it. The minimal row proves the minimal extras
@@ -227,7 +229,7 @@ workflows:
   # Used when an upstream project changes to reduce time spent smoke testing dependencies.
   pull_request_lite:
     # libcudacxx - Specialized, testing default SM
-    - {project: 'libcudacxx', jobs: ['test'],  std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtx2080', sm: 'gpu'}
+    - {project: 'libcudacxx', jobs: ['test'],  std: 'max', cxx: ['gcc', 'msvc'], gpu: 't4', sm: 'gpu'}
     - {project: 'libcudacxx', jobs: ['build'], std: 'max', cxx: 'clang'}
     - {project: 'libcudacxx', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc'}
     - {project: 'libcudacxx', jobs: ['build'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '70;80;90;100;120'}
@@ -244,7 +246,7 @@ workflows:
     - {project: 'thrust', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc', sm: '75;120'}
     - {project: 'thrust', jobs: ['build'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '75;120'}
     # cudax
-    - {project: 'cudax', jobs: ['test'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtx2080', sm: 'gpu'}
+    - {project: 'cudax', jobs: ['test'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 't4', sm: 'gpu'}
     - {project: 'cudax', jobs: ['build'], std: 'max', cxx: 'clang', sm: '75;120'}
     - {project: 'cudax', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc', sm: '75;120'}
     # CTK '13.X' build with tile support: default projects
@@ -253,20 +255,20 @@ workflows:
     # stdpar
     - {project: 'stdpar', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc'}
     # Python + support
-    - {project: 'cccl_c_parallel', jobs: ['test'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: 'rtx2080', sm: 'gpu'}
+    - {project: 'cccl_c_parallel', jobs: ['test'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: 't4', sm: 'gpu'}
     - {project: 'cccl_c_parallel', jobs: ['test'], ctk: '13.X', cxx: 'gcc13', gpu: 'rtxpro6000', sm: 'gpu'}
     - {project: 'cccl_c_stf',      jobs: ['test'], ctk: '13.X', cxx: 'gcc13',               gpu: 't4', sm: 'gpu'}
     - {project: 'python', jobs: ['test'], ctk: '13.X', py_version: '3.14', gpu: 'l4', cxx: ['gcc13', 'msvc2022']}
     - {project: 'python', jobs: ['test_headers'], ctk: '13.X', py_version: '3.14', cxx: ['gcc13', 'msvc2022']}
     - {project: 'python', jobs: ['test_py_stf'], ctk: '13.X', py_version: '3.14', gpu: 'l4', cxx: 'gcc13'}
     # Packaging / install
-    - {project: 'packaging', jobs: ['test'], ctk: '13.X', cxx: ['gcc', 'clang'], gpu: 'rtx2080', sm: 'gpu'}
+    - {project: 'packaging', jobs: ['test'], ctk: '13.X', cxx: ['gcc', 'clang'], gpu: 't4', sm: 'gpu'}
     - {project: 'packaging', jobs: ['test'], args: '-min-cmake', gpu: 't4', sm: 'gpu'}
     - {project: 'packaging', jobs: ['install']}
     # NVBench Helper testing:
-    - {project: 'nvbench_helper', jobs: ['test'], ctk: '13.X', cxx: ['gcc', 'clang'], gpu: 'rtx2080'}
+    - {project: 'nvbench_helper', jobs: ['test'], ctk: '13.X', cxx: ['gcc', 'clang'], gpu: 't4'}
     # c.parallel v2 (HostJIT-based)
-    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: ['gcc13'], gpu: 'rtx2080'}
+    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: ['gcc13'], gpu: 't4'}
     # Python against c.parallel v2 (HostJIT-based)
     - {jobs: ['test'], project: 'python_v2', ctk: '13.X', py_version: '3.14', gpu: 'l4', cxx: 'gcc13'}
 
@@ -318,7 +320,7 @@ workflows:
     - {jobs: ['test'], project: 'libcudacxx', ctk: '13.X', std: 'max', cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtx2080'}
     - {jobs: ['test'], project: 'cub',        ctk: '13.X', std: 'max', cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtxa6000'}
     - {jobs: ['test'], project: 'thrust',     ctk: '13.X', std: 'max', cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtx4090'}
-    - {jobs: ['test'], project: 'cudax',      ctk: '13.X', std: 'max', cxx: ['gcc', 'clang', 'msvc'], gpu: 't4'}
+    - {jobs: ['test'], project: 'cudax',      ctk: '13.X', std: 'max', cxx: ['gcc', 'clang', 'msvc'], gpu: ['t4', 'rtx2080']}
     - {jobs: ['test'], project: ['libcudacxx', 'cub', 'thrust', 'cudax'], ctk: '13.X', std: 'max', gpu: 'h100' }
     # CTK '13.X' testing with tile support:
     - {jobs: ['test'], project: 'libcudacxx', ctk: '13.X', std: 20, cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtxa6000', args: '-enable-tile'}
@@ -338,6 +340,8 @@ workflows:
     - {jobs: ['limited'], project: 'cub', std: 17, gpu: 'rtx2080'}
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
+    # Retain the latest-host-compiler RTX2080 NVRTC coverage moved out of PRs.
+    - {jobs: ['nvrtc'], project: 'libcudacxx', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # libcu++ Codegen FileCheck: nightly covers the GCC and Clang host compilers
     # supported by each CTK. Suite-specific architectures are added separately.
@@ -354,6 +358,8 @@ workflows:
     # c.parallel -- pinned to gcc13 / msvc2022 to match python
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '12.X', cxx: ['gcc13', 'msvc2022'], gpu: ['t4']}
     - {jobs: ['test'],  project: ['cccl_c_parallel'], ctk: '13.X', cxx: ['gcc13', 'msvc2022'], gpu: ['rtx2080', 'l4', 'h100']}
+    # Keep HostJIT-based c.parallel v2 RTX2080 coverage in nightly.
+    - {jobs: ['test'], project: 'cccl_c_parallel_v2', ctk: '13.X', cxx: ['gcc13', 'msvc'], gpu: 'rtx2080'}
     # RTX PRO 6000 coverage (limited due to small number of runners):
     - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: ['gcc13'], gpu: ['rtxpro6000']}
     # c.experimental.stf -- pinned to gcc13 to match python
@@ -392,7 +398,7 @@ workflows:
     - {jobs: ['test'], project: 'nvbench_helper', ctk: '12.0', cxx: ['gcc10', 'clang14'], gpu: 'rtx2080'}
     - {jobs: ['test'], project: 'nvbench_helper', ctk: '12.X', cxx: ['gcc10', 'clang14'], gpu: 't4'}
     - {jobs: ['test'], project: 'nvbench_helper', ctk: '13.0', cxx: ['gcc15', 'clang20'], gpu: 'rtx2080'}
-    - {jobs: ['test'], project: 'nvbench_helper', ctk: '13.X', cxx: ['gcc',   'clang'],   gpu: 't4'}
+    - {jobs: ['test'], project: 'nvbench_helper', ctk: '13.X', cxx: ['gcc',   'clang'],   gpu: ['t4', 'rtx2080']}
     # NVHPC build
     - {jobs: ['build'], cxx: 'nvhpc-prev', ctk: 'nvhpc-prev', std: 'all', project: ['libcudacxx', 'cub', 'thrust', 'cudax', 'stdpar'], cpu: ['amd64', 'arm64']}
     - {jobs: ['build'], cxx: 'nvhpc',      ctk: 'nvhpc',      std: 'all', project: ['libcudacxx', 'cub', 'thrust', 'cudax', 'stdpar'], cpu: ['amd64', 'arm64']}
@@ -882,7 +888,7 @@ projects:
   # Use the override workflow and supply arguments via the `args` tag.
   # Example:
   #   override:
-  #     - { jobs: ['run'], project: 'target', ctk: ['12.X', '13.X'], cxx: 'gcc', gpu: 'rtx2080',
+  #     - { jobs: ['run'], project: 'target', ctk: ['12.X', '13.X'], cxx: 'gcc', gpu: 't4',
   #         args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
   target:
     name: 'Target'
@@ -932,8 +938,8 @@ tags:
   ctk: { default: '13.X' }
   # CPU architecture
   cpu: { default: 'amd64' }
-  # GPU model
-  gpu: { default: 'rtx2080' }
+  # GPU model: implicit PR jobs must not use the scheduled-only RTX2080 pool.
+  gpu: { default: 't4' }
   # Host compiler {name, version, exe}
   # See the `host_compilers` map.
   cxx: { default: 'gcc' }


### PR DESCRIPTION
## Description

RTX2080 queues are delaying PR feedback: the Aug 27–Sep 10 CI analysis found a Linux RTX2080 queue p95 of about 3h43m. Move routine PR work to other GPU pools while retaining RTX2080 functional coverage in nightly.

- Route all Linux RTX2080 jobs in the full PR and PR-lite matrices, plus the compile-time benchmark, to T4. Both GPUs target SM75, so `sm: gpu` and native compile-time targets retain their architecture coverage.
- Route the Windows c.parallel v2 PR job to the existing L4 pool.
- Change the default GPU to T4 and update the override and compile-time examples so implicit PR jobs also avoid RTX2080.
- Add the missing nightly RTX2080 variants for latest-compiler NVRTC, CUDA 13.X cudax and NVBench Helper, and c.parallel v2. Existing nightly and weekly jobs remain covered.

The full PR matrix still has 528 jobs and PR-lite still has 90. This changes runner routing rather than dropping PR checks. Nightly increases from 1,354 to 1,362 jobs; the extra cudax consumers reuse existing builds.

## Validation

- Expanded the actual workflow generator before and after the change for full PR, all-lite PR, mixed full/lite PR, nightly, and weekly. PR variants have zero RTX2080 runners; commands, images, environments, and dependency edges are preserved apart from GPU names/runner selection. Weekly is unchanged and nightly retains all existing jobs.
- Parsed the compile-time PR matrix and verified that only its GPU changed.
- `python3 -m unittest discover -s ci/compile_time -p 'test_*.py'`: 31 tests passed.
- `pre-commit run --files ci/matrix.yaml ci/compile_time/README.md` and `git diff --check`: passed.

GPU execution and queue improvements will be measured in CI. After rollout, compare PR feedback p95 and T4/L4 queue p95 against the existing baseline to ensure the backlog has not simply moved pools.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
