### PR TITLE
Document `cuda::std::mdspan` C++23 operator[] limitation

### DIFF
--- a/docs/libcudacxx/standard_api/container_library/mdspan.rst
+++ b/docs/libcudacxx/standard_api/container_library/mdspan.rst
@@ -20,3 +20,4 @@ Restrictions
 ------------
 
 -  On device no exceptions are thrown in case of a bad access.
+-  ``operator[]`` is disabled even in C++23 mode because it is not yet fully supported by the ``nvcc`` compiler.


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/cccl/issues/11369